### PR TITLE
feat: add auth0 login and logout

### DIFF
--- a/jest.setup.ts
+++ b/jest.setup.ts
@@ -1,7 +1,7 @@
 import '@testing-library/jest-dom';
 
 process.env = Object.assign(process.env, {
-    AUTH0_DOMAIN: 'test.auth0.com',
+    AUTH0_BACKEND_DOMAIN: 'test.auth0.com',
     AUTH0_BACKEND_CLIENT_ID: 'test-client-id',
     AUTH0_BACKEND_CLIENT_SECRET: 'dont-tell-nobody',
     STRIPE_SECRET_KEY: 'test-secret',

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
         "prisma:studio": "prisma studio"
     },
     "dependencies": {
+        "@auth0/nextjs-auth0": "^2.1.0",
         "@emotion/react": "^11.10.5",
         "@emotion/styled": "^11.10.5",
         "@fontsource/roboto": "^4.5.8",

--- a/src/components/features/registration/ProviderRegistrationFlow/ProviderRegistrationFlow.tsx
+++ b/src/components/features/registration/ProviderRegistrationFlow/ProviderRegistrationFlow.tsx
@@ -80,7 +80,7 @@ export const ProviderRegistrationFlow = ({
         }
     }, [emailAddress, emailValidationUrl, emailsCheckedForUniqueness]);
 
-    if (isRegistrationComplete) {
+    if (isRegistrationComplete && errorMessage === undefined) {
         return (
             <FormContainer isError={false}>
                 <CenteredContainer>

--- a/src/lib/sitemap/authentication/index.ts
+++ b/src/lib/sitemap/authentication/index.ts
@@ -1,0 +1,4 @@
+export const AUTHENTICATION_PATHS = {
+    LOGIN: '/api/auth/login',
+    LOGOUT: '/api/auth/logout',
+} as const;

--- a/src/lib/sitemap/index.ts
+++ b/src/lib/sitemap/index.ts
@@ -1,0 +1,5 @@
+import { AUTHENTICATION_PATHS } from './authentication';
+
+export const URL_PATHS = {
+    AUTH: AUTHENTICATION_PATHS,
+} as const;

--- a/src/lib/vendors/auth0/client/get-access-token/getAccessToken.ts
+++ b/src/lib/vendors/auth0/client/get-access-token/getAccessToken.ts
@@ -38,7 +38,7 @@ export const generateGetAccessToken = (CONFIG: Auth0Configuration) => {
                 body: JSON.stringify({
                     client_id: CONFIG.AUTH0_BACKEND_CLIENT_ID,
                     client_secret: CONFIG.AUTH0_BACKEND_CLIENT_SECRET,
-                    audience: `https://${CONFIG.AUTH0_DOMAIN}/api/v2/`,
+                    audience: `https://${CONFIG.AUTH0_BACKEND_DOMAIN}/api/v2/`,
                     grant_type: 'client_credentials',
                 }),
             });

--- a/src/lib/vendors/auth0/client/get-resource-endpoint/getResourceEndpoint.spec.ts
+++ b/src/lib/vendors/auth0/client/get-resource-endpoint/getResourceEndpoint.spec.ts
@@ -2,7 +2,7 @@ import { getResourceEndpointFactory } from './getResourceEndpoint';
 
 describe('getResourceEndpoint', () => {
     const getResourceEndpoint = getResourceEndpointFactory({
-        AUTH0_DOMAIN: 'test.auth0.com',
+        AUTH0_BACKEND_DOMAIN: 'test.auth0.com',
     });
     it('should return the correct endpoint for a resource', () => {
         const endpoint = getResourceEndpoint('USERS');

--- a/src/lib/vendors/auth0/client/get-resource-endpoint/getResourceEndpoint.ts
+++ b/src/lib/vendors/auth0/client/get-resource-endpoint/getResourceEndpoint.ts
@@ -12,8 +12,8 @@ export type Resource = keyof typeof ENDPOINTS;
 export type Endpoints = typeof ENDPOINTS[keyof typeof ENDPOINTS];
 
 export const getResourceEndpointFactory = ({
-    AUTH0_DOMAIN,
-}: Pick<Auth0Configuration, 'AUTH0_DOMAIN'>) => {
+    AUTH0_BACKEND_DOMAIN,
+}: Pick<Auth0Configuration, 'AUTH0_BACKEND_DOMAIN'>) => {
     /**
      * Returns the endpoint for a given resource. If an id is provided, the endpoint will be replaced with the id.
      * @param resource - The resource to get the endpoint for
@@ -27,6 +27,6 @@ export const getResourceEndpointFactory = ({
         const formattedEndpoint = id
             ? ENDPOINTS[resource].replace('{id}', id)
             : ENDPOINTS[resource];
-        return `https://${AUTH0_DOMAIN}${formattedEndpoint}`;
+        return `https://${AUTH0_BACKEND_DOMAIN}${formattedEndpoint}`;
     };
 };

--- a/src/lib/vendors/auth0/configuration/configuration.spec.ts
+++ b/src/lib/vendors/auth0/configuration/configuration.spec.ts
@@ -3,7 +3,7 @@ let originalEnv: NodeJS.ProcessEnv;
 describe('Auth0 Configuration', () => {
     test('retrieving Auth0 configuration', () => {
         expect(getAuth0Configuration()).toMatchObject({
-            AUTH0_DOMAIN: expect.any(String),
+            AUTH0_BACKEND_DOMAIN: expect.any(String),
             AUTH0_BACKEND_CLIENT_ID: expect.any(String),
             AUTH0_BACKEND_CLIENT_SECRET: expect.any(String),
         });
@@ -11,7 +11,7 @@ describe('Auth0 Configuration', () => {
     describe('Required Environment Variables', () => {
         beforeAll(() => {
             originalEnv = process.env;
-            delete process.env.AUTH0_DOMAIN;
+            delete process.env.AUTH0_BACKEND_DOMAIN;
             delete process.env.AUTH0_BACKEND_CLIENT_ID;
             delete process.env.AUTH0_BACKEND_CLIENT_SECRET;
         });

--- a/src/lib/vendors/auth0/configuration/configuration.ts
+++ b/src/lib/vendors/auth0/configuration/configuration.ts
@@ -5,7 +5,7 @@ import { generateWithConfig } from '@/lib/utils';
  * Auth0 Domain - The domain of your Auth0 tenant
  * @see https://auth0.com/docs/get-started/dashboard
  */
-const AUTH0_DOMAIN = 'AUTH0_DOMAIN' as const;
+const AUTH0_BACKEND_DOMAIN = 'AUTH0_BACKEND_DOMAIN' as const;
 /**
  * Auth0 Client ID - The client ID of your Auth0 Machine to Machine application
  * @see https://auth0.com/docs/applications
@@ -20,12 +20,12 @@ const AUTH0_BACKEND_CLIENT_SECRET = 'AUTH0_BACKEND_CLIENT_SECRET' as const;
 
 /**
  * Auth0 Configuration
- * @property {string} AUTH0_DOMAIN - The domain of your Auth0 tenant
+ * @property {string} AUTH0_BACKEND_DOMAIN - The domain of your Auth0 tenant
  * @property {string} AUTH0_BACKEND_CLIENT_ID - The client ID of your Auth0 application
  * @property {string} AUTH0_BACKEND_CLIENT_SECRET - The client secret of your Auth0 application
  */
 export interface Auth0Configuration {
-    AUTH0_DOMAIN: string;
+    AUTH0_BACKEND_DOMAIN: string;
     AUTH0_BACKEND_CLIENT_ID: string;
     AUTH0_BACKEND_CLIENT_SECRET: string;
 }
@@ -38,7 +38,7 @@ export interface Auth0Configuration {
 export const getAuth0Configuration = (
     overrides: Partial<Auth0Configuration> = {}
 ) => ({
-    [AUTH0_DOMAIN]: get(AUTH0_DOMAIN).required().asString(),
+    [AUTH0_BACKEND_DOMAIN]: get(AUTH0_BACKEND_DOMAIN).required().asString(),
     [AUTH0_BACKEND_CLIENT_ID]: get(AUTH0_BACKEND_CLIENT_ID)
         .required()
         .asString(),

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -4,14 +4,17 @@ import { ThemeProvider } from '@mui/material/styles';
 import { therifyDesignSystem } from '../components/themes/therify-design-system';
 import { ApplicationContainer } from '@/components/ui/Layout/Containers/ApplicationContainer';
 import { withTRPC } from '@trpc/next';
+import { UserProvider } from '@auth0/nextjs-auth0/client';
 import { AppRouter } from '@/lib/server/routers/app';
 
 const App: AppType = ({ Component, pageProps }: AppProps) => {
     return (
         <ThemeProvider theme={therifyDesignSystem}>
-            <ApplicationContainer>
-                <Component {...pageProps} />
-            </ApplicationContainer>
+            <UserProvider>
+                <ApplicationContainer>
+                    <Component {...pageProps} />
+                </ApplicationContainer>
+            </UserProvider>
         </ThemeProvider>
     );
 };

--- a/src/pages/api/auth/callback.ts
+++ b/src/pages/api/auth/callback.ts
@@ -1,0 +1,19 @@
+import { handleCallback, CallbackHandlerError } from '@auth0/nextjs-auth0';
+import { NextApiRequest, NextApiResponse } from 'next';
+
+export default async function callback(
+    req: NextApiRequest,
+    res: NextApiResponse
+) {
+    try {
+        await handleCallback(req, res);
+    } catch (error) {
+        if (error instanceof CallbackHandlerError) {
+            res.status(error.status ?? 400).end(error.message);
+        }
+        res.status(500).end(
+            (error as { message: string }).message ??
+                'An unknown callback error occurred.'
+        );
+    }
+}

--- a/src/pages/api/auth/login.ts
+++ b/src/pages/api/auth/login.ts
@@ -1,0 +1,16 @@
+import { handleLogin, LoginHandlerError } from '@auth0/nextjs-auth0';
+import { NextApiRequest, NextApiResponse } from 'next';
+
+export default async function login(req: NextApiRequest, res: NextApiResponse) {
+    try {
+        await handleLogin(req, res);
+    } catch (error) {
+        if (error instanceof LoginHandlerError) {
+            res.status(error.status ?? 400).end(error.message);
+        }
+        res.status(500).end(
+            (error as { message: string }).message ??
+                'An unknown login error occurred.'
+        );
+    }
+}

--- a/src/pages/api/auth/logout.ts
+++ b/src/pages/api/auth/logout.ts
@@ -1,0 +1,16 @@
+import { handleLogout, LogoutHandlerError } from '@auth0/nextjs-auth0';
+import { NextApiRequest, NextApiResponse } from 'next';
+
+export default async function login(req: NextApiRequest, res: NextApiResponse) {
+    try {
+        await handleLogout(req, res);
+    } catch (error) {
+        if (error instanceof LogoutHandlerError) {
+            res.status(error.status ?? 400).end(error.message);
+        }
+        res.status(500).end(
+            (error as { message: string }).message ??
+                'An unknown logout error occurred.'
+        );
+    }
+}

--- a/src/pages/api/auth/me.ts
+++ b/src/pages/api/auth/me.ts
@@ -1,0 +1,19 @@
+import { handleProfile, ProfileHandlerError } from '@auth0/nextjs-auth0';
+import { NextApiRequest, NextApiResponse } from 'next';
+
+export default async function callback(
+    req: NextApiRequest,
+    res: NextApiResponse
+) {
+    try {
+        await handleProfile(req, res);
+    } catch (error) {
+        if (error instanceof ProfileHandlerError) {
+            res.status(error.status ?? 400).end(error.message);
+        }
+        res.status(500).end(
+            (error as { message: string }).message ??
+                'An unknown profile error occurred.'
+        );
+    }
+}

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,11 +1,13 @@
 import { useEffect, useState } from 'react';
 import { TwoColumnGrid } from '@/components/ui/Grids/TwoColumnGrid';
 import { Button } from '@/components/ui/Button';
-import { Caption, H1 } from '@/components/ui/Typography';
+import { Caption, H1, Paragraph, LoadingContainer } from '@/components/ui';
 import { CenteredContainer } from '@/components/ui/Layout/Containers/CenteredContainer';
 import Box from '@mui/material/Box';
 import { styled, useTheme } from '@mui/material/styles';
 import { default as NextImage } from 'next/image';
+import { useRouter } from 'next/router';
+import { useUser } from '@auth0/nextjs-auth0/client';
 
 const ABSTRACT_SHAPE_URL =
     'https://res.cloudinary.com/dbrkfldqn/image/upload/v1673455675/app.therify.co/shapes/abstract-shape_fbvcil.svg' as const;
@@ -28,6 +30,8 @@ const LOGIN_IMAGES = [
 
 export default function Home() {
     const theme = useTheme();
+    const router = useRouter();
+    const { isLoading, user } = useUser();
     const [randomLoginImage, setRandomLoginImage] = useState<string | null>(
         null
     );
@@ -36,57 +40,77 @@ export default function Home() {
             LOGIN_IMAGES[Math.floor(Math.random() * LOGIN_IMAGES.length)]
         );
     }, []);
+    if (user) {
+        return (
+            <CenteredContainer fillSpace padding={8}>
+                <Paragraph>{JSON.stringify(user)}</Paragraph>
+                <Button
+                    fullWidth
+                    onClick={() => router.push('/api/auth/logout')}
+                >
+                    Logout
+                </Button>
+            </CenteredContainer>
+        );
+    }
     return (
-        <TwoColumnGrid
-            fillSpace
-            leftColumnSize={6}
-            rightSlot={
-                <CenteredContainer fillSpace>
-                    {/*
+        <LoadingContainer isLoading={isLoading}>
+            <TwoColumnGrid
+                fillSpace
+                leftColumnSize={6}
+                rightSlot={
+                    <CenteredContainer fillSpace>
+                        {/*
                         eslint-disable-next-line jsx-a11y/alt-text
             */}
-                    <Image fillSpace imageUrl={randomLoginImage} />
-                </CenteredContainer>
-            }
-            rightSlotSx={{
-                [theme.breakpoints.down('md')]: {
-                    display: 'none',
-                },
-            }}
-            leftSlot={
-                <LoginContainer fillSpace>
-                    <Box maxWidth={480}>
-                        <TherifyLogo
-                            alt="The Official logo of Therify Inc."
-                            src={THERIFY_LOGO_URL}
-                            data-cy="logo"
-                            width={279}
-                            height={96}
+                        <Image fillSpace imageUrl={randomLoginImage} />
+                    </CenteredContainer>
+                }
+                rightSlotSx={{
+                    [theme.breakpoints.down('md')]: {
+                        display: 'none',
+                    },
+                }}
+                leftSlot={
+                    <LoginContainer fillSpace>
+                        <Box maxWidth={480}>
+                            <TherifyLogo
+                                alt="The Official logo of Therify Inc."
+                                src={THERIFY_LOGO_URL}
+                                data-cy="logo"
+                                width={279}
+                                height={96}
+                            />
+                            <Header>
+                                The new standard for inclusive mental healthcare
+                            </Header>
+
+                            <Button
+                                fullWidth
+                                onClick={() => router.push('/api/auth/login')}
+                            >
+                                Login
+                            </Button>
+
+                            <Caption
+                                color="info"
+                                style={{
+                                    marginTop: theme.spacing(8),
+                                }}
+                            >
+                                Dont have an account?{' '}
+                            </Caption>
+                        </Box>
+                        <AbstractShape
+                            height={260}
+                            width={260}
+                            alt="Abstract shape"
+                            src={ABSTRACT_SHAPE_URL}
                         />
-                        <Header>
-                            The new standard for inclusive mental healthcare
-                        </Header>
-
-                        <Button fullWidth>Login</Button>
-
-                        <Caption
-                            color="info"
-                            style={{
-                                marginTop: theme.spacing(8),
-                            }}
-                        >
-                            Dont have an account?{' '}
-                        </Caption>
-                    </Box>
-                    <AbstractShape
-                        height={260}
-                        width={260}
-                        alt="Abstract shape"
-                        src={ABSTRACT_SHAPE_URL}
-                    />
-                </LoginContainer>
-            }
-        />
+                    </LoginContainer>
+                }
+            />
+        </LoadingContainer>
     );
 }
 

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -8,6 +8,7 @@ import { styled, useTheme } from '@mui/material/styles';
 import { default as NextImage } from 'next/image';
 import { useRouter } from 'next/router';
 import { useUser } from '@auth0/nextjs-auth0/client';
+import { URL_PATHS } from '@/lib/sitemap';
 
 const ABSTRACT_SHAPE_URL =
     'https://res.cloudinary.com/dbrkfldqn/image/upload/v1673455675/app.therify.co/shapes/abstract-shape_fbvcil.svg' as const;
@@ -46,7 +47,7 @@ export default function Home() {
                 <Paragraph>{JSON.stringify(user)}</Paragraph>
                 <Button
                     fullWidth
-                    onClick={() => router.push('/api/auth/logout')}
+                    onClick={() => router.push(URL_PATHS.AUTH.LOGOUT)}
                 >
                     Logout
                 </Button>
@@ -87,7 +88,9 @@ export default function Home() {
 
                             <Button
                                 fullWidth
-                                onClick={() => router.push('/api/auth/login')}
+                                onClick={() =>
+                                    router.push(URL_PATHS.AUTH.LOGIN)
+                                }
                             >
                                 Login
                             </Button>

--- a/src/pages/providers/register/success.tsx
+++ b/src/pages/providers/register/success.tsx
@@ -15,6 +15,7 @@ import { useRouter } from 'next/router';
 import { useEmailVerification } from '@/components/features/registration/ProviderRegistrationFlow/hooks';
 import { ReactNode } from 'react';
 import { motion } from 'framer-motion';
+import { URL_PATHS } from '@/lib/sitemap';
 
 export default function RegistrationSuccessPage() {
     const theme = useTheme();
@@ -97,10 +98,7 @@ export default function RegistrationSuccessPage() {
                             : 'Resend verification email'}
                     </Button>
                     <Button
-                        onClick={() => {
-                            // TODO: Link to login
-                            console.log('TODO: Go to login page');
-                        }}
+                        onClick={() => router.push(URL_PATHS.AUTH.LOGIN)}
                         style={{
                             flex: 2,
                             backgroundColor: theme.palette.background.paper,

--- a/yarn.lock
+++ b/yarn.lock
@@ -22,6 +22,21 @@
   dependencies:
     randexp "^0.5.3"
 
+"@auth0/nextjs-auth0@^2.1.0":
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/@auth0/nextjs-auth0/-/nextjs-auth0-2.1.0.tgz#261bddd13ed72be3075cafb93fa9e1083c23109a"
+  integrity sha512-puykicpdlM2bl8G7cWjXEjktvpnEgWHGjFcwvDQzKgjAfuGYNTPFFRZ6v725w2rw1wzEz4uKDlKmew/ImbtySA==
+  dependencies:
+    "@panva/hkdf" "^1.0.2"
+    cookie "^0.5.0"
+    debug "^4.3.4"
+    http-errors "^1.8.1"
+    joi "^17.6.0"
+    jose "^4.9.2"
+    openid-client "^5.2.1"
+    tslib "^2.4.0"
+    url-join "^4.0.1"
+
 "@aw-web-design/x-default-browser@1.4.88":
   version "1.4.88"
   resolved "https://registry.yarnpkg.com/@aw-web-design/x-default-browser/-/x-default-browser-1.4.88.tgz#33d869cb2a537cd6d2a8369d4dc8ea4988d4be89"
@@ -1537,6 +1552,18 @@
   resolved "https://registry.yarnpkg.com/@fontsource/roboto/-/roboto-4.5.8.tgz#56347764786079838faf43f0eeda22dd7328437f"
   integrity sha512-CnD7zLItIzt86q4Sj3kZUiLcBk1dSk81qcqgMGaZe7SQ1P8hFNxhMl5AZthK1zrDM5m74VVhaOpuMGIL4gagaA==
 
+"@hapi/hoek@^9.0.0":
+  version "9.3.0"
+  resolved "https://registry.yarnpkg.com/@hapi/hoek/-/hoek-9.3.0.tgz#8368869dcb735be2e7f5cb7647de78e167a251fb"
+  integrity sha512-/c6rf4UJlmHlC9b5BaNvzAcFv7HZ2QHaV0D4/HNlBdvFnvQq8RI4kYdhyPCl7Xj+oWvTWQ8ujhqS53LIgAe6KQ==
+
+"@hapi/topo@^5.0.0":
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/@hapi/topo/-/topo-5.1.0.tgz#dc448e332c6c6e37a4dc02fd84ba8d44b9afb012"
+  integrity sha512-foQZKJig7Ob0BMAYBfcJk8d77QtOe7Wo4ox7ff1lQYoNNAb6jwcY1ncdoy2e9wQZzvNy7ODZCYJkK8kzmcAnAg==
+  dependencies:
+    "@hapi/hoek" "^9.0.0"
+
 "@humanwhocodes/config-array@^0.11.8":
   version "0.11.8"
   resolved "https://registry.yarnpkg.com/@humanwhocodes/config-array/-/config-array-0.11.8.tgz#03595ac2075a4dc0f191cc2131de14fbd7d410b9"
@@ -2106,6 +2133,11 @@
     "@nodelib/fs.scandir" "2.1.5"
     fastq "^1.6.0"
 
+"@panva/hkdf@^1.0.2":
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/@panva/hkdf/-/hkdf-1.0.2.tgz#bab0f09d09de9fd83628220d496627681bc440d6"
+  integrity sha512-MSAs9t3Go7GUkMhpKC44T58DJ5KGk2vBo+h1cqQeqlMfdGkxaVB78ZWpv9gYi/g2fa4sopag9gJsNvS8XGgWJA==
+
 "@pkgr/utils@^2.3.1":
   version "2.3.1"
   resolved "https://registry.yarnpkg.com/@pkgr/utils/-/utils-2.3.1.tgz#0a9b06ffddee364d6642b3cd562ca76f55b34a03"
@@ -2178,6 +2210,23 @@
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/@rushstack/eslint-patch/-/eslint-patch-1.2.0.tgz#8be36a1f66f3265389e90b5f9c9962146758f728"
   integrity sha512-sXo/qW2/pAcmT43VoRKOJbDOfV3cYpq3szSVfIThQXNt+E4DfKj361vaAt3c88U5tPUxzEswam7GW48PJqtKAg==
+
+"@sideway/address@^4.1.3":
+  version "4.1.4"
+  resolved "https://registry.yarnpkg.com/@sideway/address/-/address-4.1.4.tgz#03dccebc6ea47fdc226f7d3d1ad512955d4783f0"
+  integrity sha512-7vwq+rOHVWjyXxVlR76Agnvhy8I9rpzjosTESvmhNeXOXdZZB15Fl+TI9x1SiHZH5Jv2wTGduSxFDIaq0m3DUw==
+  dependencies:
+    "@hapi/hoek" "^9.0.0"
+
+"@sideway/formula@^3.0.0":
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/@sideway/formula/-/formula-3.0.1.tgz#80fcbcbaf7ce031e0ef2dd29b1bfc7c3f583611f"
+  integrity sha512-/poHZJJVjx3L+zVD6g9KgHfYnb443oi7wLu/XKojDviHy6HOEOA6z1Trk5aR1dGcmPenJEgb2sK2I80LeS3MIg==
+
+"@sideway/pinpoint@^2.0.0":
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/@sideway/pinpoint/-/pinpoint-2.0.0.tgz#cff8ffadc372ad29fd3f78277aeb29e632cc70df"
+  integrity sha512-RNiOoTPkptFtSVzQevY/yWtZwf/RxyVnPy/OcA9HBM3MlGDnBEYL5B41H0MTn0Uec8Hi+2qUtTfG2WWZBmMejQ==
 
 "@sinclair/typebox@^0.24.1":
   version "0.24.51"
@@ -5038,7 +5087,7 @@ cookie-signature@1.0.6:
   resolved "https://registry.yarnpkg.com/cookie-signature/-/cookie-signature-1.0.6.tgz#e303a882b342cc3ee8ca513a79999734dab3ae2c"
   integrity sha512-QADzlaHc8icV8I7vbaJXJwod9HWYp8uCqf1xa4OfNu1T7JVxQIrUgOWtHdNDtPiywmFbiS12VjotIXLrKM3orQ==
 
-cookie@0.5.0:
+cookie@0.5.0, cookie@^0.5.0:
   version "0.5.0"
   resolved "https://registry.yarnpkg.com/cookie/-/cookie-0.5.0.tgz#d1f5d71adec6558c58f389987c366aa47e994f8b"
   integrity sha512-YZ3GUyn/o8gfKJlnlX7g7xq4gyO6OSuhGPKaaGssGB2qgDUS0gPgtTvoyZLTt9Ab6dC4hfc9dV5arkvc/OCmrw==
@@ -5347,6 +5396,11 @@ depd@2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/depd/-/depd-2.0.0.tgz#b696163cc757560d09cf22cc8fad1571b79e76df"
   integrity sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==
+
+depd@~1.1.2:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/depd/-/depd-1.1.2.tgz#9bcd52e14c097763e749b274c4346ed2e560b5a9"
+  integrity sha512-7emPTl6Dpo6JRXOXjLRxck+FlLRX5847cLKEn00PLAgc3g2hTZZgr+e4c2v6QpSmLeFP3n5yUo7ft6avBK/5jQ==
 
 dequal@^2.0.2:
   version "2.0.3"
@@ -6899,6 +6953,17 @@ http-errors@2.0.0:
     statuses "2.0.1"
     toidentifier "1.0.1"
 
+http-errors@^1.8.1:
+  version "1.8.1"
+  resolved "https://registry.yarnpkg.com/http-errors/-/http-errors-1.8.1.tgz#7c3f28577cbc8a207388455dbd62295ed07bd68c"
+  integrity sha512-Kpk9Sm7NmI+RHhnj6OIWDI1d6fIoFAtFt9RLaTMRlg/8w49juAStsrBgp0Dp4OdxdVbRIeKhtCUvoi/RuAhO4g==
+  dependencies:
+    depd "~1.1.2"
+    inherits "2.0.4"
+    setprototypeof "1.2.0"
+    statuses ">= 1.5.0 < 2"
+    toidentifier "1.0.1"
+
 http-proxy-agent@^5.0.0:
   version "5.0.0"
   resolved "https://registry.yarnpkg.com/http-proxy-agent/-/http-proxy-agent-5.0.0.tgz#5129800203520d434f142bc78ff3c170800f2b43"
@@ -7855,6 +7920,22 @@ jest@^29.3.1:
     import-local "^3.0.2"
     jest-cli "^29.3.1"
 
+joi@^17.6.0:
+  version "17.7.0"
+  resolved "https://registry.yarnpkg.com/joi/-/joi-17.7.0.tgz#591a33b1fe1aca2bc27f290bcad9b9c1c570a6b3"
+  integrity sha512-1/ugc8djfn93rTE3WRKdCzGGt/EtiYKxITMO4Wiv6q5JL1gl9ePt4kBsl1S499nbosspfctIQTpYIhSmHA3WAg==
+  dependencies:
+    "@hapi/hoek" "^9.0.0"
+    "@hapi/topo" "^5.0.0"
+    "@sideway/address" "^4.1.3"
+    "@sideway/formula" "^3.0.0"
+    "@sideway/pinpoint" "^2.0.0"
+
+jose@^4.10.0, jose@^4.9.2:
+  version "4.11.2"
+  resolved "https://registry.yarnpkg.com/jose/-/jose-4.11.2.tgz#d9699307c02e18ff56825843ba90e2fae9f09e23"
+  integrity sha512-njj0VL2TsIxCtgzhO+9RRobBvws4oYyCM8TpvoUQwl/MbIM3NFJRR9+e6x0sS5xXaP1t6OCBkaBME98OV9zU5A==
+
 js-sdsl@^4.1.4:
   version "4.2.0"
   resolved "https://registry.yarnpkg.com/js-sdsl/-/js-sdsl-4.2.0.tgz#278e98b7bea589b8baaf048c20aeb19eb7ad09d0"
@@ -8780,6 +8861,11 @@ object-copy@^0.1.0:
     define-property "^0.2.5"
     kind-of "^3.0.3"
 
+object-hash@^2.0.1:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/object-hash/-/object-hash-2.2.0.tgz#5ad518581eefc443bd763472b8ff2e9c2c0d54a5"
+  integrity sha512-gScRMn0bS5fH+IuwyIFgnh9zBdo4DV+6GhygmWM9HyNJSgS0hScp1f5vjtm7oIIOiT9trXrShAkLFSc2IqKNgw==
+
 object-inspect@^1.12.2, object-inspect@^1.9.0:
   version "1.12.2"
   resolved "https://registry.yarnpkg.com/object-inspect/-/object-inspect-1.12.2.tgz#c0641f26394532f28ab8d796ab954e43c009a8ea"
@@ -8867,6 +8953,11 @@ oblivious-set@1.0.0:
   resolved "https://registry.yarnpkg.com/oblivious-set/-/oblivious-set-1.0.0.tgz#c8316f2c2fb6ff7b11b6158db3234c49f733c566"
   integrity sha512-z+pI07qxo4c2CulUHCDf9lcqDlMSo72N/4rLUpRXf6fu+q8vjt8y0xS+Tlf8NTJDdTXHbdeO1n3MlbctwEoXZw==
 
+oidc-token-hash@^5.0.1:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/oidc-token-hash/-/oidc-token-hash-5.0.1.tgz#ae6beec3ec20f0fd885e5400d175191d6e2f10c6"
+  integrity sha512-EvoOtz6FIEBzE+9q253HsLCVRiK/0doEJ2HCvvqMQb3dHZrP3WlJKYtJ55CRTw4jmYomzH4wkPuCj/I3ZvpKxQ==
+
 on-finished@2.4.1:
   version "2.4.1"
   resolved "https://registry.yarnpkg.com/on-finished/-/on-finished-2.4.1.tgz#58c8c44116e54845ad57f14ab10b03533184ac3f"
@@ -8916,6 +9007,16 @@ open@^8.4.0:
     define-lazy-prop "^2.0.0"
     is-docker "^2.1.1"
     is-wsl "^2.2.0"
+
+openid-client@^5.2.1:
+  version "5.3.1"
+  resolved "https://registry.yarnpkg.com/openid-client/-/openid-client-5.3.1.tgz#69a5fa7d2b5ad479032f576852d40b4d4435488a"
+  integrity sha512-RLfehQiHch9N6tRWNx68cicf3b1WR0x74bJWHRc25uYIbSRwjxYcTFaRnzbbpls5jroLAaB/bFIodTgA5LJMvw==
+  dependencies:
+    jose "^4.10.0"
+    lru-cache "^6.0.0"
+    object-hash "^2.0.1"
+    oidc-token-hash "^5.0.1"
 
 optionator@^0.8.1:
   version "0.8.3"
@@ -10358,6 +10459,11 @@ statuses@2.0.1:
   resolved "https://registry.yarnpkg.com/statuses/-/statuses-2.0.1.tgz#55cb000ccf1d48728bd23c685a063998cf1a1b63"
   integrity sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==
 
+"statuses@>= 1.5.0 < 2":
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/statuses/-/statuses-1.5.0.tgz#161c7dac177659fd9811f43771fa99381478628c"
+  integrity sha512-OpZ3zP+jT1PI7I8nemJX4AKmAX070ZkYPVWV/AaKTJl+tXCTGyVdC1a4SL8RUQYEwk/f34ZX8UTykN68FwrqAA==
+
 store2@^2.12.0, store2@^2.14.2:
   version "2.14.2"
   resolved "https://registry.yarnpkg.com/store2/-/store2-2.14.2.tgz#56138d200f9fe5f582ad63bc2704dbc0e4a45068"
@@ -11077,6 +11183,11 @@ urix@^0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/urix/-/urix-0.1.0.tgz#da937f7a62e21fec1fd18d49b35c2935067a6c72"
   integrity sha512-Am1ousAhSLBeB9cG/7k7r2R0zj50uDRlZHPGbazid5s9rlF1F/QKYObEKSIunSjIOkJZqwRRLpvewjEkM7pSqg==
+
+url-join@^4.0.1:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/url-join/-/url-join-4.0.1.tgz#b642e21a2646808ffa178c4c5fda39844e12cde7"
+  integrity sha512-jk1+QP6ZJqyOiuEI9AEWQfju/nB2Pw466kbA0LEZljHwKeMgd9WrAEgEGxjPDD2+TNbbb37rTyhEfrCXfuKXnA==
 
 url-parse@^1.5.3:
   version "1.5.10"


### PR DESCRIPTION
# Description
Follows [Auth0 docs](https://auth0.com/docs/quickstart/webapp/nextjs/01-login#configure-auth0) to add Login and Logout to Next.js app.

### Notes
- I renamed `AUTH0_DOMAIN` to `AUTH0_BACKEND_DOMAIN` in the Auth0 Management API backend app configuration. Initially, I was going to reuse this variable between the management client and the Next auth feature. They share the same value, but come from different apps, so ultimately I decided to separate them. The value is the same only because the apps happen to be in the same Auth0 tenant, not because the apps are _truly_ dependent on the same value.

- In the Auth0 docs, they use the `handleAuth` method in a wildcard `/api/auth/[...auth].ts` file, but this approach would not work for me. All client requests to auth routes returned 404 responses. I solved this problem by creating the 4 auth methods in separate files and calling their appropriate handler methods. 

# Closes issue(s)
NA

# How to test / repro
`yarn dev:doppler`
go to `http://localhost:3000/api/auth/login`
Login and see yourself get redirected to `/api/auth/callback` and then back to `http://localhost:3000` with your stringified user data shown. Then go to `http://localhost:3000/api/auth/logout`

# Screenshots
<img src="https://user-images.githubusercontent.com/25045075/212980115-0f1f61b9-184c-4480-8163-45ae7a4f4bc1.png" alt="auth0 login page" width="600px" />

# Changes include

-   [ ] Bugfix (non-breaking change that solves an issue)
-   [x] New feature (non-breaking change that adds functionality)
-   [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Checklist

-   [ ] I have tested this code
-   [ ] I have updated the Readme

# Other comments
