### PR TITLE
feat: get plan status by user id

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,6 @@ next-env.d.ts
 
 # Generated Files
 src/lib/schema
+
+# local development
+src/pages/api/test.ts

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -32,13 +32,13 @@ model User {
   stripeCustomerId              String?  @map("stripe_customer_id")
   auth0Id                       String   @unique @map("auth0_id")
 
-  account                    Account?                     @relation(fields: [accountId], references: [id])
-  accountId                  String?                      @unique
-  plan                       Plan[]
-  stripeInvoice              StripeInvoice[]
-  practiceProvider           PracticeProvider[]
-  directoryListingInvitation DirectoryListingInvitation[]
-  providerProfile            ProviderProfile?
+  account                     Account?                     @relation(fields: [accountId], references: [id])
+  accountId                   String?                      @unique
+  plans                       Plan[]
+  stripeInvoices              StripeInvoice[]
+  practiceProviders           PracticeProvider[]
+  directoryListingInvitations DirectoryListingInvitation[]
+  providerProfile             ProviderProfile?
 
   @@map("users")
 }
@@ -89,6 +89,17 @@ enum ProductType {
   session
 }
 
+// Stripe subscription statuses: https://stripe.com/docs/api/subscriptions/object#subscription_object-status
+enum PlanStatus {
+  incomplete
+  incomplete_expired
+  trialing
+  active
+  past_due
+  canceled
+  unpaid
+}
+
 model Plan {
   id                   Int             @id @default(autoincrement()) @map("plan_id")
   seats                Int
@@ -103,7 +114,7 @@ model Plan {
   billingUserId        String?         @map("billing_user_id")
   createdAt            DateTime        @default(now()) @map("created_at")
   updatedAt            DateTime        @updatedAt @map("updated_at")
-  status               String
+  status               PlanStatus
   stripeCustomerId     String?         @map("stripe_customer_id")
   stripeSubscriptionId String?         @unique @map("stripe_subscription_id")
   product              ProductType

--- a/src/lib/features/users/get-plan-status/index.ts
+++ b/src/lib/features/users/get-plan-status/index.ts
@@ -1,0 +1,5 @@
+export { ROUTE as TRPC_ROUTE } from './trpc';
+export { schema as inputSchema } from './input';
+export type { Input } from './input';
+export { schema as outputSchema } from './output';
+export type { Output } from './output';

--- a/src/lib/features/users/get-plan-status/input.ts
+++ b/src/lib/features/users/get-plan-status/input.ts
@@ -1,0 +1,20 @@
+import * as z from 'zod';
+
+export const schema = z.object({
+    auth0Id: z.string(),
+});
+
+export type Input = z.infer<typeof schema>;
+
+export const validate = (value: unknown): Input => {
+    return schema.parse(value);
+};
+
+export const isValid = (value: unknown): value is Input => {
+    try {
+        validate(value);
+        return true;
+    } catch {
+        return false;
+    }
+};

--- a/src/lib/features/users/get-plan-status/output.ts
+++ b/src/lib/features/users/get-plan-status/output.ts
@@ -1,0 +1,32 @@
+import { PlanStatus } from '@prisma/client';
+import * as z from 'zod';
+
+export const schema = z.object({
+    status: z
+        .enum([
+            PlanStatus.active,
+            PlanStatus.canceled,
+            PlanStatus.incomplete,
+            PlanStatus.incomplete_expired,
+            PlanStatus.trialing,
+            PlanStatus.unpaid,
+            PlanStatus.past_due,
+        ])
+        .nullable(),
+    errors: z.array(z.string()),
+});
+
+export type Output = z.infer<typeof schema>;
+
+export const validate = (value: unknown): Output => {
+    return schema.parse(value);
+};
+
+export const isValid = (value: unknown): value is Output => {
+    try {
+        validate(value);
+        return true;
+    } catch {
+        return false;
+    }
+};

--- a/src/lib/features/users/get-plan-status/trpc.ts
+++ b/src/lib/features/users/get-plan-status/trpc.ts
@@ -1,0 +1,1 @@
+export const ROUTE = 'users.get-plan-status-by-user-id' as const;

--- a/src/lib/features/users/index.ts
+++ b/src/lib/features/users/index.ts
@@ -1,1 +1,2 @@
 export * as IsEmailUnique from './is-email-unique';
+export * as GetPlanStatus from './get-plan-status';

--- a/src/lib/server/routers/accounts/resolvers/get-plan-status/index.ts
+++ b/src/lib/server/routers/accounts/resolvers/get-plan-status/index.ts
@@ -1,0 +1,1 @@
+export { resolve as getPlanStatusResolver } from './resolver';

--- a/src/lib/server/routers/accounts/resolvers/get-plan-status/resolver.ts
+++ b/src/lib/server/routers/accounts/resolvers/get-plan-status/resolver.ts
@@ -17,7 +17,7 @@ export const resolve: ProcedureResolver<
             errors: [],
         };
     } catch (error) {
-        let errorMessage = 'Status could not be checked.';
+        let errorMessage = 'Plan status could not be checked.';
         if (error instanceof Error) {
             errorMessage = error.message;
         }

--- a/src/lib/server/routers/accounts/resolvers/get-plan-status/resolver.ts
+++ b/src/lib/server/routers/accounts/resolvers/get-plan-status/resolver.ts
@@ -1,0 +1,29 @@
+import { Context } from '@/lib/server/context';
+import { GetPlanStatus } from '@/lib/features/users';
+import { ProcedureResolver } from '@trpc/server/dist/declarations/src/internals/procedure';
+
+export const resolve: ProcedureResolver<
+    Context,
+    GetPlanStatus.Input,
+    GetPlanStatus.Output
+> = async function resolveGetPlanStatus({
+    input,
+    ctx,
+}): Promise<GetPlanStatus.Output> {
+    try {
+        const result = await ctx.accounts.getPlanStatusByUserId(input);
+        return {
+            ...result,
+            errors: [],
+        };
+    } catch (error) {
+        let errorMessage = 'Status could not be checked.';
+        if (error instanceof Error) {
+            errorMessage = error.message;
+        }
+        return {
+            status: null,
+            errors: [errorMessage],
+        };
+    }
+};

--- a/src/lib/server/routers/accounts/resolvers/index.ts
+++ b/src/lib/server/routers/accounts/resolvers/index.ts
@@ -1,3 +1,4 @@
 export { registerProviderResolver } from './register-provider';
 export { getVerificationEmailStatusResolver } from './get-verification-email-status';
 export { sendEmailVerificationResolver } from './send-email-verification';
+export { getPlanStatusResolver } from './get-plan-status';

--- a/src/lib/server/routers/accounts/router.ts
+++ b/src/lib/server/routers/accounts/router.ts
@@ -4,10 +4,12 @@ import {
     SendEmailVerification,
     GetVerificationEmailStatus,
 } from '@/lib/features/registration';
+import { GetPlanStatus } from '@/lib/features/users';
 import {
     registerProviderResolver,
     sendEmailVerificationResolver,
     getVerificationEmailStatusResolver,
+    getPlanStatusResolver,
 } from './resolvers';
 import { Context } from '../../context';
 
@@ -17,6 +19,11 @@ export const router = trpc
         input: GetVerificationEmailStatus.inputSchema,
         output: GetVerificationEmailStatus.outputSchema,
         resolve: getVerificationEmailStatusResolver,
+    })
+    .query(GetPlanStatus.TRPC_ROUTE, {
+        input: GetPlanStatus.inputSchema,
+        output: GetPlanStatus.outputSchema,
+        resolve: getPlanStatusResolver,
     })
     .mutation(RegisterProvider.TRPC_ROUTE, {
         input: RegisterProvider.inputSchema,

--- a/src/lib/services/accounts/service/get-plan-status-by-user-id/getPlanStatusByUserId.spec.ts
+++ b/src/lib/services/accounts/service/get-plan-status-by-user-id/getPlanStatusByUserId.spec.ts
@@ -1,0 +1,58 @@
+import { VendorStripe } from '@/lib/vendors/stripe';
+import { VendorAuth0 } from '@/lib/vendors/auth0';
+import { Plan, PlanStatus, User } from '@prisma/client';
+import { prismaMock } from '@/lib/prisma/__mock__';
+import * as GetPlanStatusByUserId from './getPlanStatusByUserId';
+
+describe('GetPlanStatusByUserId', function () {
+    it('sorts and references newest plan', async function () {
+        prismaMock.user.findUniqueOrThrow.mockResolvedValue({
+            plans: [
+                {
+                    createdAt: new Date('2021-02-01'),
+                    status: PlanStatus.canceled,
+                } as Plan,
+                {
+                    createdAt: new Date('2021-03-01'),
+                    status: PlanStatus.active,
+                } as Plan,
+                {
+                    createdAt: new Date('2021-01-03'),
+                    status: PlanStatus.past_due,
+                } as Plan,
+            ],
+        } as unknown as User);
+        const getPlanStatusByUserId = GetPlanStatusByUserId.factory({
+            prisma: prismaMock,
+            auth0: {} as VendorAuth0,
+            stripe: {} as VendorStripe,
+        });
+
+        await expect(
+            getPlanStatusByUserId({
+                auth0Id: 'auth0|123',
+            })
+        ).resolves.toEqual({
+            status: PlanStatus.active,
+        });
+    });
+
+    it('returns null if no plans exist', async function () {
+        prismaMock.user.findUniqueOrThrow.mockResolvedValue({
+            plans: [],
+        } as unknown as User);
+        const getPlanStatusByUserId = GetPlanStatusByUserId.factory({
+            prisma: prismaMock,
+            auth0: {} as VendorAuth0,
+            stripe: {} as VendorStripe,
+        });
+
+        await expect(
+            getPlanStatusByUserId({
+                auth0Id: 'auth0|123',
+            })
+        ).resolves.toEqual({
+            status: null,
+        });
+    });
+});

--- a/src/lib/services/accounts/service/get-plan-status-by-user-id/getPlanStatusByUserId.spec.ts
+++ b/src/lib/services/accounts/service/get-plan-status-by-user-id/getPlanStatusByUserId.spec.ts
@@ -5,20 +5,16 @@ import { prismaMock } from '@/lib/prisma/__mock__';
 import * as GetPlanStatusByUserId from './getPlanStatusByUserId';
 
 describe('GetPlanStatusByUserId', function () {
-    it('sorts and references newest plan', async function () {
+    it('references newest plan', async function () {
         prismaMock.user.findUniqueOrThrow.mockResolvedValue({
             plans: [
-                {
-                    createdAt: new Date('2021-02-01'),
-                    status: PlanStatus.canceled,
-                } as Plan,
                 {
                     createdAt: new Date('2021-03-01'),
                     status: PlanStatus.active,
                 } as Plan,
                 {
-                    createdAt: new Date('2021-01-03'),
-                    status: PlanStatus.past_due,
+                    createdAt: new Date('2021-02-01'),
+                    status: PlanStatus.canceled,
                 } as Plan,
             ],
         } as unknown as User);

--- a/src/lib/services/accounts/service/get-plan-status-by-user-id/getPlanStatusByUserId.ts
+++ b/src/lib/services/accounts/service/get-plan-status-by-user-id/getPlanStatusByUserId.ts
@@ -1,0 +1,29 @@
+import { GetPlanStatus } from '@/lib/features/users';
+import { AccountsServiceParams } from '../params';
+
+export const factory =
+    ({ prisma }: AccountsServiceParams) =>
+    async (
+        input: GetPlanStatus.Input
+    ): Promise<{
+        status: GetPlanStatus.Output['status'];
+    }> => {
+        const { plans } = await prisma.user.findUniqueOrThrow({
+            where: {
+                auth0Id: input.auth0Id,
+            },
+            select: {
+                plans: true,
+            },
+        });
+        // sort plans newest to oldest
+        const [newestPlan] = plans.sort((a, b) => {
+            if (a.createdAt > b.createdAt) return -1;
+            if (a.createdAt < b.createdAt) return 1;
+            return 0;
+        });
+
+        return {
+            status: newestPlan?.status ?? null,
+        };
+    };

--- a/src/lib/services/accounts/service/get-plan-status-by-user-id/getPlanStatusByUserId.ts
+++ b/src/lib/services/accounts/service/get-plan-status-by-user-id/getPlanStatusByUserId.ts
@@ -13,15 +13,19 @@ export const factory =
                 auth0Id: input.auth0Id,
             },
             select: {
-                plans: true,
+                plans: {
+                    orderBy: {
+                        createdAt: 'desc',
+                    },
+                    take: 1,
+                    select: {
+                        status: true,
+                        createdAt: true,
+                    },
+                },
             },
         });
-        // sort plans newest to oldest
-        const [newestPlan] = plans.sort((a, b) => {
-            if (a.createdAt > b.createdAt) return -1;
-            if (a.createdAt < b.createdAt) return 1;
-            return 0;
-        });
+        const [newestPlan] = plans;
 
         return {
             status: newestPlan?.status ?? null,

--- a/src/lib/services/accounts/service/get-plan-status-by-user-id/index.ts
+++ b/src/lib/services/accounts/service/get-plan-status-by-user-id/index.ts
@@ -1,0 +1,1 @@
+export * as GetPlanStatusByUserId from './getPlanStatusByUserId';

--- a/src/lib/services/accounts/service/index.ts
+++ b/src/lib/services/accounts/service/index.ts
@@ -8,6 +8,7 @@ import { AccountsServiceParams } from './params';
 import { IsEmailUnique } from './is-email-unique';
 import { SendEmailVerification } from './send-email-verification';
 import { GetVerificationEmailStatus } from './get-verification-email-status';
+import { GetPlanStatusByUserId } from './get-plan-status-by-user-id';
 
 const factoryParams: AccountsServiceParams = {
     prisma,
@@ -21,6 +22,7 @@ export const AccountsService = {
     sendEmailVerification: SendEmailVerification.factory(factoryParams),
     getVerificationEmailStatus:
         GetVerificationEmailStatus.factory(factoryParams),
+    getPlanStatusByUserId: GetPlanStatusByUserId.factory(factoryParams),
 };
 
 export type AccountsService = typeof AccountsService;

--- a/src/lib/sitemap/index.ts
+++ b/src/lib/sitemap/index.ts
@@ -1,5 +1,7 @@
 import { AUTHENTICATION_PATHS } from './authentication';
+import { ONBOARDING_PATHS } from './onboarding';
 
 export const URL_PATHS = {
     AUTH: AUTHENTICATION_PATHS,
+    ONBOARDING: ONBOARDING_PATHS,
 } as const;

--- a/src/lib/sitemap/onboarding/index.ts
+++ b/src/lib/sitemap/onboarding/index.ts
@@ -1,0 +1,3 @@
+export const ONBOARDING_PATHS = {
+    BILLING: '/onboarding/billing',
+} as const;

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -9,6 +9,7 @@ import { default as NextImage } from 'next/image';
 import { useRouter } from 'next/router';
 import { useUser } from '@auth0/nextjs-auth0/client';
 import { URL_PATHS } from '@/lib/sitemap';
+import { trpc } from '@/lib/utils/trpc';
 
 const ABSTRACT_SHAPE_URL =
     'https://res.cloudinary.com/dbrkfldqn/image/upload/v1673455675/app.therify.co/shapes/abstract-shape_fbvcil.svg' as const;
@@ -41,9 +42,27 @@ export default function Home() {
             LOGIN_IMAGES[Math.floor(Math.random() * LOGIN_IMAGES.length)]
         );
     }, []);
+    const { data: planStatus } = trpc.useQuery(
+        [
+            'accounts.users.get-plan-status-by-user-id',
+            {
+                auth0Id: user?.sub ?? '',
+            },
+        ],
+        {
+            refetchOnWindowFocus: false,
+            enabled: Boolean(user?.sub),
+        }
+    );
     if (user) {
+        if (planStatus?.status === null) {
+            router.push(URL_PATHS.ONBOARDING.BILLING);
+        }
         return (
             <CenteredContainer fillSpace padding={8}>
+                <Paragraph>
+                    {JSON.stringify({ planStatus: planStatus?.status })}
+                </Paragraph>
                 <Paragraph>{JSON.stringify(user)}</Paragraph>
                 <Button
                     fullWidth


### PR DESCRIPTION
# Description
Given an Auth0 user id, returns the status of their most recent plan or `null`.
#### Adds:
- Feature i/o 
- Resolver + TRPC query
- Accounts service method
- Placeholder UI
- `PlanStatus` enum to the Prisma `Plan` Schema. They follow Stripe's [Subscription statuses](https://stripe.com/docs/api/subscriptions/object#subscription_object-status) 
#### Updates
- One-to-many relations on the Prisma `User` model now plural

# Closes issue(s)
NA
# How to test / repro
Spin up app and login
On login, see yourself get redirected to `/onboarding/billing`. The plan status should be `null` since no plan capturing is implemented yet.

# Screenshots
NA
# Changes include

-   [ ] Bugfix (non-breaking change that solves an issue)
-   [x] New feature (non-breaking change that adds functionality)
-   [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Checklist

-   [x] I have tested this code 
-   [ ] I have updated the Readme

# Other comments
Basic Unit tests included for the service method