### PR TITLE
feat: handle plan cancelations and renewals

### DIFF
--- a/prisma/migrations/20230123061213_stripe_webhook_listeners/migration.sql
+++ b/prisma/migrations/20230123061213_stripe_webhook_listeners/migration.sql
@@ -1,0 +1,50 @@
+/*
+  Warnings:
+
+  - The primary key for the `billing_provider_invoices` table will be changed. If it partially fails, the table could be left without primary key constraint.
+  - You are about to drop the column `stripe_invoice_id` on the `billing_provider_invoices` table. All the data in the column will be lost.
+  - The primary key for the `plans` table will be changed. If it partially fails, the table could be left without primary key constraint.
+  - You are about to drop the column `plan_id` on the `plans` table. All the data in the column will be lost.
+  - You are about to drop the column `product` on the `plans` table. All the data in the column will be lost.
+  - A unique constraint covering the columns `[stripe_customer_id]` on the table `users` will be added. If there are existing duplicate values, this will fail.
+  - The required column `id` was added to the `plans` table with a prisma-level default value. This is not possible if the table is not empty. Please add this column as optional, then populate it before making it required.
+
+*/
+-- AlterEnum
+ALTER TYPE "PlanStatus" ADD VALUE 'invalidated';
+
+-- DropForeignKey
+ALTER TABLE "billing_provider_invoices" DROP CONSTRAINT "billing_provider_invoices_plan_id_fkey";
+
+-- DropIndex
+DROP INDEX "billing_provider_invoices_user_id_key";
+
+-- DropIndex
+DROP INDEX "plans_stripe_subscription_id_key";
+
+-- DropIndex
+DROP INDEX "plans_user_id_key";
+
+-- AlterTable
+ALTER TABLE "billing_provider_invoices" DROP CONSTRAINT "billing_provider_invoices_pkey",
+DROP COLUMN "stripe_invoice_id",
+ALTER COLUMN "id" DROP DEFAULT,
+ALTER COLUMN "id" SET DATA TYPE TEXT,
+ALTER COLUMN "plan_id" SET DATA TYPE TEXT,
+ADD CONSTRAINT "billing_provider_invoices_pkey" PRIMARY KEY ("id");
+DROP SEQUENCE "billing_provider_invoices_id_seq";
+
+-- AlterTable
+ALTER TABLE "plans" DROP CONSTRAINT "plans_pkey",
+DROP COLUMN "plan_id",
+DROP COLUMN "product",
+ADD COLUMN     "id" TEXT NOT NULL,
+ADD COLUMN     "renews" BOOLEAN NOT NULL DEFAULT true,
+ADD COLUMN     "stripe_price_id" TEXT,
+ADD CONSTRAINT "plans_pkey" PRIMARY KEY ("id");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "users_stripe_customer_id_key" ON "users"("stripe_customer_id");
+
+-- AddForeignKey
+ALTER TABLE "billing_provider_invoices" ADD CONSTRAINT "billing_provider_invoices_plan_id_fkey" FOREIGN KEY ("plan_id") REFERENCES "plans"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -120,6 +120,7 @@ model Plan {
   stripeCustomerId     String?         @map("stripe_customer_id")
   stripeSubscriptionId String?         @map("stripe_subscription_id")
   stripePriceId        String?         @map("stripe_price_id")
+  renews               Boolean         @default(true)
   invoices             StripeInvoice[]
 
   @@index([stripeCustomerId, stripeSubscriptionId])

--- a/src/lib/features/accounts/billing/cancel-plan/index.ts
+++ b/src/lib/features/accounts/billing/cancel-plan/index.ts
@@ -1,0 +1,4 @@
+export { schema as InputSchema } from './input';
+export type { Input } from './input';
+export { schema as OutputSchema } from './output';
+export type { Output } from './output';

--- a/src/lib/features/accounts/billing/cancel-plan/input.ts
+++ b/src/lib/features/accounts/billing/cancel-plan/input.ts
@@ -1,0 +1,20 @@
+import * as z from 'zod';
+
+export const schema = z.object({
+    stripeSubscriptionId: z.string(),
+});
+
+export type Input = z.infer<typeof schema>;
+
+export const validate = (value: unknown): Input => {
+    return schema.parse(value);
+};
+
+export const isValid = (value: unknown): value is Input => {
+    try {
+        validate(value);
+        return true;
+    } catch {
+        return false;
+    }
+};

--- a/src/lib/features/accounts/billing/cancel-plan/output.ts
+++ b/src/lib/features/accounts/billing/cancel-plan/output.ts
@@ -1,0 +1,26 @@
+import * as z from 'zod';
+import { PlanSchema } from '@/lib/schema';
+
+export const schema = z.object({
+    subscription: z
+        .object({
+            status: PlanSchema.shape.status,
+            startDate: z.string(),
+            endDate: z.string(),
+        })
+        .optional(),
+});
+export type Output = z.infer<typeof schema>;
+
+export const validate = (value: unknown): Output => {
+    return schema.parse(value);
+};
+
+export const isValid = (value: unknown): value is Output => {
+    try {
+        validate(value);
+        return true;
+    } catch {
+        return false;
+    }
+};

--- a/src/lib/features/accounts/billing/handle-group-practice-plan-payment/index.ts
+++ b/src/lib/features/accounts/billing/handle-group-practice-plan-payment/index.ts
@@ -1,4 +1,3 @@
-export { ROUTE as TRPC_ROUTE } from './trpc';
 export { schema as inputSchema } from './input';
 export { schema as outputSchema } from './output';
 export type { Input } from './input';

--- a/src/lib/features/accounts/billing/handle-group-practice-plan-payment/trpc.ts
+++ b/src/lib/features/accounts/billing/handle-group-practice-plan-payment/trpc.ts
@@ -1,1 +1,0 @@
-export const ROUTE = 'onboarding.handle-practice-onboarding' as const;

--- a/src/lib/features/accounts/billing/index.ts
+++ b/src/lib/features/accounts/billing/index.ts
@@ -1,2 +1,4 @@
 export * as HandleGroupPracticePlanPayment from './handle-group-practice-plan-payment';
 export * as HandlePlanChange from './handle-plan-change';
+export * as RenewPlan from './renew-plan';
+export * as CancelPlan from './cancel-plan';

--- a/src/lib/features/accounts/billing/renew-plan/index.ts
+++ b/src/lib/features/accounts/billing/renew-plan/index.ts
@@ -1,0 +1,4 @@
+export { schema as InputSchema } from './input';
+export { schema as OutputSchema } from './output';
+export type { Input } from './input';
+export type { Output } from './output';

--- a/src/lib/features/accounts/billing/renew-plan/input.ts
+++ b/src/lib/features/accounts/billing/renew-plan/input.ts
@@ -1,0 +1,20 @@
+import * as z from 'zod';
+
+export const schema = z.object({
+    stripeSubscriptionId: z.string(),
+});
+
+export type Input = z.infer<typeof schema>;
+
+export const validate = (value: unknown): Input => {
+    return schema.parse(value);
+};
+
+export const isValid = (value: unknown): value is Input => {
+    try {
+        validate(value);
+        return true;
+    } catch {
+        return false;
+    }
+};

--- a/src/lib/features/accounts/billing/renew-plan/output.ts
+++ b/src/lib/features/accounts/billing/renew-plan/output.ts
@@ -1,0 +1,26 @@
+import * as z from 'zod';
+import { PlanSchema } from '@/lib/schema';
+
+export const schema = z.object({
+    subscription: z
+        .object({
+            status: PlanSchema.shape.status,
+            startDate: z.string(),
+            endDate: z.string(),
+        })
+        .optional(),
+});
+export type Output = z.infer<typeof schema>;
+
+export const validate = (value: unknown): Output => {
+    return schema.parse(value);
+};
+
+export const isValid = (value: unknown): value is Output => {
+    try {
+        validate(value);
+        return true;
+    } catch {
+        return false;
+    }
+};

--- a/src/lib/features/users/get-plan-status/output.ts
+++ b/src/lib/features/users/get-plan-status/output.ts
@@ -1,18 +1,9 @@
-import { PlanStatus } from '@prisma/client';
+import { PlanSchema } from '@/lib/schema';
+
 import * as z from 'zod';
 
 export const schema = z.object({
-    status: z
-        .enum([
-            PlanStatus.active,
-            PlanStatus.canceled,
-            PlanStatus.incomplete,
-            PlanStatus.incomplete_expired,
-            PlanStatus.trialing,
-            PlanStatus.unpaid,
-            PlanStatus.past_due,
-        ])
-        .nullable(),
+    status: PlanSchema.shape.status.nullable(),
     errors: z.array(z.string()),
 });
 

--- a/src/lib/services/accounts/service/billing/billingFactory.ts
+++ b/src/lib/services/accounts/service/billing/billingFactory.ts
@@ -1,9 +1,13 @@
 import { AccountsServiceParams } from '../params';
+import { CancelPlan } from './cancel-plan';
 import { HandleGroupPracticePlanPayment } from './handle-group-practice-plan-payment';
 import { HandlePlanChange } from './handle-plan-change';
+import { RenewPlan } from './renew-plan';
 
 export const factory = (context: AccountsServiceParams) => ({
     handleGroupPracticePlanPayment:
         HandleGroupPracticePlanPayment.factory(context),
     handlePlanChange: HandlePlanChange.factory(context),
+    cancelPlan: CancelPlan.factory(context),
+    renewPlan: RenewPlan.factory(context),
 });

--- a/src/lib/services/accounts/service/billing/cancel-plan/cancelPlan.ts
+++ b/src/lib/services/accounts/service/billing/cancel-plan/cancelPlan.ts
@@ -1,0 +1,22 @@
+import { CancelPlan } from '@/lib/features/accounts/billing';
+import { TransactionV1 } from '@/lib/utils';
+import { AccountsServiceParams } from '../../params';
+
+import {
+    cancelPlanTransactionDefinition,
+    CancelPlanEntity,
+    FindPlanEntity,
+} from './transaction';
+
+export const factory =
+    (context: AccountsServiceParams) => async (params: CancelPlan.Input) => {
+        return await TransactionV1.executeTransaction(
+            cancelPlanTransactionDefinition,
+            { ...context },
+            {
+                findPlanEntity: FindPlanEntity.factory(params),
+                cancelPlanEntity: CancelPlanEntity.step,
+            },
+            true
+        );
+    };

--- a/src/lib/services/accounts/service/billing/cancel-plan/index.ts
+++ b/src/lib/services/accounts/service/billing/cancel-plan/index.ts
@@ -1,0 +1,1 @@
+export * as CancelPlan from './cancelPlan';

--- a/src/lib/services/accounts/service/billing/cancel-plan/transaction/cancelPlanEntity.ts
+++ b/src/lib/services/accounts/service/billing/cancel-plan/transaction/cancelPlanEntity.ts
@@ -1,0 +1,28 @@
+import { PlanStatus } from '@prisma/client';
+import { CancelPlanTransaction } from './definition';
+
+export const step: CancelPlanTransaction['cancelPlanEntity'] = {
+    async commit({ prisma }, { findPlanEntity: { planId: id } }) {
+        await prisma.plan.update({
+            where: {
+                id,
+            },
+            data: {
+                status: PlanStatus.canceled,
+                renews: false,
+            },
+        });
+        return { updated: true };
+    },
+    async rollback(
+        { prisma },
+        { findPlanEntity: { planId: id, status, renews } }
+    ) {
+        return prisma.plan.update({
+            where: {
+                id,
+            },
+            data: { status, renews },
+        });
+    },
+};

--- a/src/lib/services/accounts/service/billing/cancel-plan/transaction/definition.ts
+++ b/src/lib/services/accounts/service/billing/cancel-plan/transaction/definition.ts
@@ -1,0 +1,20 @@
+import * as z from 'zod';
+import { PlanSchema } from '@/lib/schema';
+import { TransactionDefinition } from '@/lib/utils/transaction/transaction.v1';
+import { AccountsServiceParams as Context } from '../../../params';
+
+export const cancelPlanTransactionDefinition = z.object({
+    findPlanEntity: z.object({
+        planId: z.string(),
+        status: PlanSchema.shape.status,
+        renews: z.boolean(),
+    }),
+    cancelPlanEntity: z.object({
+        updated: z.boolean(),
+    }),
+});
+
+export type CancelPlanTransaction = TransactionDefinition<
+    Context,
+    typeof cancelPlanTransactionDefinition.shape
+>;

--- a/src/lib/services/accounts/service/billing/cancel-plan/transaction/findPlanEntity.ts
+++ b/src/lib/services/accounts/service/billing/cancel-plan/transaction/findPlanEntity.ts
@@ -1,0 +1,34 @@
+import { CancelPlan } from '@/lib/features/accounts/billing';
+import { PlanStatus } from '@prisma/client';
+import { CancelPlanTransaction } from './definition';
+
+interface FindPlanEntityFactory {
+    (params: CancelPlan.Input): CancelPlanTransaction['findPlanEntity'];
+}
+
+export const factory: FindPlanEntityFactory = ({ stripeSubscriptionId }) => ({
+    async commit({ prisma }) {
+        const plan = await prisma.plan.findFirstOrThrow({
+            where: {
+                stripeSubscriptionId,
+                status: PlanStatus.active,
+            },
+            orderBy: {
+                endDate: 'desc',
+            },
+            select: {
+                id: true,
+                status: true,
+                renews: true,
+            },
+        });
+        return {
+            planId: plan.id,
+            status: plan.status,
+            renews: plan.renews,
+        };
+    },
+    async rollback() {
+        return;
+    },
+});

--- a/src/lib/services/accounts/service/billing/cancel-plan/transaction/index.ts
+++ b/src/lib/services/accounts/service/billing/cancel-plan/transaction/index.ts
@@ -1,0 +1,3 @@
+export * as FindPlanEntity from './findPlanEntity';
+export * as CancelPlanEntity from './cancelPlanEntity';
+export * from './definition';

--- a/src/lib/services/accounts/service/billing/renew-plan/index.ts
+++ b/src/lib/services/accounts/service/billing/renew-plan/index.ts
@@ -1,0 +1,1 @@
+export * as RenewPlan from './renewPlan';

--- a/src/lib/services/accounts/service/billing/renew-plan/renewPlan.ts
+++ b/src/lib/services/accounts/service/billing/renew-plan/renewPlan.ts
@@ -1,0 +1,21 @@
+import { RenewPlan } from '@/lib/features/accounts/billing';
+import { executeTransaction } from '@/lib/utils/transaction/transaction.v1';
+import { AccountsServiceParams } from '../../params';
+import {
+    renewPlanTransactionDefinition,
+    FindPlanEntity,
+    RenewPlanEntity,
+} from './transaction';
+
+export const factory =
+    (context: AccountsServiceParams) => async (params: RenewPlan.Input) => {
+        return await executeTransaction(
+            renewPlanTransactionDefinition,
+            { ...context },
+            {
+                findPlanEntity: FindPlanEntity.factory(params),
+                renewPlanEntity: RenewPlanEntity.step,
+            },
+            true
+        );
+    };

--- a/src/lib/services/accounts/service/billing/renew-plan/transaction/definition.ts
+++ b/src/lib/services/accounts/service/billing/renew-plan/transaction/definition.ts
@@ -1,0 +1,20 @@
+import { PlanSchema } from '@/lib/schema';
+import { TransactionDefinition } from '@/lib/utils/transaction/transaction.v1';
+import * as z from 'zod';
+import { AccountsServiceParams as Context } from '../../../params';
+
+export const renewPlanTransactionDefinition = z.object({
+    findPlanEntity: z.object({
+        planId: z.string(),
+        status: PlanSchema.shape.status,
+        renews: z.boolean(),
+    }),
+    renewPlanEntity: z.object({
+        updated: z.boolean(),
+    }),
+});
+
+export type RenewPlanTransaction = TransactionDefinition<
+    Context,
+    typeof renewPlanTransactionDefinition.shape
+>;

--- a/src/lib/services/accounts/service/billing/renew-plan/transaction/findPlanEntity.ts
+++ b/src/lib/services/accounts/service/billing/renew-plan/transaction/findPlanEntity.ts
@@ -1,0 +1,33 @@
+import { RenewPlan } from '@/lib/features/accounts/billing';
+import { RenewPlanTransaction } from './definition';
+
+interface FindPlanEntityFactory {
+    (params: RenewPlan.Input): RenewPlanTransaction['findPlanEntity'];
+}
+
+export const factory: FindPlanEntityFactory = ({ stripeSubscriptionId }) => ({
+    async commit({ prisma }) {
+        const plan = await prisma.plan.findFirstOrThrow({
+            where: {
+                stripeSubscriptionId,
+                renews: false,
+            },
+            orderBy: {
+                endDate: 'desc',
+            },
+            select: {
+                id: true,
+                status: true,
+                renews: true,
+            },
+        });
+        return {
+            planId: plan.id,
+            status: plan.status,
+            renews: plan.renews,
+        };
+    },
+    async rollback() {
+        return;
+    },
+});

--- a/src/lib/services/accounts/service/billing/renew-plan/transaction/index.ts
+++ b/src/lib/services/accounts/service/billing/renew-plan/transaction/index.ts
@@ -1,0 +1,3 @@
+export * as FindPlanEntity from './findPlanEntity';
+export * as RenewPlanEntity from './renewPlanEntity';
+export * from './definition';

--- a/src/lib/services/accounts/service/billing/renew-plan/transaction/renewPlanEntity.ts
+++ b/src/lib/services/accounts/service/billing/renew-plan/transaction/renewPlanEntity.ts
@@ -1,0 +1,28 @@
+import { PlanStatus } from '@prisma/client';
+import { RenewPlanTransaction } from './definition';
+
+export const step: RenewPlanTransaction['renewPlanEntity'] = {
+    async commit({ prisma }, { findPlanEntity: { planId: id } }) {
+        await prisma.plan.update({
+            where: {
+                id,
+            },
+            data: {
+                status: PlanStatus.active,
+                renews: true,
+            },
+        });
+        return { updated: true };
+    },
+    async rollback(
+        { prisma },
+        { findPlanEntity: { planId: id, status, renews } }
+    ) {
+        return prisma.plan.update({
+            where: {
+                id,
+            },
+            data: { status, renews },
+        });
+    },
+};

--- a/src/lib/services/webhooks/stripe/event-handlers/index.ts
+++ b/src/lib/services/webhooks/stripe/event-handlers/index.ts
@@ -1,6 +1,8 @@
 import { StripeWebhookParams } from '../webhookParams';
 import { handleInvoicesFactory } from './invoices';
+import { handleSubscriptionFactory } from './subscriptions';
 
 export const eventHandlersFactory = (context: StripeWebhookParams) => ({
     invoices: handleInvoicesFactory(context),
+    subscriptions: handleSubscriptionFactory(context),
 });

--- a/src/lib/services/webhooks/stripe/event-handlers/subscriptions/index.ts
+++ b/src/lib/services/webhooks/stripe/event-handlers/subscriptions/index.ts
@@ -1,0 +1,6 @@
+import { StripeWebhookParams } from '../../webhookParams';
+import { handleSubscriptionUpdatedFactory } from './updated';
+
+export const handleSubscriptionFactory = (context: StripeWebhookParams) => ({
+    updated: handleSubscriptionUpdatedFactory(context),
+});

--- a/src/lib/services/webhooks/stripe/event-handlers/subscriptions/updated/handleSubscriptionUpdated.ts
+++ b/src/lib/services/webhooks/stripe/event-handlers/subscriptions/updated/handleSubscriptionUpdated.ts
@@ -1,0 +1,51 @@
+import Stripe from 'stripe';
+import { StripeSubsctiption } from '@/lib/vendors/stripe';
+import { StripeWebhookParams } from '../../../webhookParams';
+
+export const handleSubscriptionUpdatedFactory =
+    ({ accounts }: StripeWebhookParams) =>
+    async (
+        rawSubscription: unknown,
+        previousAttributes?: Stripe.Event.Data.PreviousAttributes
+    ) => {
+        const subscription = StripeSubsctiption.schema.parse(rawSubscription);
+        const subscriptionId = subscription.id;
+
+        if (!subscriptionId) {
+            throw new Error('Subscription ID not found');
+        }
+
+        const isCanceling =
+            subscription.cancel_at_period_end ||
+            subscription.status === 'canceled';
+
+        const isRenewing =
+            (previousAttributes as { cancel_at_period_end: boolean })
+                ?.cancel_at_period_end === true &&
+            subscription.cancel_at_period_end === false;
+
+        if (isCanceling || isRenewing) {
+            const handlerFn = isCanceling
+                ? accounts.billing.cancelPlan
+                : accounts.billing.renewPlan;
+            const result = await handlerFn({
+                stripeSubscriptionId: subscriptionId,
+            });
+
+            if (result.isErr()) {
+                let errorMessage = 'Could not handle plan update';
+                result.mapErr(([errorStep, error]) => {
+                    const message = (error as Error)?.message;
+                    const failedStepMessage = `Failed on step: ${errorStep}`;
+                    errorMessage = `[handleSubscriptionUpdated error]: ${
+                        message ?? failedStepMessage
+                    }`;
+                });
+                throw new Error(errorMessage);
+            }
+        }
+
+        return {
+            success: true,
+        };
+    };

--- a/src/lib/services/webhooks/stripe/event-handlers/subscriptions/updated/handleSubscriptionUpdated.ts
+++ b/src/lib/services/webhooks/stripe/event-handlers/subscriptions/updated/handleSubscriptionUpdated.ts
@@ -9,11 +9,6 @@ export const handleSubscriptionUpdatedFactory =
         previousAttributes?: Stripe.Event.Data.PreviousAttributes
     ) => {
         const subscription = StripeSubsctiption.schema.parse(rawSubscription);
-        const subscriptionId = subscription.id;
-
-        if (!subscriptionId) {
-            throw new Error('Subscription ID not found');
-        }
 
         const isCanceling =
             subscription.cancel_at_period_end ||
@@ -29,7 +24,7 @@ export const handleSubscriptionUpdatedFactory =
                 ? accounts.billing.cancelPlan
                 : accounts.billing.renewPlan;
             const result = await handlerFn({
-                stripeSubscriptionId: subscriptionId,
+                stripeSubscriptionId: subscription.id,
             });
 
             if (result.isErr()) {

--- a/src/lib/services/webhooks/stripe/event-handlers/subscriptions/updated/index.ts
+++ b/src/lib/services/webhooks/stripe/event-handlers/subscriptions/updated/index.ts
@@ -1,0 +1,1 @@
+export * from './handleSubscriptionUpdated';

--- a/src/lib/vendors/stripe/types/plan.ts
+++ b/src/lib/vendors/stripe/types/plan.ts
@@ -10,7 +10,7 @@ export const stripePlanTier = z.object({
 
 export const schema = z.object({
     active: z.boolean(),
-    aggregate_usage: z.string(),
+    aggregate_usage: z.string().nullable(),
     amount: z.number(),
     amount_decimal: z.string(),
     billing_scheme: z.string(),
@@ -21,16 +21,18 @@ export const schema = z.object({
     interval_count: z.number(),
     livemode: z.boolean(),
     metadata: z.object({}),
-    nickname: z.string(),
+    nickname: z.string().nullable(),
     object: z.literal('plan'),
     product: z.string(),
-    tiers: z.array(stripePlanTier),
-    tiers_mode: z.string(),
-    transform_usage: z.object({
-        divide_by: z.number(),
-        round: z.string(),
-    }),
-    trial_period_days: z.number(),
+    tiers: z.array(stripePlanTier).optional(),
+    tiers_mode: z.string().nullable(),
+    transform_usage: z
+        .object({
+            divide_by: z.number(),
+            round: z.string(),
+        })
+        .nullable(),
+    trial_period_days: z.number().nullable(),
     usage_type: z.string(),
 });
 

--- a/src/lib/vendors/stripe/types/subscription.ts
+++ b/src/lib/vendors/stripe/types/subscription.ts
@@ -1,40 +1,18 @@
 import * as z from 'zod';
-import { schema as stripePlan, stripePlanTier } from './plan';
+import { schema as stripePlan } from './plan';
 import { schema as stripeDiscount } from './discount';
 
 export const stripeSubscriptionItem = z.object({
     id: z.string(),
     object: z.literal('subscription_item'),
-    billing_thresholds: z.object({
-        usage_gte: z.number(),
-    }),
+    billing_thresholds: z
+        .object({
+            usage_gte: z.number(),
+        })
+        .nullable(),
     created: z.number(),
     metadata: z.object({}),
-    plan: z.object({
-        active: z.boolean(),
-        aggregate_usage: z.string(),
-        amount: z.number(),
-        amount_decimal: z.string(),
-        billing_scheme: z.string(),
-        created: z.number(),
-        currency: z.string(),
-        id: z.string(),
-        interval: z.string(),
-        interval_count: z.number(),
-        livemode: z.boolean(),
-        metadata: z.object({}),
-        nickname: z.string(),
-        object: z.literal('plan'),
-        product: z.string(),
-        tiers: z.array(stripePlanTier),
-        tiers_mode: z.string(),
-        transform_usage: z.object({
-            divide_by: z.number(),
-            round: z.string(),
-        }),
-        trial_period_days: z.number(),
-        usage_type: z.string(),
-    }),
+    plan: stripePlan,
     quantity: z.number(),
     subscription: z.string(),
     tax_rates: z.array(z.string()),
@@ -43,74 +21,89 @@ export const stripeSubscriptionItem = z.object({
 export const schema = z.object({
     id: z.string(),
     object: z.literal('subscription'),
-    application_fee_percent: z.number(),
-    billing: z.string(),
+    application_fee_percent: z.number().nullable(),
+    billing: z.string().optional(),
     billing_cycle_anchor: z.number(),
-    billing_thresholds: z.object({
-        amount_gte: z.number(),
-        reset_billing_cycle_anchor: z.boolean(),
-    }),
-    cancel_at: z.number(),
+    billing_thresholds: z
+        .object({
+            amount_gte: z.number(),
+            reset_billing_cycle_anchor: z.boolean(),
+        })
+        .nullable(),
+    cancel_at: z.number().nullable(),
     cancel_at_period_end: z.boolean(),
-    canceled_at: z.number(),
+    canceled_at: z.number().nullable(),
     collection_method: z.string(),
     created: z.number(),
     current_period_end: z.number(),
     current_period_start: z.number(),
     customer: z.string(),
-    days_until_due: z.number(),
+    days_until_due: z.number().nullable(),
     default_payment_method: z.string(),
-    default_source: z.string(),
+    default_source: z.string().nullable(),
     default_tax_rates: z.array(z.string()),
-    discount: stripeDiscount,
-    ended_at: z.number(),
-    items: z.array(stripeSubscriptionItem),
+    discount: stripeDiscount.nullable(),
+    ended_at: z.number().nullable(),
+    items: z.object({
+        object: z.literal('list'),
+        has_more: z.boolean(),
+        url: z.string(),
+        data: z.array(stripeSubscriptionItem),
+    }),
     latest_invoice: z.string(),
     livemode: z.boolean(),
     metadata: z.object({}),
-    next_pending_invoice_item_invoice: z.number(),
-    on_behalf_of: z.string(),
-    pause_collection: z.object({
-        behavior: z.string(),
-        resumes_at: z.number(),
-    }),
-    pending_invoice_item_interval: z.object({
-        interval: z.string(),
-        interval_count: z.number(),
-    }),
-    pending_setup_intent: z.string(),
-    pending_update: z.object({
-        billing_cycle_anchor: z.number(),
-        billing_thresholds: z.object({
-            amount_gte: z.number(),
-            reset_billing_cycle_anchor: z.boolean(),
-        }),
-        cancel_at_period_end: z.boolean(),
-        collection_method: z.string(),
-        default_payment_method: z.string(),
-        default_source: z.string(),
-        default_tax_rates: z.array(z.string()),
-        items: z.array(stripeSubscriptionItem),
-        proration_behavior: z.string(),
-        proration_date: z.number(),
-        transfer_data: z.object({
-            amount_percent: z.number(),
-            destination: z.string(),
-        }),
-    }),
+    next_pending_invoice_item_invoice: z.number().nullable(),
+    on_behalf_of: z.string().nullable(),
+    pause_collection: z
+        .object({
+            behavior: z.string(),
+            resumes_at: z.number(),
+        })
+        .nullable(),
+    pending_invoice_item_interval: z
+        .object({
+            interval: z.string(),
+            interval_count: z.number(),
+        })
+        .nullable(),
+    pending_setup_intent: z.string().nullable(),
+    pending_update: z
+        .object({
+            billing_cycle_anchor: z.number(),
+            billing_thresholds: z.object({
+                amount_gte: z.number(),
+                reset_billing_cycle_anchor: z.boolean(),
+            }),
+            cancel_at_period_end: z.boolean(),
+            collection_method: z.string(),
+            default_payment_method: z.string(),
+            default_source: z.string(),
+            default_tax_rates: z.array(z.string()),
+            items: z.array(stripeSubscriptionItem),
+            proration_behavior: z.string(),
+            proration_date: z.number(),
+            transfer_data: z.object({
+                amount_percent: z.number(),
+                destination: z.string(),
+            }),
+        })
+        .nullable(),
     plan: stripePlan,
     quantity: z.number(),
-    schedule: z.string(),
+    schedule: z.string().nullable(),
     start_date: z.number(),
-    start_proration_behavior: z.string(),
+    start_proration_behavior: z.string().optional(),
     status: z.string(),
-    tax_percent: z.number(),
-    transfer_data: z.object({
-        amount_percent: z.number(),
-        destination: z.string(),
-    }),
-    trial_end: z.number(),
-    trial_start: z.number(),
+    tax_percent: z.number().optional(),
+    transfer_data: z
+        .object({
+            amount_percent: z.number(),
+            destination: z.string(),
+        })
+        .nullable(),
+    trial_end: z.number().nullable(),
+    trial_start: z.number().nullable(),
 });
 
 export type Subscription = z.infer<typeof schema>;


### PR DESCRIPTION
# Description
Adds Stripe Webhooks handlers to handle plan cancelations and renewals.

#### Adds: 
- Event handler case for `customer.subscription.update` event
- Feature schema for `CancelPlan` and `RenewPlan` features
- Accounts service methods at `accounts.billing.cancelPlan` and `accounts.billing.renewPlan`
- `renews` column to `Plan` Prisma model
- Prisma Migration
- Small typing fix on previous Pr's  handler work
- Fixes Subscription Schema in Stripe vendor
- Default Event Handler case now only throws `UnknownStripeEventTypeError`  when not in the `development` node environment

# Closes issue(s)
NA

# How to test / repro
2. Run `yard dev:doppler` to start app
3. Run `yarn stripe-cli:listen` to listen to stripe test events. Copy the webhook secret to your local env
4. Login to an account with an active plan
5. Navigate to `http://localhost:3000/providers/onboarding/billing/success` and launch a Stripe Checkout session
6. Cancel the plan.
7. Check the Db to see the plan's `status` change to `canceled` and `renews` property set to `false`
8. Renew the plan in the Customer portal
9. See the plan's `status` change back to `active` and `renews` property set back to `true`.

# Screenshots
NA

# Changes include

-   [ ] Bugfix (non-breaking change that solves an issue)
-   [x] New feature (non-breaking change that adds functionality)
-   [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Checklist

-   [ ] I have tested this code
-   [ ] I have updated the Readme

# Other comments
