### PR TITLE
feat: role based page access

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
         "micro": "^10.0.1",
         "neverthrow": "^6.0.0",
         "next": "^13.1.1",
+        "nookies": "^2.5.2",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "react-hook-form": "^7.41.5",

--- a/src/lib/context/therify-user/Context.ts
+++ b/src/lib/context/therify-user/Context.ts
@@ -7,6 +7,7 @@ interface TherifyUserContext {
     isLoading: boolean;
     errorMessage?: string;
     isRefetching: boolean;
+    clearCookies: () => void;
     refetch?: ReturnType<typeof trpc.useQuery>['refetch'];
 }
 export const Context = createContext<TherifyUserContext>({
@@ -14,4 +15,5 @@ export const Context = createContext<TherifyUserContext>({
     isLoading: false,
     errorMessage: undefined,
     isRefetching: false,
+    clearCookies: () => {},
 });

--- a/src/lib/context/therify-user/Provider.tsx
+++ b/src/lib/context/therify-user/Provider.tsx
@@ -38,9 +38,6 @@ export const Provider = ({ children }: { children: ReactNode }) => {
 
     useEffect(() => {
         if (therifyUser?.roles) {
-            const cookies = parseCookies();
-            console.log({ cookies });
-            // Set
             setCookie(
                 null,
                 USER_ROLES_COOKIE_KEY,

--- a/src/lib/context/therify-user/Provider.tsx
+++ b/src/lib/context/therify-user/Provider.tsx
@@ -1,7 +1,10 @@
 import { ReactNode, useEffect } from 'react';
+import { parseCookies, setCookie, destroyCookie } from 'nookies';
 import { useUser } from '@auth0/nextjs-auth0/client';
 import { Context } from './Context';
 import { trpc } from '@/lib/utils/trpc';
+
+const USER_ROLES_COOKIE_KEY = 'userRoles' as const;
 
 export const Provider = ({ children }: { children: ReactNode }) => {
     const { user: auth0User, isLoading: isLoadingAuth0User } = useUser();
@@ -33,6 +36,28 @@ export const Provider = ({ children }: { children: ReactNode }) => {
         if (error) console.error(error);
     }, [queryError, error]);
 
+    useEffect(() => {
+        if (therifyUser?.roles) {
+            const cookies = parseCookies();
+            console.log({ cookies });
+            // Set
+            setCookie(
+                null,
+                USER_ROLES_COOKIE_KEY,
+                therifyUser.roles.join(','),
+                {
+                    maxAge: 30 * 24 * 60 * 60,
+                    path: '/',
+                }
+            );
+        }
+    }, [therifyUser]);
+
+    const clearCookies = () => {
+        destroyCookie(null, USER_ROLES_COOKIE_KEY, {
+            path: '/',
+        });
+    };
     return (
         <Context.Provider
             value={{
@@ -41,6 +66,7 @@ export const Provider = ({ children }: { children: ReactNode }) => {
                 isRefetching,
                 errorMessage,
                 refetch,
+                clearCookies,
             }}
         >
             {children}

--- a/src/lib/sitemap/urlPaths.ts
+++ b/src/lib/sitemap/urlPaths.ts
@@ -14,4 +14,5 @@ export const URL_PATHS = {
     DIRECTORY: DIRECTORY_PATHS,
     CONTENT: CONTENT_PATHS,
     EXTERNAL: EXTERNAL_URLS,
+    404: '/404',
 } as const;

--- a/src/lib/sitemap/urlPaths.ts
+++ b/src/lib/sitemap/urlPaths.ts
@@ -15,4 +15,5 @@ export const URL_PATHS = {
     CONTENT: CONTENT_PATHS,
     EXTERNAL: EXTERNAL_URLS,
     404: '/404',
+    ROOT: '/',
 } as const;

--- a/src/lib/utils/index.ts
+++ b/src/lib/utils/index.ts
@@ -4,3 +4,4 @@ export * from './extract-at-path';
 export * from './map-object';
 export * from './create-mapper';
 export * from './transaction';
+export * from './rbac';

--- a/src/lib/utils/rbac/get-server-side-props-methods/__tests__/requireCoachAuth.spec.ts
+++ b/src/lib/utils/rbac/get-server-side-props-methods/__tests__/requireCoachAuth.spec.ts
@@ -1,8 +1,8 @@
-import { URL_PATHS } from '@/lib/sitemap';
 import { Role } from '@prisma/client';
 import { parseCookies } from 'nookies';
 import { GetServerSidePropsContext } from 'next';
 import { requireCoachAuth } from '../requireCoachAuth';
+import { defaultRedirect } from '../constants';
 
 jest.mock('nookies', () => {
     return { parseCookies: jest.fn() };
@@ -23,16 +23,13 @@ describe('requireCoachAuth', () => {
         expect(result).toEqual('return value');
     });
 
-    it('should return a redirect if the user is not a coach', async () => {
+    it('should return default redirect if the user is not a coach', async () => {
         jest.mocked(parseCookies).mockReturnValueOnce({
             userRoles: Role.member,
         });
         const result = await requireCoachAuth(jest.fn())(mockContext);
         expect(result).toEqual({
-            redirect: {
-                destination: URL_PATHS[404],
-                permanent: false,
-            },
+            redirect: defaultRedirect,
         });
     });
 

--- a/src/lib/utils/rbac/get-server-side-props-methods/__tests__/requireCoachAuth.spec.ts
+++ b/src/lib/utils/rbac/get-server-side-props-methods/__tests__/requireCoachAuth.spec.ts
@@ -1,0 +1,54 @@
+import { URL_PATHS } from '@/lib/sitemap';
+import { Role } from '@prisma/client';
+import { parseCookies } from 'nookies';
+import { GetServerSidePropsContext } from 'next';
+import { requireCoachAuth } from '../requireCoachAuth';
+
+jest.mock('nookies', () => {
+    return { parseCookies: jest.fn() };
+});
+
+describe('requireCoachAuth', () => {
+    const mockContext = {
+        req: { headers: { host: 'localhost' } },
+    } as GetServerSidePropsContext;
+    it('should return the authCallback result if the user is a coach', async () => {
+        jest.mocked(parseCookies).mockImplementationOnce(() => ({
+            userRoles: Role.provider_coach,
+        }));
+        const authCallback = jest.fn();
+        authCallback.mockReturnValue('return value');
+        const result = await requireCoachAuth(authCallback)(mockContext);
+        expect(authCallback).toHaveBeenCalledWith(mockContext);
+        expect(result).toEqual('return value');
+    });
+
+    it('should return a redirect if the user is not a coach', async () => {
+        jest.mocked(parseCookies).mockReturnValueOnce({
+            userRoles: Role.member,
+        });
+        const result = await requireCoachAuth(jest.fn())(mockContext);
+        expect(result).toEqual({
+            redirect: {
+                destination: URL_PATHS[404],
+                permanent: false,
+            },
+        });
+    });
+
+    it('should return a custom redirect', async () => {
+        jest.mocked(parseCookies).mockReturnValueOnce({
+            userRoles: Role.member,
+        });
+        const redirect = {
+            destination: '/custom-redirect',
+            permanent: true,
+        };
+        const result = await requireCoachAuth(jest.fn(), {
+            redirect,
+        })(mockContext);
+        expect(result).toEqual({
+            redirect,
+        });
+    });
+});

--- a/src/lib/utils/rbac/get-server-side-props-methods/__tests__/requireMemberAuth.spec.ts
+++ b/src/lib/utils/rbac/get-server-side-props-methods/__tests__/requireMemberAuth.spec.ts
@@ -1,8 +1,8 @@
-import { URL_PATHS } from '@/lib/sitemap';
 import { Role } from '@prisma/client';
 import { parseCookies } from 'nookies';
 import { GetServerSidePropsContext } from 'next';
 import { requireMemberAuth } from '../requireMemberAuth';
+import { defaultRedirect } from '../constants';
 
 jest.mock('nookies', () => {
     return { parseCookies: jest.fn() };
@@ -23,16 +23,13 @@ describe('requireMemberAuth', () => {
         expect(result).toEqual('return value');
     });
 
-    it('should return a redirect if the user is not a member', async () => {
+    it('should return default redirect if the user is not a member', async () => {
         jest.mocked(parseCookies).mockReturnValueOnce({
             userRoles: Role.provider_coach,
         });
         const result = await requireMemberAuth(jest.fn())(mockContext);
         expect(result).toEqual({
-            redirect: {
-                destination: URL_PATHS[404],
-                permanent: false,
-            },
+            redirect: defaultRedirect,
         });
     });
 

--- a/src/lib/utils/rbac/get-server-side-props-methods/__tests__/requireMemberAuth.spec.ts
+++ b/src/lib/utils/rbac/get-server-side-props-methods/__tests__/requireMemberAuth.spec.ts
@@ -1,0 +1,54 @@
+import { URL_PATHS } from '@/lib/sitemap';
+import { Role } from '@prisma/client';
+import { parseCookies } from 'nookies';
+import { GetServerSidePropsContext } from 'next';
+import { requireMemberAuth } from '../requireMemberAuth';
+
+jest.mock('nookies', () => {
+    return { parseCookies: jest.fn() };
+});
+
+describe('requireMemberAuth', () => {
+    const mockContext = {
+        req: { headers: { host: 'localhost' } },
+    } as GetServerSidePropsContext;
+    it('should return the authCallback result if the user is a member', async () => {
+        jest.mocked(parseCookies).mockImplementationOnce(() => ({
+            userRoles: Role.member,
+        }));
+        const authCallback = jest.fn();
+        authCallback.mockReturnValue('return value');
+        const result = await requireMemberAuth(authCallback)(mockContext);
+        expect(authCallback).toHaveBeenCalledWith(mockContext);
+        expect(result).toEqual('return value');
+    });
+
+    it('should return a redirect if the user is not a member', async () => {
+        jest.mocked(parseCookies).mockReturnValueOnce({
+            userRoles: Role.provider_coach,
+        });
+        const result = await requireMemberAuth(jest.fn())(mockContext);
+        expect(result).toEqual({
+            redirect: {
+                destination: URL_PATHS[404],
+                permanent: false,
+            },
+        });
+    });
+
+    it('should return a custom redirect', async () => {
+        jest.mocked(parseCookies).mockReturnValueOnce({
+            userRoles: Role.provider_coach,
+        });
+        const redirect = {
+            destination: '/custom-redirect',
+            permanent: true,
+        };
+        const result = await requireMemberAuth(jest.fn(), {
+            redirect,
+        })(mockContext);
+        expect(result).toEqual({
+            redirect,
+        });
+    });
+});

--- a/src/lib/utils/rbac/get-server-side-props-methods/__tests__/requireProviderAuth.spec.ts
+++ b/src/lib/utils/rbac/get-server-side-props-methods/__tests__/requireProviderAuth.spec.ts
@@ -1,8 +1,8 @@
-import { URL_PATHS } from '@/lib/sitemap';
 import { Role } from '@prisma/client';
 import { parseCookies } from 'nookies';
 import { GetServerSidePropsContext } from 'next';
 import { requireProviderAuth } from '../requireProviderAuth';
+import { defaultRedirect } from '../constants';
 
 jest.mock('nookies', () => {
     return { parseCookies: jest.fn() };
@@ -41,10 +41,7 @@ describe('requireProviderAuth', () => {
         });
         const result = await requireProviderAuth(jest.fn())(mockContext);
         expect(result).toEqual({
-            redirect: {
-                destination: URL_PATHS[404],
-                permanent: false,
-            },
+            redirect: defaultRedirect,
         });
     });
 

--- a/src/lib/utils/rbac/get-server-side-props-methods/__tests__/requireProviderAuth.spec.ts
+++ b/src/lib/utils/rbac/get-server-side-props-methods/__tests__/requireProviderAuth.spec.ts
@@ -1,0 +1,66 @@
+import { URL_PATHS } from '@/lib/sitemap';
+import { Role } from '@prisma/client';
+import { parseCookies } from 'nookies';
+import { GetServerSidePropsContext } from 'next';
+import { requireProviderAuth } from '../requireProviderAuth';
+
+jest.mock('nookies', () => {
+    return { parseCookies: jest.fn() };
+});
+
+describe('requireProviderAuth', () => {
+    const mockContext = {
+        req: { headers: { host: 'localhost' } },
+    } as GetServerSidePropsContext;
+
+    it('should return the authCallback result if the user is a therapist', async () => {
+        jest.mocked(parseCookies).mockImplementationOnce(() => ({
+            userRoles: Role.provider_therapist,
+        }));
+        const authCallback = jest.fn();
+        authCallback.mockReturnValue('return value');
+        const result = await requireProviderAuth(authCallback)(mockContext);
+        expect(authCallback).toHaveBeenCalledWith(mockContext);
+        expect(result).toEqual('return value');
+    });
+
+    it('should return the authCallback result if the user is a coach', async () => {
+        jest.mocked(parseCookies).mockImplementationOnce(() => ({
+            userRoles: Role.provider_coach,
+        }));
+        const authCallback = jest.fn();
+        authCallback.mockReturnValue('return value');
+        const result = await requireProviderAuth(authCallback)(mockContext);
+        expect(authCallback).toHaveBeenCalledWith(mockContext);
+        expect(result).toEqual('return value');
+    });
+
+    it('should return a redirect if the user is not a provider', async () => {
+        jest.mocked(parseCookies).mockReturnValueOnce({
+            userRoles: Role.member,
+        });
+        const result = await requireProviderAuth(jest.fn())(mockContext);
+        expect(result).toEqual({
+            redirect: {
+                destination: URL_PATHS[404],
+                permanent: false,
+            },
+        });
+    });
+
+    it('should return a custom redirect', async () => {
+        jest.mocked(parseCookies).mockReturnValueOnce({
+            userRoles: Role.member,
+        });
+        const redirect = {
+            destination: '/custom-redirect',
+            permanent: true,
+        };
+        const result = await requireProviderAuth(jest.fn(), {
+            redirect,
+        })(mockContext);
+        expect(result).toEqual({
+            redirect,
+        });
+    });
+});

--- a/src/lib/utils/rbac/get-server-side-props-methods/__tests__/requireTherapistAuth.spec.ts
+++ b/src/lib/utils/rbac/get-server-side-props-methods/__tests__/requireTherapistAuth.spec.ts
@@ -1,8 +1,8 @@
-import { URL_PATHS } from '@/lib/sitemap';
 import { Role } from '@prisma/client';
 import { parseCookies } from 'nookies';
 import { GetServerSidePropsContext } from 'next';
 import { requireTherapistAuth } from '../requireTherapistAuth';
+import { defaultRedirect } from '../constants';
 
 jest.mock('nookies', () => {
     return { parseCookies: jest.fn() };
@@ -23,16 +23,13 @@ describe('requireTherapistAuth', () => {
         expect(result).toEqual('return value');
     });
 
-    it('should return a redirect if the user is not a therapist', async () => {
+    it('should return default redirect if the user is not a therapist', async () => {
         jest.mocked(parseCookies).mockReturnValueOnce({
             userRoles: Role.member,
         });
         const result = await requireTherapistAuth(jest.fn())(mockContext);
         expect(result).toEqual({
-            redirect: {
-                destination: URL_PATHS[404],
-                permanent: false,
-            },
+            redirect: defaultRedirect,
         });
     });
 

--- a/src/lib/utils/rbac/get-server-side-props-methods/__tests__/requireTherapistAuth.spec.ts
+++ b/src/lib/utils/rbac/get-server-side-props-methods/__tests__/requireTherapistAuth.spec.ts
@@ -1,0 +1,54 @@
+import { URL_PATHS } from '@/lib/sitemap';
+import { Role } from '@prisma/client';
+import { parseCookies } from 'nookies';
+import { GetServerSidePropsContext } from 'next';
+import { requireTherapistAuth } from '../requireTherapistAuth';
+
+jest.mock('nookies', () => {
+    return { parseCookies: jest.fn() };
+});
+
+describe('requireTherapistAuth', () => {
+    const mockContext = {
+        req: { headers: { host: 'localhost' } },
+    } as GetServerSidePropsContext;
+    it('should return the authCallback result if the user is a therapist', async () => {
+        jest.mocked(parseCookies).mockImplementationOnce(() => ({
+            userRoles: Role.provider_therapist,
+        }));
+        const authCallback = jest.fn();
+        authCallback.mockReturnValue('return value');
+        const result = await requireTherapistAuth(authCallback)(mockContext);
+        expect(authCallback).toHaveBeenCalledWith(mockContext);
+        expect(result).toEqual('return value');
+    });
+
+    it('should return a redirect if the user is not a therapist', async () => {
+        jest.mocked(parseCookies).mockReturnValueOnce({
+            userRoles: Role.member,
+        });
+        const result = await requireTherapistAuth(jest.fn())(mockContext);
+        expect(result).toEqual({
+            redirect: {
+                destination: URL_PATHS[404],
+                permanent: false,
+            },
+        });
+    });
+
+    it('should return a custom redirect', async () => {
+        jest.mocked(parseCookies).mockReturnValueOnce({
+            userRoles: Role.member,
+        });
+        const redirect = {
+            destination: '/custom-redirect',
+            permanent: true,
+        };
+        const result = await requireTherapistAuth(jest.fn(), {
+            redirect,
+        })(mockContext);
+        expect(result).toEqual({
+            redirect,
+        });
+    });
+});

--- a/src/lib/utils/rbac/get-server-side-props-methods/constants.ts
+++ b/src/lib/utils/rbac/get-server-side-props-methods/constants.ts
@@ -1,0 +1,7 @@
+import { URL_PATHS } from '@/lib/sitemap';
+import { Redirect } from 'next';
+
+export const defaultRedirect: Redirect = {
+    destination: URL_PATHS[404],
+    permanent: false,
+};

--- a/src/lib/utils/rbac/get-server-side-props-methods/index.ts
+++ b/src/lib/utils/rbac/get-server-side-props-methods/index.ts
@@ -1,0 +1,4 @@
+export { requireCoachAuth } from './requireCoachAuth';
+export { requireTherapistAuth } from './requireTherapistAuth';
+export { requireProviderAuth } from './requireProviderAuth';
+export { requireMemberAuth } from './requireMemberAuth';

--- a/src/lib/utils/rbac/get-server-side-props-methods/requireCoachAuth.ts
+++ b/src/lib/utils/rbac/get-server-side-props-methods/requireCoachAuth.ts
@@ -1,0 +1,23 @@
+import { URL_PATHS } from '@/lib/sitemap';
+import { GetServerSideProps } from 'next';
+import { parseCookies } from 'nookies';
+import { RBACOptions } from '../rbacOptions';
+import { isCoach } from '../role-validators';
+
+export const requireCoachAuth =
+    (
+        authCallback: GetServerSideProps,
+        options?: RBACOptions
+    ): GetServerSideProps =>
+    async (context) => {
+        const { userRoles } = parseCookies(context);
+        if (!isCoach(userRoles)) {
+            return {
+                redirect: options?.redirect ?? {
+                    destination: URL_PATHS[404],
+                    permanent: false,
+                },
+            };
+        }
+        return authCallback(context);
+    };

--- a/src/lib/utils/rbac/get-server-side-props-methods/requireCoachAuth.ts
+++ b/src/lib/utils/rbac/get-server-side-props-methods/requireCoachAuth.ts
@@ -1,8 +1,8 @@
-import { URL_PATHS } from '@/lib/sitemap';
 import { GetServerSideProps } from 'next';
 import { parseCookies } from 'nookies';
 import { RBACOptions } from '../rbacOptions';
 import { isCoach } from '../role-validators';
+import { defaultRedirect } from './constants';
 
 export const requireCoachAuth =
     (
@@ -13,10 +13,7 @@ export const requireCoachAuth =
         const { userRoles } = parseCookies(context);
         if (!isCoach(userRoles)) {
             return {
-                redirect: options?.redirect ?? {
-                    destination: URL_PATHS[404],
-                    permanent: false,
-                },
+                redirect: options?.redirect ?? defaultRedirect,
             };
         }
         return authCallback(context);

--- a/src/lib/utils/rbac/get-server-side-props-methods/requireMemberAuth.ts
+++ b/src/lib/utils/rbac/get-server-side-props-methods/requireMemberAuth.ts
@@ -1,8 +1,8 @@
-import { URL_PATHS } from '@/lib/sitemap';
 import { GetServerSideProps } from 'next';
 import { parseCookies } from 'nookies';
 import { RBACOptions } from '../rbacOptions';
 import { isMember } from '../role-validators';
+import { defaultRedirect } from './constants';
 
 export const requireMemberAuth =
     (
@@ -13,10 +13,7 @@ export const requireMemberAuth =
         const { userRoles } = parseCookies(context);
         if (!isMember(userRoles)) {
             return {
-                redirect: options?.redirect ?? {
-                    destination: URL_PATHS[404],
-                    permanent: false,
-                },
+                redirect: options?.redirect ?? defaultRedirect,
             };
         }
         return authCallback(context);

--- a/src/lib/utils/rbac/get-server-side-props-methods/requireMemberAuth.ts
+++ b/src/lib/utils/rbac/get-server-side-props-methods/requireMemberAuth.ts
@@ -1,0 +1,23 @@
+import { URL_PATHS } from '@/lib/sitemap';
+import { GetServerSideProps } from 'next';
+import { parseCookies } from 'nookies';
+import { RBACOptions } from '../rbacOptions';
+import { isMember } from '../role-validators';
+
+export const requireMemberAuth =
+    (
+        authCallback: GetServerSideProps,
+        options?: RBACOptions
+    ): GetServerSideProps =>
+    async (context) => {
+        const { userRoles } = parseCookies(context);
+        if (!isMember(userRoles)) {
+            return {
+                redirect: options?.redirect ?? {
+                    destination: URL_PATHS[404],
+                    permanent: false,
+                },
+            };
+        }
+        return authCallback(context);
+    };

--- a/src/lib/utils/rbac/get-server-side-props-methods/requireProviderAuth.ts
+++ b/src/lib/utils/rbac/get-server-side-props-methods/requireProviderAuth.ts
@@ -1,0 +1,24 @@
+import { URL_PATHS } from '@/lib/sitemap';
+import { withPageAuthRequired } from '@auth0/nextjs-auth0';
+import { GetServerSideProps } from 'next';
+import { parseCookies } from 'nookies';
+import { RBACOptions } from '../rbacOptions';
+import { isProvider } from '../role-validators';
+
+export const requireProviderAuth =
+    (
+        authCallback: GetServerSideProps,
+        options?: RBACOptions
+    ): GetServerSideProps =>
+    async (context) => {
+        const { userRoles } = parseCookies(context);
+        if (!isProvider(userRoles)) {
+            return {
+                redirect: options?.redirect ?? {
+                    destination: URL_PATHS[404],
+                    permanent: false,
+                },
+            };
+        }
+        return authCallback(context);
+    };

--- a/src/lib/utils/rbac/get-server-side-props-methods/requireProviderAuth.ts
+++ b/src/lib/utils/rbac/get-server-side-props-methods/requireProviderAuth.ts
@@ -1,9 +1,8 @@
-import { URL_PATHS } from '@/lib/sitemap';
-import { withPageAuthRequired } from '@auth0/nextjs-auth0';
 import { GetServerSideProps } from 'next';
 import { parseCookies } from 'nookies';
 import { RBACOptions } from '../rbacOptions';
 import { isProvider } from '../role-validators';
+import { defaultRedirect } from './constants';
 
 export const requireProviderAuth =
     (
@@ -14,10 +13,7 @@ export const requireProviderAuth =
         const { userRoles } = parseCookies(context);
         if (!isProvider(userRoles)) {
             return {
-                redirect: options?.redirect ?? {
-                    destination: URL_PATHS[404],
-                    permanent: false,
-                },
+                redirect: options?.redirect ?? defaultRedirect,
             };
         }
         return authCallback(context);

--- a/src/lib/utils/rbac/get-server-side-props-methods/requireTherapistAuth.ts
+++ b/src/lib/utils/rbac/get-server-side-props-methods/requireTherapistAuth.ts
@@ -1,0 +1,23 @@
+import { URL_PATHS } from '@/lib/sitemap';
+import { GetServerSideProps } from 'next';
+import { parseCookies } from 'nookies';
+import { RBACOptions } from '../rbacOptions';
+import { isTherapist } from '../role-validators';
+
+export const requireTherapistAuth =
+    (
+        authCallback: GetServerSideProps,
+        options?: RBACOptions
+    ): GetServerSideProps =>
+    async (context) => {
+        const { userRoles } = parseCookies(context);
+        if (!isTherapist(userRoles)) {
+            return {
+                redirect: options?.redirect ?? {
+                    destination: URL_PATHS[404],
+                    permanent: false,
+                },
+            };
+        }
+        return authCallback(context);
+    };

--- a/src/lib/utils/rbac/get-server-side-props-methods/requireTherapistAuth.ts
+++ b/src/lib/utils/rbac/get-server-side-props-methods/requireTherapistAuth.ts
@@ -1,8 +1,8 @@
-import { URL_PATHS } from '@/lib/sitemap';
 import { GetServerSideProps } from 'next';
 import { parseCookies } from 'nookies';
 import { RBACOptions } from '../rbacOptions';
 import { isTherapist } from '../role-validators';
+import { defaultRedirect } from './constants';
 
 export const requireTherapistAuth =
     (
@@ -13,10 +13,7 @@ export const requireTherapistAuth =
         const { userRoles } = parseCookies(context);
         if (!isTherapist(userRoles)) {
             return {
-                redirect: options?.redirect ?? {
-                    destination: URL_PATHS[404],
-                    permanent: false,
-                },
+                redirect: options?.redirect ?? defaultRedirect,
             };
         }
         return authCallback(context);

--- a/src/lib/utils/rbac/index.ts
+++ b/src/lib/utils/rbac/index.ts
@@ -1,0 +1,1 @@
+export * as RBAC from './get-server-side-props-methods';

--- a/src/lib/utils/rbac/rbacOptions.ts
+++ b/src/lib/utils/rbac/rbacOptions.ts
@@ -1,0 +1,5 @@
+import { Redirect } from 'next';
+
+export interface RBACOptions {
+    redirect?: Redirect;
+}

--- a/src/lib/utils/rbac/role-validators/__tests__/hasRole.spec.ts
+++ b/src/lib/utils/rbac/role-validators/__tests__/hasRole.spec.ts
@@ -1,0 +1,31 @@
+import { Role } from '@prisma/client';
+import { hasRole } from '../hasRole';
+
+describe('hasRole', () => {
+    it('should return true if user has role', () => {
+        expect(hasRole(Role.member, Role.member)).toBe(true);
+    });
+
+    it('should return false if user does not have role', () => {
+        expect(hasRole(Role.member, Role.provider_coach)).toBe(false);
+    });
+
+    it('should return true if user has multiple roles and one of them is the role', () => {
+        expect(
+            hasRole(Role.member, [Role.member, Role.provider_coach].join(','))
+        ).toBe(true);
+    });
+
+    it('should return false if user has multiple roles and none of them are the role', () => {
+        expect(
+            hasRole(
+                Role.member,
+                [Role.provider_coach, Role.provider_therapist].join(',')
+            )
+        ).toBe(false);
+    });
+
+    it('should handle undefined', () => {
+        expect(hasRole(Role.member, undefined)).toBe(false);
+    });
+});

--- a/src/lib/utils/rbac/role-validators/__tests__/isCoach.spec.ts
+++ b/src/lib/utils/rbac/role-validators/__tests__/isCoach.spec.ts
@@ -1,0 +1,16 @@
+import { Role } from '@prisma/client';
+import { isCoach } from '../isCoach';
+
+describe('isCoach', () => {
+    it('should return true if the role is a coach', () => {
+        expect(isCoach(Role.provider_coach)).toBe(true);
+    });
+
+    it('should return false if the role is not a coach', () => {
+        expect(isCoach(Role.provider_therapist)).toBe(false);
+    });
+
+    it('should return false if the role is undefined', () => {
+        expect(isCoach(undefined)).toBe(false);
+    });
+});

--- a/src/lib/utils/rbac/role-validators/__tests__/isMember.spec.ts
+++ b/src/lib/utils/rbac/role-validators/__tests__/isMember.spec.ts
@@ -1,0 +1,16 @@
+import { Role } from '@prisma/client';
+import { isMember } from '../isMember';
+
+describe('isMember', () => {
+    it('should return true if the role is a member', () => {
+        expect(isMember(Role.member)).toBe(true);
+    });
+
+    it('should return false if the role is not a member', () => {
+        expect(isMember(Role.provider_therapist)).toBe(false);
+    });
+
+    it('should return false if the role is undefined', () => {
+        expect(isMember(undefined)).toBe(false);
+    });
+});

--- a/src/lib/utils/rbac/role-validators/__tests__/isProvider.spec.ts
+++ b/src/lib/utils/rbac/role-validators/__tests__/isProvider.spec.ts
@@ -1,0 +1,20 @@
+import { Role } from '@prisma/client';
+import { isProvider } from '../isProvider';
+
+describe('isProvider', () => {
+    it('should return true if the role is a therapist', () => {
+        expect(isProvider(Role.provider_therapist)).toBe(true);
+    });
+
+    it('should return true if the role a coach', () => {
+        expect(isProvider(Role.provider_coach)).toBe(true);
+    });
+
+    it('should return false if the role is not a provider', () => {
+        expect(isProvider(Role.member)).toBe(false);
+    });
+
+    it('should return false if the role is undefined', () => {
+        expect(isProvider(undefined)).toBe(false);
+    });
+});

--- a/src/lib/utils/rbac/role-validators/__tests__/isTherapist.spec.ts
+++ b/src/lib/utils/rbac/role-validators/__tests__/isTherapist.spec.ts
@@ -1,0 +1,16 @@
+import { Role } from '@prisma/client';
+import { isTherapist } from '../isTherapist';
+
+describe('isTherapist', () => {
+    it('should return true if the role is a therapist', () => {
+        expect(isTherapist(Role.provider_therapist)).toBe(true);
+    });
+
+    it('should return false if the role is not a therapist', () => {
+        expect(isTherapist(Role.member)).toBe(false);
+    });
+
+    it('should return false if the role is undefined', () => {
+        expect(isTherapist(undefined)).toBe(false);
+    });
+});

--- a/src/lib/utils/rbac/role-validators/hasRole.ts
+++ b/src/lib/utils/rbac/role-validators/hasRole.ts
@@ -1,0 +1,6 @@
+import { Role } from '@prisma/client';
+
+export const hasRole = (role: Role, userRoleString: string) => {
+    const roles = userRoleString.split(',');
+    return roles.includes(role);
+};

--- a/src/lib/utils/rbac/role-validators/hasRole.ts
+++ b/src/lib/utils/rbac/role-validators/hasRole.ts
@@ -1,6 +1,6 @@
 import { Role } from '@prisma/client';
 
-export const hasRole = (role: Role, userRoleString: string) => {
-    const roles = userRoleString.split(',');
+export const hasRole = (role: Role, userRoleString: string | undefined) => {
+    const roles = (userRoleString ?? '').split(',');
     return roles.includes(role);
 };

--- a/src/lib/utils/rbac/role-validators/index.ts
+++ b/src/lib/utils/rbac/role-validators/index.ts
@@ -1,0 +1,4 @@
+export { isCoach } from './isCoach';
+export { isMember } from './isMember';
+export { isProvider } from './isProvider';
+export { isTherapist } from './isTherapist';

--- a/src/lib/utils/rbac/role-validators/isCoach.ts
+++ b/src/lib/utils/rbac/role-validators/isCoach.ts
@@ -1,0 +1,6 @@
+import { Role } from '@prisma/client';
+import { hasRole } from './hasRole';
+
+export const isCoach = (roles: string) => {
+    return hasRole(Role.provider_coach, roles);
+};

--- a/src/lib/utils/rbac/role-validators/isCoach.ts
+++ b/src/lib/utils/rbac/role-validators/isCoach.ts
@@ -1,6 +1,6 @@
 import { Role } from '@prisma/client';
 import { hasRole } from './hasRole';
 
-export const isCoach = (roles: string) => {
+export const isCoach = (roles: string | undefined) => {
     return hasRole(Role.provider_coach, roles);
 };

--- a/src/lib/utils/rbac/role-validators/isMember.ts
+++ b/src/lib/utils/rbac/role-validators/isMember.ts
@@ -1,0 +1,6 @@
+import { Role } from '@prisma/client';
+import { hasRole } from './hasRole';
+
+export const isMember = (roles: string) => {
+    return hasRole(Role.member, roles);
+};

--- a/src/lib/utils/rbac/role-validators/isMember.ts
+++ b/src/lib/utils/rbac/role-validators/isMember.ts
@@ -1,6 +1,6 @@
 import { Role } from '@prisma/client';
 import { hasRole } from './hasRole';
 
-export const isMember = (roles: string) => {
+export const isMember = (roles: string | undefined) => {
     return hasRole(Role.member, roles);
 };

--- a/src/lib/utils/rbac/role-validators/isProvider.ts
+++ b/src/lib/utils/rbac/role-validators/isProvider.ts
@@ -1,0 +1,7 @@
+import { Role } from '@prisma/client';
+import { isCoach } from './isCoach';
+import { isTherapist } from './isTherapist';
+
+export const isProvider = (roles: string) => {
+    return isCoach(roles) || isTherapist(roles);
+};

--- a/src/lib/utils/rbac/role-validators/isProvider.ts
+++ b/src/lib/utils/rbac/role-validators/isProvider.ts
@@ -2,6 +2,6 @@ import { Role } from '@prisma/client';
 import { isCoach } from './isCoach';
 import { isTherapist } from './isTherapist';
 
-export const isProvider = (roles: string) => {
+export const isProvider = (roles: string | undefined) => {
     return isCoach(roles) || isTherapist(roles);
 };

--- a/src/lib/utils/rbac/role-validators/isTherapist.ts
+++ b/src/lib/utils/rbac/role-validators/isTherapist.ts
@@ -1,0 +1,6 @@
+import { Role } from '@prisma/client';
+import { hasRole } from './hasRole';
+
+export const isTherapist = (roles: string) => {
+    return hasRole(Role.provider_therapist, roles);
+};

--- a/src/lib/utils/rbac/role-validators/isTherapist.ts
+++ b/src/lib/utils/rbac/role-validators/isTherapist.ts
@@ -1,6 +1,6 @@
 import { Role } from '@prisma/client';
 import { hasRole } from './hasRole';
 
-export const isTherapist = (roles: string) => {
+export const isTherapist = (roles: string | undefined) => {
     return hasRole(Role.provider_therapist, roles);
 };

--- a/src/pages/404.tsx
+++ b/src/pages/404.tsx
@@ -8,7 +8,7 @@ import {
 import { URL_PATHS } from '@/lib/sitemap';
 import { useRouter } from 'next/router';
 
-export default function Page() {
+export default function NotFoundPage() {
     const router = useRouter();
     return (
         <CenteredContainer fillSpace padding={6} textAlign="center">

--- a/src/pages/404.tsx
+++ b/src/pages/404.tsx
@@ -1,0 +1,23 @@
+import {
+    CenteredContainer,
+    H1,
+    Paragraph,
+    Button,
+    TherifyIcon,
+} from '@/components/ui';
+import { URL_PATHS } from '@/lib/sitemap';
+import { useRouter } from 'next/router';
+
+export default function Page() {
+    const router = useRouter();
+    return (
+        <CenteredContainer fillSpace padding={6} textAlign="center">
+            <TherifyIcon />
+            <H1 marginTop={4}>404 - Page Not Found</H1>
+            <Paragraph>
+                Oh no! Looks like this page doesn&apos;t exist.
+            </Paragraph>
+            <Button onClick={() => router.push(URL_PATHS.ROOT)}>Go Home</Button>
+        </CenteredContainer>
+    );
+}

--- a/src/pages/members/home.tsx
+++ b/src/pages/members/home.tsx
@@ -1,4 +1,5 @@
 import { useRouter } from 'next/router';
+import { withPageAuthRequired } from '@auth0/nextjs-auth0';
 import { H1 } from '@/components/ui';
 import { TopNavigationPage } from '@/components/features/pages';
 import {
@@ -8,6 +9,11 @@ import {
     URL_PATHS,
 } from '@/lib/sitemap';
 import { useTherifyUser } from '@/lib/hooks';
+import { RBAC } from '@/lib/utils';
+
+export const getServerSideProps = RBAC.requireMemberAuth(
+    withPageAuthRequired()
+);
 
 export default function MemberHomePage() {
     const { user, isLoading } = useTherifyUser();

--- a/src/pages/providers/coach/dashboard.tsx
+++ b/src/pages/providers/coach/dashboard.tsx
@@ -1,4 +1,5 @@
 import { useRouter } from 'next/router';
+import { withPageAuthRequired } from '@auth0/nextjs-auth0';
 import { H1 } from '@/components/ui';
 import {
     COACH_MAIN_MENU,
@@ -8,6 +9,9 @@ import {
 } from '@/lib/sitemap';
 import { SideNavigationPage } from '@/components/features/pages';
 import { useTherifyUser } from '@/lib/hooks';
+import { RBAC } from '@/lib/utils';
+
+export const getServerSideProps = RBAC.requireCoachAuth(withPageAuthRequired());
 
 export default function TherapistDashboardPage() {
     const { user, isLoading } = useTherifyUser();

--- a/src/pages/providers/onboarding/billing/index.tsx
+++ b/src/pages/providers/onboarding/billing/index.tsx
@@ -21,6 +21,7 @@ import { getProductByEnvironment, PRODUCTS } from '@/lib/types';
 import { TRPCClientError } from '@trpc/client';
 import Link from 'next/link';
 import { URL_PATHS } from '@/lib/sitemap';
+import { RBAC } from '@/lib/utils';
 
 const REGISTRATION_STEPS = ['Registration', 'Payment', 'Onboarding'] as const;
 
@@ -28,7 +29,9 @@ const PRODUCT = getProductByEnvironment(
     PRODUCTS.GROUP_PRACTICE_PLAN,
     process.env.NODE_ENV
 );
-export const getServerSideProps = withPageAuthRequired();
+export const getServerSideProps = RBAC.requireProviderAuth(
+    withPageAuthRequired()
+);
 
 export default function PracticeOnboardingPage() {
     const theme = useTheme();

--- a/src/pages/providers/onboarding/billing/success.tsx
+++ b/src/pages/providers/onboarding/billing/success.tsx
@@ -17,8 +17,11 @@ import { PlanStatus, Role } from '@prisma/client';
 import { useRouter } from 'next/router';
 import { URL_PATHS } from '@/lib/sitemap';
 import { useTherifyUser } from '@/lib/hooks';
+import { RBAC } from '@/lib/utils';
 
-export const getServerSideProps = withPageAuthRequired();
+export const getServerSideProps = RBAC.requireProviderAuth(
+    withPageAuthRequired()
+);
 
 const REGISTRATION_STEPS = ['Registration', 'Payment', 'Onboarding'] as const;
 const SIXTY_SECONDS = 1000 * 60;

--- a/src/pages/providers/therapist/dashboard.tsx
+++ b/src/pages/providers/therapist/dashboard.tsx
@@ -1,4 +1,5 @@
 import { useRouter } from 'next/router';
+import { withPageAuthRequired } from '@auth0/nextjs-auth0';
 import { H1 } from '@/components/ui';
 import { SideNavigationPage } from '@/components/features/pages';
 import {
@@ -8,6 +9,12 @@ import {
     URL_PATHS,
 } from '@/lib/sitemap';
 import { useTherifyUser } from '@/lib/hooks';
+import { GetServerSideProps } from 'next';
+import { RBAC } from '@/lib/utils';
+
+export const getServerSideProps: GetServerSideProps = RBAC.requireTherapistAuth(
+    withPageAuthRequired()
+);
 
 export default function TherapistDashboardPage() {
     const { user, isLoading } = useTherifyUser();

--- a/src/pages/providers/therapist/dashboard.tsx
+++ b/src/pages/providers/therapist/dashboard.tsx
@@ -9,10 +9,9 @@ import {
     URL_PATHS,
 } from '@/lib/sitemap';
 import { useTherifyUser } from '@/lib/hooks';
-import { GetServerSideProps } from 'next';
 import { RBAC } from '@/lib/utils';
 
-export const getServerSideProps: GetServerSideProps = RBAC.requireTherapistAuth(
+export const getServerSideProps = RBAC.requireTherapistAuth(
     withPageAuthRequired()
 );
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -5706,6 +5706,11 @@ cookie@0.5.0, cookie@^0.5.0:
   resolved "https://registry.yarnpkg.com/cookie/-/cookie-0.5.0.tgz#d1f5d71adec6558c58f389987c366aa47e994f8b"
   integrity sha512-YZ3GUyn/o8gfKJlnlX7g7xq4gyO6OSuhGPKaaGssGB2qgDUS0gPgtTvoyZLTt9Ab6dC4hfc9dV5arkvc/OCmrw==
 
+cookie@^0.4.1:
+  version "0.4.2"
+  resolved "https://registry.yarnpkg.com/cookie/-/cookie-0.4.2.tgz#0e41f24de5ecf317947c82fc789e06a884824432"
+  integrity sha512-aSWTXFzaKWkvHO1Ny/s+ePFpvKsPnjc551iI41v3ny/ow6tBG5Vd+FuqGNhh1LxOmVzOlGUriIlOaokOvhaStA==
+
 copy-descriptor@^0.1.0:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/copy-descriptor/-/copy-descriptor-0.1.1.tgz#676f6eb3c39997c2ee1ac3a924fd6124748f578d"
@@ -9809,6 +9814,14 @@ node-releases@^2.0.6:
   resolved "https://registry.yarnpkg.com/node-releases/-/node-releases-2.0.8.tgz#0f349cdc8fcfa39a92ac0be9bc48b7706292b9ae"
   integrity sha512-dFSmB8fFHEH/s81Xi+Y/15DQY6VHW81nXRj86EMSL3lmuTmK1e+aT4wrFCkTbm+gSwkw4KpX+rT/pMM2c1mF+A==
 
+nookies@^2.5.2:
+  version "2.5.2"
+  resolved "https://registry.yarnpkg.com/nookies/-/nookies-2.5.2.tgz#cc55547efa982d013a21475bd0db0c02c1b35b27"
+  integrity sha512-x0TRSaosAEonNKyCrShoUaJ5rrT5KHRNZ5DwPCuizjgrnkpE5DRf3VL7AyyQin4htict92X1EQ7ejDbaHDVdYA==
+  dependencies:
+    cookie "^0.4.1"
+    set-cookie-parser "^2.4.6"
+
 normalize-package-data@^2.5.0:
   version "2.5.0"
   resolved "https://registry.yarnpkg.com/normalize-package-data/-/normalize-package-data-2.5.0.tgz#e66db1838b200c1dfc233225d12cb36520e234a8"
@@ -11332,6 +11345,11 @@ set-blocking@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/set-blocking/-/set-blocking-2.0.0.tgz#045f9782d011ae9a6803ddd382b24392b3d890f7"
   integrity sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw==
+
+set-cookie-parser@^2.4.6:
+  version "2.5.1"
+  resolved "https://registry.yarnpkg.com/set-cookie-parser/-/set-cookie-parser-2.5.1.tgz#ddd3e9a566b0e8e0862aca974a6ac0e01349430b"
+  integrity sha512-1jeBGaKNGdEq4FgIrORu/N570dwoPYio8lSoYLWmX7sQ//0JY08Xh9o5pBcgmHQ/MbsYp/aZnOe1s1lIsbLprQ==
 
 set-value@^2.0.0, set-value@^2.0.1:
   version "2.0.1"


### PR DESCRIPTION
# Description
Adds `nookies` dependancy and role based protection to pages
Adds: 
- Cookie creation in Therify User context
- Cookie-reading auth methods for `getServerSideProps` in `RBAC` util library

# Closes issue(s)
[Trello card: RBAC middleware](https://trello.com/c/AMhExBNl)
# How to test / repro
Log in as a user with a role and visit a page that requires different role. Get redirected to `404`

# Screenshots
![image](https://user-images.githubusercontent.com/25045075/215934442-8749489b-423d-4709-8484-e567e81c1fd4.png)
![image](https://user-images.githubusercontent.com/25045075/215936370-9532a4b5-fbcc-466b-871d-5fc9e895e900.png)
![image](https://user-images.githubusercontent.com/25045075/215936423-9e642c49-4eb7-489c-9164-c7ccbe78c04f.png)
![image](https://user-images.githubusercontent.com/25045075/215936457-1418b517-def0-4746-b754-d49a9fdee092.png)

# Changes include

-   [ ] Bugfix (non-breaking change that solves an issue)
-   [x] New feature (non-breaking change that adds functionality)
-   [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Checklist

-   [x] I have tested this code
-   [ ] I have updated the Readme

# Other comments
I chose to go with the get serverside props solution because writing conditional `if` logic in a middleware file felt less than ideal. This was especially true on the member side where certain member routes may require auth while others are public. The logic required to determine access for a page seemed more scalable IMO when handled at the page level. I felt that the middleware function could grow to become somewhat convoluted over time. [Here](https://nextjs.org/docs/messages/nested-middleware) is a response from Nest I referenced about removing nested middleware

