### PR TITLE
feat: add practice admin check

### DIFF
--- a/src/lib/features/users/get-user-details-by-auth0-id/output.ts
+++ b/src/lib/features/users/get-user-details-by-auth0-id/output.ts
@@ -14,6 +14,7 @@ export const schema = z.object({
             createdAt: UserSchema.shape.createdAt,
             roles: UserSchema.shape.roles,
             accountId: UserSchema.shape.accountId,
+            isPracticeAdmin: z.boolean(),
             plan: z
                 .object({
                     status: PlanSchema.shape.status,

--- a/src/lib/services/accounts/service/get-user-details-by-auth0-id/getUserDetailsByAuth0Id.spec.ts
+++ b/src/lib/services/accounts/service/get-user-details-by-auth0-id/getUserDetailsByAuth0Id.spec.ts
@@ -11,6 +11,7 @@ const mockUserResult = {
     givenName: 'Test',
     surname: 'Jackson',
     createdAt: new Date('2021-03-01'),
+    isPracticeAdmin: true,
     plans: [
         {
             status: PlanStatus.active,
@@ -43,6 +44,7 @@ describe('GetUserDetailsByAuth0Id', function () {
                     renews: mockUserResult.plans[0].renews,
                     seats: mockUserResult.plans[0].seats,
                 },
+                isPracticeAdmin: true,
                 userId: mockUserResult.id,
                 emailAddress: mockUserResult.emailAddress,
                 roles: mockUserResult.roles,
@@ -58,6 +60,7 @@ describe('GetUserDetailsByAuth0Id', function () {
     it('returns null plan if no plans exist', async function () {
         prismaMock.user.findUniqueOrThrow.mockResolvedValue({
             ...mockUserResult,
+            isPracticeAdmin: false,
             plans: [],
         } as unknown as User);
         const getUserDetailsByAuth0Id = GetUserDetailsByAuth0Id.factory({
@@ -78,6 +81,7 @@ describe('GetUserDetailsByAuth0Id', function () {
                 givenName: mockUserResult.givenName,
                 surname: mockUserResult.surname,
                 createdAt: mockUserResult.createdAt,
+                isPracticeAdmin: false,
                 auth0Id,
             },
         });

--- a/src/lib/services/accounts/service/get-user-details-by-auth0-id/getUserDetailsByAuth0Id.spec.ts
+++ b/src/lib/services/accounts/service/get-user-details-by-auth0-id/getUserDetailsByAuth0Id.spec.ts
@@ -19,6 +19,7 @@ const mockUserResult = {
             startDate: new Date('2021-03-01'),
             endDate: new Date('2021-04-01'),
             seats: 1,
+            billingUserId: 'test-user-id',
         } as Plan,
     ],
 } as unknown as User & { plans: Plan[] };
@@ -60,7 +61,6 @@ describe('GetUserDetailsByAuth0Id', function () {
     it('returns null plan if no plans exist', async function () {
         prismaMock.user.findUniqueOrThrow.mockResolvedValue({
             ...mockUserResult,
-            isPracticeAdmin: false,
             plans: [],
         } as unknown as User);
         const getUserDetailsByAuth0Id = GetUserDetailsByAuth0Id.factory({

--- a/src/lib/services/accounts/service/get-user-details-by-auth0-id/getUserDetailsByAuth0Id.ts
+++ b/src/lib/services/accounts/service/get-user-details-by-auth0-id/getUserDetailsByAuth0Id.ts
@@ -48,7 +48,15 @@ export const factory =
                 userId,
                 auth0Id,
                 isPracticeAdmin: userId === newestPlan?.billingUserId,
-                plan: newestPlan ?? null,
+                plan: newestPlan
+                    ? {
+                          seats: newestPlan.seats,
+                          status: newestPlan.status,
+                          startDate: newestPlan.startDate,
+                          endDate: newestPlan.endDate,
+                          renews: newestPlan.renews,
+                      }
+                    : null,
             },
         };
     };

--- a/src/lib/services/accounts/service/get-user-details-by-auth0-id/getUserDetailsByAuth0Id.ts
+++ b/src/lib/services/accounts/service/get-user-details-by-auth0-id/getUserDetailsByAuth0Id.ts
@@ -30,6 +30,7 @@ export const factory =
                     },
                     take: 1,
                     select: {
+                        billingUserId: true,
                         seats: true,
                         status: true,
                         startDate: true,
@@ -46,6 +47,7 @@ export const factory =
                 ...user,
                 userId,
                 auth0Id,
+                isPracticeAdmin: userId === newestPlan?.billingUserId,
                 plan: newestPlan ?? null,
             },
         };

--- a/src/lib/sitemap/menus/index.ts
+++ b/src/lib/sitemap/menus/index.ts
@@ -1,4 +1,5 @@
 export * from './coach-menu';
 export * from './member-menu';
 export * from './therapist-menu';
+export * from './practice-admin-menu';
 export * from './marketing-site-menu';

--- a/src/lib/sitemap/menus/practice-admin-menu/index.ts
+++ b/src/lib/sitemap/menus/practice-admin-menu/index.ts
@@ -1,0 +1,2 @@
+export * as PRACTICE_ADMIN_NAVIGATION_LINKS from './links';
+export * from './menu';

--- a/src/lib/sitemap/menus/practice-admin-menu/links.ts
+++ b/src/lib/sitemap/menus/practice-admin-menu/links.ts
@@ -4,17 +4,17 @@ import { URL_PATHS } from '../../urlPaths';
 export const DASHBOARD: NavigationLink = {
     icon: NAVIGATION_ICON.DASHBOARD,
     displayName: 'Dashbaord',
-    path: URL_PATHS.PROVIDERS.COACH.DASHBOARD,
+    path: URL_PATHS.PROVIDERS.PRACTICE.DASHBOARD,
 } as const;
 
 export const CLIENTS: NavigationLink = {
     icon: NAVIGATION_ICON.CLIENTS,
     displayName: 'Clients',
-    path: URL_PATHS.PROVIDERS.COACH.CLIENTS,
+    path: URL_PATHS.PROVIDERS.PRACTICE.CLIENTS,
 } as const;
 
-export const PROFILE_EDITOR: NavigationLink = {
+export const PROFILES: NavigationLink = {
     icon: NAVIGATION_ICON.PROFILE_EDITOR,
-    displayName: 'Profile',
-    path: URL_PATHS.PROVIDERS.THERAPIST.PROFILE_EDITOR,
+    displayName: 'Profiles',
+    path: URL_PATHS.PROVIDERS.PRACTICE.PROFILES,
 } as const;

--- a/src/lib/sitemap/menus/practice-admin-menu/menu.tsx
+++ b/src/lib/sitemap/menus/practice-admin-menu/menu.tsx
@@ -1,0 +1,15 @@
+import { DASHBOARD, CLIENTS, PROFILES } from './links';
+import { ACCOUNT, BILLING_AND_SUBSCRIPTION, LOGOUT } from '../accountLinks';
+
+export const PRACTICE_ADMIN_MAIN_MENU = [DASHBOARD, CLIENTS, PROFILES] as const;
+
+export const PRACTICE_ADMIN_SECONDARY_MENU = [
+    { ...ACCOUNT, icon: undefined },
+    BILLING_AND_SUBSCRIPTION,
+    LOGOUT,
+] as const;
+
+export const PRACTICE_ADMIN_MOBILE_MENU = [
+    ...PRACTICE_ADMIN_MAIN_MENU,
+    ACCOUNT,
+] as const;

--- a/src/lib/sitemap/menus/therapist-menu/links.ts
+++ b/src/lib/sitemap/menus/therapist-menu/links.ts
@@ -15,6 +15,6 @@ export const CLIENTS: NavigationLink = {
 
 export const PROFILE_EDITOR: NavigationLink = {
     icon: NAVIGATION_ICON.PROFILE_EDITOR,
-    displayName: 'Profiles',
+    displayName: 'Profile',
     path: URL_PATHS.PROVIDERS.THERAPIST.PROFILE_EDITOR,
 } as const;

--- a/src/lib/sitemap/urls/providers/index.ts
+++ b/src/lib/sitemap/urls/providers/index.ts
@@ -1,6 +1,7 @@
 import { ACCOUNT_LINKS } from './account';
 import { COACH_PATHS } from './coaches';
 import { ONBOARDING_PATHS } from './onboarding';
+import { PRACTICE_PATHS } from './practice';
 import { THERAPIST_PATHS } from './therapists';
 
 export const PROVIDERS_PATHS = {
@@ -8,4 +9,5 @@ export const PROVIDERS_PATHS = {
     THERAPIST: THERAPIST_PATHS,
     ONBOARDING: ONBOARDING_PATHS,
     ACCOUNT: ACCOUNT_LINKS,
+    PRACTICE: PRACTICE_PATHS,
 } as const;

--- a/src/lib/sitemap/urls/providers/practice/index.ts
+++ b/src/lib/sitemap/urls/providers/practice/index.ts
@@ -1,0 +1,6 @@
+export const PRACTICE_PATHS = {
+    DASHBOARD: '/providers/practice/dashboard',
+    CLIENTS: '/providers/practice/clients',
+    PROFILES: '/providers/practice/profiles',
+    PROFILE_EDITOR: '/providers/practice/profile/editor',
+} as const;

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -55,6 +55,8 @@ export default function Home() {
             router.push(URL_PATHS.MEMBERS.HOME);
         } else if (user.plan === null) {
             router.push(URL_PATHS.PROVIDERS.ONBOARDING.BILLING);
+        } else if (user.isPracticeAdmin) {
+            router.push(URL_PATHS.PROVIDERS.PRACTICE.DASHBOARD);
         } else if (role === Role.provider_therapist) {
             router.push(URL_PATHS.PROVIDERS.THERAPIST.DASHBOARD);
         } else if (role === Role.provider_coach) {

--- a/src/pages/providers/practice/dashboard.tsx
+++ b/src/pages/providers/practice/dashboard.tsx
@@ -1,0 +1,44 @@
+import { useRouter } from 'next/router';
+import { withPageAuthRequired } from '@auth0/nextjs-auth0';
+import { H1 } from '@/components/ui';
+import { SideNavigationPage } from '@/components/features/pages';
+import {
+    PRACTICE_ADMIN_MAIN_MENU,
+    PRACTICE_ADMIN_SECONDARY_MENU,
+    PRACTICE_ADMIN_MOBILE_MENU,
+    URL_PATHS,
+} from '@/lib/sitemap';
+import { useTherifyUser } from '@/lib/hooks';
+import { RBAC } from '@/lib/utils';
+import { useEffect } from 'react';
+import { Role } from '@prisma/client';
+
+export const getServerSideProps = RBAC.requireProviderAuth(
+    withPageAuthRequired()
+);
+
+export default function PracticeDashboardPage() {
+    const { user, isLoading } = useTherifyUser();
+    const router = useRouter();
+    useEffect(() => {
+        if (user?.isPracticeAdmin === false) {
+            const isTherapist = user.roles.includes(Role.provider_therapist);
+            isTherapist
+                ? router.push(URL_PATHS.PROVIDERS.THERAPIST.DASHBOARD)
+                : router.push(URL_PATHS.PROVIDERS.COACH.DASHBOARD);
+        }
+    }, [router, user?.isPracticeAdmin, user?.roles]);
+    return (
+        <SideNavigationPage
+            currentPath={URL_PATHS.PROVIDERS.PRACTICE.DASHBOARD}
+            onNavigate={router.push}
+            user={user}
+            primaryMenu={[...PRACTICE_ADMIN_MAIN_MENU]}
+            secondaryMenu={[...PRACTICE_ADMIN_SECONDARY_MENU]}
+            mobileMenu={[...PRACTICE_ADMIN_MOBILE_MENU]}
+            isLoadingUser={isLoading}
+        >
+            <H1>Practice Dashboard</H1>
+        </SideNavigationPage>
+    );
+}


### PR DESCRIPTION
# Description
Adds practice admin support
### Adds
- menus
- Dashboard page
- check for admin status on user details (`user.id === user.plan.billingUserId`
- Practice URL paths in sitemap

# Closes issue(s)
WIP: [Practice Provider invitations](https://trello.com/c/P9ymmEKU)

# How to test / repro

# Screenshots
![image](https://user-images.githubusercontent.com/25045075/216428903-8987a33b-1a85-4968-9b84-cfdacdd5a37b.png)

# Changes include

-   [ ] Bugfix (non-breaking change that solves an issue)
-   [x] New feature (non-breaking change that adds functionality)
-   [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Checklist

-   [ ] I have tested this code
-   [ ] I have updated the Readme

# Other comments
