### PR TITLE
feat: add new client status to provider profile

### DIFF
--- a/prisma/migrations/20230211171020_add_new_client_status_to_provider_profile/migration.sql
+++ b/prisma/migrations/20230211171020_add_new_client_status_to_provider_profile/migration.sql
@@ -1,0 +1,11 @@
+/*
+  Warnings:
+
+  - Added the required column `new_client_status` to the `provider_profiles` table without a default value. This is not possible if the table is not empty.
+
+*/
+-- CreateEnum
+CREATE TYPE "NewClientStatus" AS ENUM ('accepting', 'waitlist', 'not_accepting');
+
+-- AlterTable
+ALTER TABLE "provider_profiles" ADD COLUMN     "new_client_status" "NewClientStatus" NOT NULL;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -219,6 +219,12 @@ enum ProfileType {
   therapist
 }
 
+enum NewClientStatus {
+  accepting
+  waitlist
+  not_accepting
+}
+
 model ProviderProfile {
   id                         String                       @id @default(cuid()) @map("provider_profile_id")
   givenName                  String                       @map("given_name")
@@ -255,6 +261,7 @@ model ProviderProfile {
   offersPhoneConsultations   Boolean                      @default(false) @map("offers_phone_consultations")
   offersVirtual              Boolean                      @default(true) @map("offers_virtual")
   designation                ProfileType                  @map("profile_type")
+  newClientStatus            NewClientStatus              @map("new_client_status")
   directoryListing           DirectoryListing?
   practiceStartDate          DateTime?                    @map("practice_start_date") @db.Timestamp(6)
   PracticeProviderInvitation PracticeProviderInvitation[]

--- a/src/lib/modules/accounts/service/service/get-provider-profile-by-user-id/getProviderProfileByUserId.spec.tsx
+++ b/src/lib/modules/accounts/service/service/get-provider-profile-by-user-id/getProviderProfileByUserId.spec.tsx
@@ -1,6 +1,6 @@
 import { factory as getProviderProfileByUserIdFactory } from './getProviderProfileByUserId';
 import { prismaMock } from '@/lib/prisma/__mock__';
-import { ProfileType, Role, User } from '@prisma/client';
+import { NewClientStatus, ProfileType, Role, User } from '@prisma/client';
 import { generateMock } from '@anatine/zod-mock';
 import { AccountsServiceParams } from '../params';
 import { ProviderProfile } from '@/lib/shared/types';
@@ -23,9 +23,10 @@ describe('getProviderProfileByUserId', () => {
         const getProviderProfileByUserId = getProviderProfileByUserIdFactory({
             prisma: prismaMock,
         } as unknown as AccountsServiceParams);
-        const mockProfile = {
+        const mockProfile: ProviderProfile.ProviderProfile = {
             ...generateMock(ProviderProfile.schema),
             designation: ProfileType.therapist,
+            newClientStatus: NewClientStatus.accepting,
         };
         prismaMock.user.findUniqueOrThrow.mockResolvedValue({
             ...mockUserResult,

--- a/src/lib/modules/providers/components/ProfileEditor/ProfileEditor.tsx
+++ b/src/lib/modules/providers/components/ProfileEditor/ProfileEditor.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useMemo, useState } from 'react';
 import { useForm } from 'react-hook-form';
-import { Practice, ProfileType } from '@prisma/client';
+import { NewClientStatus, Practice, ProfileType } from '@prisma/client';
 import { styled, SxProps, useTheme } from '@mui/material/styles';
 import { Box, Drawer, useMediaQuery } from '@mui/material';
 import { Button, TwoColumnGrid } from '@/lib/shared/components/ui';
@@ -30,6 +30,7 @@ export function ProfileEditor({
     const providerProfileForm = useForm<ProviderProfile.ProviderProfile>({
         mode: 'onChange',
         defaultValues: {
+            newClientStatus: NewClientStatus.accepting,
             offersInPerson: false,
             offersMedicationManagement: false,
             offersPhoneConsultations: false,

--- a/src/lib/modules/providers/components/ProfileEditor/ui/ProfileEditorForm.tsx
+++ b/src/lib/modules/providers/components/ProfileEditor/ui/ProfileEditorForm.tsx
@@ -150,16 +150,16 @@ export const ProfileEditorForm = ({
                 )}
                 <Divider sx={{ mb: 4 }} />
                 <FormSectionTitle style={{ marginTop: 0 }}>
-                    Accepting New Clients?
-                </FormSectionTitle>
-                <NewClientStatusInput
-                    control={control}
-                    disabled={isSubmittingForm}
-                />
-                <FormSectionTitle style={{ marginTop: 0 }}>
                     Profile Type
                 </FormSectionTitle>
                 <DesignationInput
+                    control={control}
+                    disabled={isSubmittingForm}
+                />
+                <FormSectionTitle style={{ margin: 0 }}>
+                    New Clients
+                </FormSectionTitle>
+                <NewClientStatusInput
                     control={control}
                     disabled={isSubmittingForm}
                 />

--- a/src/lib/modules/providers/components/ProfileEditor/ui/ProfileEditorForm.tsx
+++ b/src/lib/modules/providers/components/ProfileEditor/ui/ProfileEditorForm.tsx
@@ -18,6 +18,7 @@ import {
     IdentitySection,
     AboutSection,
     CredentialsSection,
+    NewClientStatusInput,
 } from './inputs';
 import { CloudinaryUploadResult } from '@/lib/modules/media/components/hooks/userCloudinaryWidget';
 import { State, ProviderProfile } from '@/lib/shared/types';
@@ -82,7 +83,7 @@ export const ProfileEditorForm = ({
     const saveButtonText = isNewProfile ? 'Create Profile' : 'Save Changes';
     const isTherapist =
         watchedProfileValues.designation === ProfileType.therapist;
-    // TODO: Add supervisor input
+
     return (
         <EditorContainer>
             <EditorForm>
@@ -101,22 +102,28 @@ export const ProfileEditorForm = ({
                 )}
                 <HeaderContainer marginBottom={4}>
                     <H1>Profile Editor</H1>
-                    <PreviewProfileButton
-                        color="secondary"
-                        onClick={() => onShowProfilePreview?.()}
-                    >
-                        Preview Profile
-                    </PreviewProfileButton>
-                    <Button
-                        ref={headerSaveButtonRef}
-                        fullWidth={false}
-                        type="contained"
-                        disabled={!isFormValid || isSubmittingForm}
-                        isLoading={isSubmittingForm}
-                        onClick={() => setConfirmSave(true)}
-                    >
-                        {saveButtonText}
-                    </Button>
+                    <Box display="flex">
+                        <PreviewProfileButton
+                            color="secondary"
+                            onClick={() => onShowProfilePreview?.()}
+                            style={{
+                                marginBottom: 0,
+                                marginRight: theme.spacing(2),
+                            }}
+                        >
+                            Preview Profile
+                        </PreviewProfileButton>
+                        <Button
+                            ref={headerSaveButtonRef}
+                            fullWidth={false}
+                            type="contained"
+                            disabled={!isFormValid || isSubmittingForm}
+                            isLoading={isSubmittingForm}
+                            onClick={() => setConfirmSave(true)}
+                        >
+                            {saveButtonText}
+                        </Button>
+                    </Box>
                 </HeaderContainer>
                 {!hideFloatingButton && (
                     <FloatingButtons
@@ -142,6 +149,13 @@ export const ProfileEditorForm = ({
                     </FloatingButtons>
                 )}
                 <Divider sx={{ mb: 4 }} />
+                <FormSectionTitle style={{ marginTop: 0 }}>
+                    Accepting New Clients?
+                </FormSectionTitle>
+                <NewClientStatusInput
+                    control={control}
+                    disabled={isSubmittingForm}
+                />
                 <FormSectionTitle style={{ marginTop: 0 }}>
                     Profile Type
                 </FormSectionTitle>

--- a/src/lib/modules/providers/components/ProfileEditor/ui/inputs/About/Bio.tsx
+++ b/src/lib/modules/providers/components/ProfileEditor/ui/inputs/About/Bio.tsx
@@ -12,11 +12,34 @@ export const BioInput = ({ control, disabled }: BioInputProps) => (
         control={control}
         name="bio"
         defaultValue=""
-        render={({ field: { onChange, onBlur, value, name } }) => (
+        rules={{
+            required: {
+                value: true,
+                message: 'Bio is required',
+            },
+            minLength: {
+                value: 50,
+                message: 'Bio must be at least 50 characters long',
+            },
+        }}
+        render={({
+            field: { onChange, onBlur, value, name },
+            fieldState: { error, isTouched },
+        }) => (
             <Textarea
                 fullWidth
+                required
                 id="bio"
                 label="Share a short bio for your profile"
+                errorMessage={
+                    isTouched && error?.message
+                        ? `${error.message} (${
+                              (value ?? '').length < 50
+                                  ? `${value?.length ?? 0}/50`
+                                  : ''
+                          })`
+                        : undefined
+                }
                 {...{
                     onChange,
                     onBlur,

--- a/src/lib/modules/providers/components/ProfileEditor/ui/inputs/NewClientStatus.tsx
+++ b/src/lib/modules/providers/components/ProfileEditor/ui/inputs/NewClientStatus.tsx
@@ -1,0 +1,51 @@
+import { Control, Controller } from 'react-hook-form';
+import { Select, SelectOption } from '@/lib/shared/components/ui';
+import { ProviderProfile } from '@/lib/shared/types';
+import { NewClientStatus } from '@prisma/client';
+
+interface NewClientStatusInputProps {
+    control: Control<ProviderProfile.ProviderProfile>;
+    disabled?: boolean;
+}
+const OPTIONS: SelectOption[] = [
+    {
+        value: NewClientStatus.accepting,
+        displayText: 'Accepting new clients',
+    },
+    {
+        value: NewClientStatus.waitlist,
+        displayText: 'I have a waitlist',
+    },
+    {
+        value: NewClientStatus.not_accepting,
+        displayText: 'Not accepting new clients',
+    },
+];
+
+export const NewClientStatusInput = ({
+    control,
+    disabled,
+}: NewClientStatusInputProps) => (
+    <Controller
+        control={control}
+        name="newClientStatus"
+        rules={{
+            required: true,
+        }}
+        render={({ field: { onChange, onBlur, value, name } }) => (
+            <Select
+                required
+                fullWidth
+                id="newClientStatus"
+                value={value}
+                {...{
+                    options: OPTIONS,
+                    onChange,
+                    name,
+                    onBlur,
+                    disabled,
+                }}
+            />
+        )}
+    />
+);

--- a/src/lib/modules/providers/components/ProfileEditor/ui/inputs/NewClientStatus.tsx
+++ b/src/lib/modules/providers/components/ProfileEditor/ui/inputs/NewClientStatus.tsx
@@ -35,6 +35,7 @@ export const NewClientStatusInput = ({
         render={({ field: { onChange, onBlur, value, name } }) => (
             <Select
                 required
+                label="Are you currently accepting new clients?"
                 fullWidth
                 id="newClientStatus"
                 value={value}

--- a/src/lib/modules/providers/components/ProfileEditor/ui/inputs/index.ts
+++ b/src/lib/modules/providers/components/ProfileEditor/ui/inputs/index.ts
@@ -3,4 +3,5 @@ export * from './About';
 export * from './Credentials';
 export * from './Practice';
 export * from './Designation';
+export * from './NewClientStatus';
 export * from './Pricing';


### PR DESCRIPTION
# Description
Adds new client status to Provider Profile.
### Adds
- `newClientStatus` column on `ProviderProfile` model
- `NewClientStatus` enum to `schema.prisma` file
- Prisma migration
- Accepting new client select to profile editor
 
Also makes Bio a required field

# Closes issue(s)
Continued Profile Editor work

# How to test / repro
Go to editor

# Screenshots
<img width="693" alt="image" src="https://user-images.githubusercontent.com/25045075/218281280-514d1a44-5de3-4f75-9532-922e1949c54a.png">


# Changes include

-   [ ] Bugfix (non-breaking change that solves an issue)
-   [x] New feature (non-breaking change that adds functionality)
-   [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Checklist

-   [ ] I have tested this code
-   [ ] I have updated the Readme

# Other comments
