### PR TITLE
feat: create and delete practice provider invitations

### DIFF
--- a/prisma/migrations/20230214164839_practice_provider_invitation_updates/migration.sql
+++ b/prisma/migrations/20230214164839_practice_provider_invitation_updates/migration.sql
@@ -1,0 +1,13 @@
+/*
+  Warnings:
+
+  - Added the required column `designation` to the `practice_provider_invitations` table without a default value. This is not possible if the table is not empty.
+  - Made the column `new_client_status` on table `provider_profiles` required. This step will fail if there are existing NULL values in that column.
+
+*/
+-- AlterTable
+ALTER TABLE "practice_provider_invitations" ADD COLUMN     "designation" "ProfileType" NOT NULL,
+ADD COLUMN     "expires_at" TIMESTAMP(3);
+
+-- AlterTable
+ALTER TABLE "provider_profiles" ALTER COLUMN "new_client_status" SET NOT NULL;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -278,7 +278,7 @@ model ProviderProfile {
   newClientStatus            NewClientStatus              @default(not_accepting) @map("new_client_status")
   directoryListing           DirectoryListing?
   practiceStartDate          DateTime?                    @map("practice_start_date") @db.Timestamp(6)
-  practiceProviderInvitation PracticeProviderInvitation[]
+  invitations                PracticeProviderInvitation[]
   memberFavorites            MemberFavorites[]
   practiceProfile            PracticeProfile?
 

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -222,6 +222,7 @@ model PracticeProviderInvitation {
   profile        ProviderProfile? @relation(fields: [profileId], references: [id], onDelete: Cascade)
   profileId      String?          @map("profile_id")
   expiresAt      DateTime?        @map("expires_at")
+  designation    ProfileType
 
   createdAt DateTime @default(now()) @map("created_at")
   updatedAt DateTime @updatedAt @map("updated_at")

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -221,6 +221,7 @@ model PracticeProviderInvitation {
   senderId       String           @map("sender_id")
   profile        ProviderProfile? @relation(fields: [profileId], references: [id], onDelete: Cascade)
   profileId      String?          @map("profile_id")
+  expiresAt      DateTime?        @map("expires_at")
 
   createdAt DateTime @default(now()) @map("created_at")
   updatedAt DateTime @updatedAt @map("updated_at")

--- a/src/lib/modules/providers/features/invitations/create-practice-provider-invitation/index.ts
+++ b/src/lib/modules/providers/features/invitations/create-practice-provider-invitation/index.ts
@@ -1,0 +1,5 @@
+export { ROUTE as TRPC_ROUTE } from './trpc';
+export { schema as inputSchema } from './input';
+export type { Input } from './input';
+export { schema as outputSchema } from './output';
+export type { Output } from './output';

--- a/src/lib/modules/providers/features/invitations/create-practice-provider-invitation/input.ts
+++ b/src/lib/modules/providers/features/invitations/create-practice-provider-invitation/input.ts
@@ -6,6 +6,7 @@ export const schema = z.object({
     recipientEmail: PracticeProviderInvitationSchema.shape.recipientEmail,
     senderId: PracticeProviderInvitationSchema.shape.senderId,
     profileId: z.string().optional(),
+    designation: PracticeProviderInvitationSchema.shape.designation,
     expiresInDays: z.number().optional(),
 });
 

--- a/src/lib/modules/providers/features/invitations/create-practice-provider-invitation/input.ts
+++ b/src/lib/modules/providers/features/invitations/create-practice-provider-invitation/input.ts
@@ -2,11 +2,11 @@ import { PracticeProviderInvitationSchema } from '@/lib/shared/schema';
 import * as z from 'zod';
 
 export const schema = z.object({
-    status: PracticeProviderInvitationSchema.shape.status,
     practiceId: PracticeProviderInvitationSchema.shape.practiceId,
     recipientEmail: PracticeProviderInvitationSchema.shape.recipientEmail,
     senderId: PracticeProviderInvitationSchema.shape.senderId,
-    profileId: PracticeProviderInvitationSchema.shape.profileId,
+    profileId: z.string().optional(),
+    expiresInDays: z.number().optional(),
 });
 
 export type Input = z.infer<typeof schema>;

--- a/src/lib/modules/providers/features/invitations/create-practice-provider-invitation/input.ts
+++ b/src/lib/modules/providers/features/invitations/create-practice-provider-invitation/input.ts
@@ -1,0 +1,25 @@
+import { PracticeProviderInvitationSchema } from '@/lib/shared/schema';
+import * as z from 'zod';
+
+export const schema = z.object({
+    status: PracticeProviderInvitationSchema.shape.status,
+    practiceId: PracticeProviderInvitationSchema.shape.practiceId,
+    recipientEmail: PracticeProviderInvitationSchema.shape.recipientEmail,
+    senderId: PracticeProviderInvitationSchema.shape.senderId,
+    profileId: PracticeProviderInvitationSchema.shape.profileId,
+});
+
+export type Input = z.infer<typeof schema>;
+
+export const validate = (value: unknown): Input => {
+    return schema.parse(value);
+};
+
+export const isValid = (value: unknown): value is Input => {
+    try {
+        validate(value);
+        return true;
+    } catch {
+        return false;
+    }
+};

--- a/src/lib/modules/providers/features/invitations/create-practice-provider-invitation/output.ts
+++ b/src/lib/modules/providers/features/invitations/create-practice-provider-invitation/output.ts
@@ -1,0 +1,21 @@
+import * as z from 'zod';
+
+export const schema = z.object({
+    invitaionId: z.string().nullable(),
+    errors: z.array(z.string()),
+});
+
+export type Output = z.infer<typeof schema>;
+
+export const validate = (value: unknown): Output => {
+    return schema.parse(value);
+};
+
+export const isValid = (value: unknown): value is Output => {
+    try {
+        validate(value);
+        return true;
+    } catch {
+        return false;
+    }
+};

--- a/src/lib/modules/providers/features/invitations/create-practice-provider-invitation/output.ts
+++ b/src/lib/modules/providers/features/invitations/create-practice-provider-invitation/output.ts
@@ -1,7 +1,7 @@
 import * as z from 'zod';
 
 export const schema = z.object({
-    invitaionId: z.string().nullable(),
+    invitationId: z.string().nullable(),
     errors: z.array(z.string()),
 });
 

--- a/src/lib/modules/providers/features/invitations/create-practice-provider-invitation/trpc.ts
+++ b/src/lib/modules/providers/features/invitations/create-practice-provider-invitation/trpc.ts
@@ -1,0 +1,1 @@
+export const ROUTE = 'invitations.create-practice-provider-invitation' as const;

--- a/src/lib/modules/providers/features/invitations/delete-practice-provider-invitation/index.ts
+++ b/src/lib/modules/providers/features/invitations/delete-practice-provider-invitation/index.ts
@@ -1,0 +1,5 @@
+export { ROUTE as TRPC_ROUTE } from './trpc';
+export { schema as inputSchema } from './input';
+export type { Input } from './input';
+export { schema as outputSchema } from './output';
+export type { Output } from './output';

--- a/src/lib/modules/providers/features/invitations/delete-practice-provider-invitation/input.ts
+++ b/src/lib/modules/providers/features/invitations/delete-practice-provider-invitation/input.ts
@@ -1,0 +1,21 @@
+import * as z from 'zod';
+
+export const schema = z.object({
+    invitationId: z.string(),
+    userId: z.string(),
+});
+
+export type Input = z.infer<typeof schema>;
+
+export const validate = (value: unknown): Input => {
+    return schema.parse(value);
+};
+
+export const isValid = (value: unknown): value is Input => {
+    try {
+        validate(value);
+        return true;
+    } catch {
+        return false;
+    }
+};

--- a/src/lib/modules/providers/features/invitations/delete-practice-provider-invitation/output.ts
+++ b/src/lib/modules/providers/features/invitations/delete-practice-provider-invitation/output.ts
@@ -1,0 +1,21 @@
+import * as z from 'zod';
+
+export const schema = z.object({
+    success: z.boolean(),
+    errors: z.array(z.string()),
+});
+
+export type Output = z.infer<typeof schema>;
+
+export const validate = (value: unknown): Output => {
+    return schema.parse(value);
+};
+
+export const isValid = (value: unknown): value is Output => {
+    try {
+        validate(value);
+        return true;
+    } catch {
+        return false;
+    }
+};

--- a/src/lib/modules/providers/features/invitations/delete-practice-provider-invitation/trpc.ts
+++ b/src/lib/modules/providers/features/invitations/delete-practice-provider-invitation/trpc.ts
@@ -1,0 +1,1 @@
+export const ROUTE = 'invitations.delete-practice-provider-invitation' as const;

--- a/src/lib/modules/providers/features/invitations/index.ts
+++ b/src/lib/modules/providers/features/invitations/index.ts
@@ -1,0 +1,1 @@
+export * as CreatePracticeProviderInvitation from './create-practice-provider-invitation';

--- a/src/lib/modules/providers/features/invitations/index.ts
+++ b/src/lib/modules/providers/features/invitations/index.ts
@@ -1,1 +1,2 @@
 export * as CreatePracticeProviderInvitation from './create-practice-provider-invitation';
+export * as DeletePracticeProviderInvitation from './delete-practice-provider-invitation';

--- a/src/lib/modules/providers/features/practice/get-practice-by-user-id/index.ts
+++ b/src/lib/modules/providers/features/practice/get-practice-by-user-id/index.ts
@@ -1,0 +1,5 @@
+export { ROUTE as TRPC_ROUTE } from './trpc';
+export { schema as inputSchema } from './input';
+export type { Input } from './input';
+export { schema as outputSchema } from './output';
+export type { Output } from './output';

--- a/src/lib/modules/providers/features/practice/get-practice-by-user-id/input.ts
+++ b/src/lib/modules/providers/features/practice/get-practice-by-user-id/input.ts
@@ -1,0 +1,20 @@
+import * as z from 'zod';
+
+export const schema = z.object({
+    userId: z.string(),
+});
+
+export type Input = z.infer<typeof schema>;
+
+export const validate = (value: unknown): Input => {
+    return schema.parse(value);
+};
+
+export const isValid = (value: unknown): value is Input => {
+    try {
+        validate(value);
+        return true;
+    } catch {
+        return false;
+    }
+};

--- a/src/lib/modules/providers/features/practice/get-practice-by-user-id/output.ts
+++ b/src/lib/modules/providers/features/practice/get-practice-by-user-id/output.ts
@@ -1,0 +1,22 @@
+import { ProviderPractice } from '@/lib/shared/types';
+import * as z from 'zod';
+
+export const schema = z.object({
+    practice: ProviderPractice.schema,
+    errors: z.array(z.string()),
+});
+
+export type Output = z.infer<typeof schema>;
+
+export const validate = (value: unknown): Output => {
+    return schema.parse(value);
+};
+
+export const isValid = (value: unknown): value is Output => {
+    try {
+        validate(value);
+        return true;
+    } catch {
+        return false;
+    }
+};

--- a/src/lib/modules/providers/features/practice/get-practice-by-user-id/trpc.ts
+++ b/src/lib/modules/providers/features/practice/get-practice-by-user-id/trpc.ts
@@ -1,0 +1,1 @@
+export const ROUTE = 'profiles.get-by-id' as const;

--- a/src/lib/modules/providers/features/practice/index.ts
+++ b/src/lib/modules/providers/features/practice/index.ts
@@ -1,0 +1,1 @@
+export * as GetPracticeByUserId from './get-practice-by-user-id';

--- a/src/lib/modules/providers/features/profiles/list-practice-profiles-by-user-id/output.ts
+++ b/src/lib/modules/providers/features/profiles/list-practice-profiles-by-user-id/output.ts
@@ -1,8 +1,8 @@
-import { ProviderProfile } from '@/lib/shared/types';
+import { ProviderProfileListing } from '@/lib/shared/types';
 import * as z from 'zod';
 
 export const schema = z.object({
-    profiles: ProviderProfile.schema.array(),
+    profiles: ProviderProfileListing.schema.array(),
     errors: z.array(z.string()),
 });
 

--- a/src/lib/modules/providers/routes/resolvers/create-practice-provider-invitation/index.ts
+++ b/src/lib/modules/providers/routes/resolvers/create-practice-provider-invitation/index.ts
@@ -1,0 +1,1 @@
+export { resolve as createPracticeProviderInvitationResolver } from './resolver';

--- a/src/lib/modules/providers/routes/resolvers/create-practice-provider-invitation/resolver.ts
+++ b/src/lib/modules/providers/routes/resolvers/create-practice-provider-invitation/resolver.ts
@@ -31,6 +31,9 @@ export const resolve: ProcedureResolver<
         };
     }
 
+    /**
+     *  TODO: Send email to recipient
+     **/
     return {
         invitationId: result.value.createInvitation.invitationId,
         errors: [],

--- a/src/lib/modules/providers/routes/resolvers/create-practice-provider-invitation/resolver.ts
+++ b/src/lib/modules/providers/routes/resolvers/create-practice-provider-invitation/resolver.ts
@@ -1,0 +1,38 @@
+import { Context } from '@/lib/server/context';
+import { CreatePracticeProviderInvitation } from '@/lib/modules/providers/features/invitations';
+import { ProcedureResolver } from '@trpc/server/dist/declarations/src/internals/procedure';
+
+export const resolve: ProcedureResolver<
+    Context,
+    CreatePracticeProviderInvitation.Input,
+    CreatePracticeProviderInvitation.Output
+> = async function ({
+    input,
+    ctx,
+}): Promise<CreatePracticeProviderInvitation.Output> {
+    const result =
+        await ctx.providers.invitations.createPracticeProviderInvitation(input);
+
+    if (result.isErr()) {
+        let errorMessage = 'Could not create invitation.';
+        result.mapErr(([erroredStep, error]) => {
+            console.log(
+                'Create practice provider invitation for practice failed on step: ' +
+                    erroredStep,
+                error
+            );
+            if (error instanceof Error) {
+                errorMessage = error.message;
+            }
+        });
+        return {
+            invitationId: null,
+            errors: [errorMessage],
+        };
+    }
+
+    return {
+        invitationId: result.value.createInvitation.invitationId,
+        errors: [],
+    };
+};

--- a/src/lib/modules/providers/routes/resolvers/delete-practice-provider-invitation/index.ts
+++ b/src/lib/modules/providers/routes/resolvers/delete-practice-provider-invitation/index.ts
@@ -1,0 +1,1 @@
+export { resolve as deletePracticeProviderInvitationResolver } from './resolver';

--- a/src/lib/modules/providers/routes/resolvers/delete-practice-provider-invitation/resolver.ts
+++ b/src/lib/modules/providers/routes/resolvers/delete-practice-provider-invitation/resolver.ts
@@ -1,0 +1,32 @@
+import { Context } from '@/lib/server/context';
+import { DeletePracticeProviderInvitation } from '@/lib/modules/providers/features/invitations';
+import { ProcedureResolver } from '@trpc/server/dist/declarations/src/internals/procedure';
+
+export const resolve: ProcedureResolver<
+    Context,
+    DeletePracticeProviderInvitation.Input,
+    DeletePracticeProviderInvitation.Output
+> = async function ({
+    input,
+    ctx,
+}): Promise<DeletePracticeProviderInvitation.Output> {
+    try {
+        const { success } =
+            await ctx.providers.invitations.deletePracticeProviderInvitation(
+                input
+            );
+        return {
+            success,
+            errors: [],
+        };
+    } catch (error) {
+        let errorMessage = 'Delete invitation failed.';
+        if (error instanceof Error) {
+            errorMessage = error.message;
+        }
+        return {
+            success: false,
+            errors: [errorMessage],
+        };
+    }
+};

--- a/src/lib/modules/providers/routes/resolvers/index.ts
+++ b/src/lib/modules/providers/routes/resolvers/index.ts
@@ -4,3 +4,5 @@ export { getProviderProfileByIdResolver } from './get-provider-profile-by-id';
 export { updateProviderProfileResolver } from './update-provider-profile';
 export { deleteProviderProfileResolver } from './delete-provider-profile';
 export { createProviderProfileForPracticeResolver } from './create-provider-profile-for-practice';
+
+export { createPracticeProviderInvitationResolver } from './create-practice-provider-invitation';

--- a/src/lib/modules/providers/routes/resolvers/list-practice-profiles-by-user-id/resolver.ts
+++ b/src/lib/modules/providers/routes/resolvers/list-practice-profiles-by-user-id/resolver.ts
@@ -1,11 +1,6 @@
 import { Context } from '@/lib/server/context';
 import { ListPracticeProfilesByUserId } from '@/lib/modules/providers/features/profiles';
 import { ProcedureResolver } from '@trpc/server/dist/declarations/src/internals/procedure';
-import {
-    ProviderCredential,
-    ProviderSupervisor,
-    ProviderProfile,
-} from '@/lib/shared/types';
 
 export const resolve: ProcedureResolver<
     Context,

--- a/src/lib/modules/providers/routes/router.ts
+++ b/src/lib/modules/providers/routes/router.ts
@@ -18,7 +18,11 @@ import {
     UpdateProviderProfile,
     DeleteProviderProfile,
 } from '@/lib/modules/providers/features/profiles';
-import { CreatePracticeProviderInvitation } from '@/lib/modules/providers/features/invitations';
+import {
+    CreatePracticeProviderInvitation,
+    DeletePracticeProviderInvitation,
+} from '@/lib/modules/providers/features/invitations';
+import { deletePracticeProviderInvitationResolver } from './resolvers/delete-practice-provider-invitation';
 
 export const router = trpc
     .router<Context>()
@@ -56,4 +60,9 @@ export const router = trpc
         input: CreatePracticeProviderInvitation.inputSchema,
         output: CreatePracticeProviderInvitation.outputSchema,
         resolve: createPracticeProviderInvitationResolver,
+    })
+    .mutation(DeletePracticeProviderInvitation.TRPC_ROUTE, {
+        input: DeletePracticeProviderInvitation.inputSchema,
+        output: DeletePracticeProviderInvitation.outputSchema,
+        resolve: deletePracticeProviderInvitationResolver,
     });

--- a/src/lib/modules/providers/routes/router.ts
+++ b/src/lib/modules/providers/routes/router.ts
@@ -7,6 +7,7 @@ import {
     getProviderProfileByIdResolver,
     updateProviderProfileResolver,
     deleteProviderProfileResolver,
+    createPracticeProviderInvitationResolver,
 } from './resolvers';
 import { Context } from '@/lib/server/context';
 import {
@@ -17,6 +18,7 @@ import {
     UpdateProviderProfile,
     DeleteProviderProfile,
 } from '@/lib/modules/providers/features/profiles';
+import { CreatePracticeProviderInvitation } from '@/lib/modules/providers/features/invitations';
 
 export const router = trpc
     .router<Context>()
@@ -49,4 +51,9 @@ export const router = trpc
         input: DeleteProviderProfile.inputSchema,
         output: DeleteProviderProfile.outputSchema,
         resolve: deleteProviderProfileResolver,
+    })
+    .mutation(CreatePracticeProviderInvitation.TRPC_ROUTE, {
+        input: CreatePracticeProviderInvitation.inputSchema,
+        output: CreatePracticeProviderInvitation.outputSchema,
+        resolve: createPracticeProviderInvitationResolver,
     });

--- a/src/lib/modules/providers/service/index.ts
+++ b/src/lib/modules/providers/service/index.ts
@@ -2,6 +2,7 @@ import { firebaseAdminVendor } from '@/lib/shared/vendors/firebase-admin';
 import { prisma } from '@/lib/prisma';
 import { ProvidersServiceParams } from './params';
 import { profilesFactory } from './profiles';
+import { pagePropsFactory } from './page-props';
 import { AccountsService } from '../../accounts/service/service';
 import { GetDashboardProps } from './dashboard/get-dashboard-props';
 import { invitationsFactory } from './invitations';
@@ -13,6 +14,7 @@ const factoryParams: ProvidersServiceParams = {
 export const ProvidersService = {
     profiles: profilesFactory(factoryParams),
     invitations: invitationsFactory(factoryParams),
+    pageProps: pagePropsFactory(factoryParams),
     getDashboardProps: GetDashboardProps.factory({
         ...factoryParams,
         accountsService: AccountsService,

--- a/src/lib/modules/providers/service/index.ts
+++ b/src/lib/modules/providers/service/index.ts
@@ -4,6 +4,7 @@ import { ProvidersServiceParams } from './params';
 import { profilesFactory } from './profiles';
 import { AccountsService } from '../../accounts/service/service';
 import { GetDashboardProps } from './dashboard/get-dashboard-props';
+import { invitationsFactory } from './invitations';
 
 const factoryParams: ProvidersServiceParams = {
     prisma,
@@ -11,6 +12,7 @@ const factoryParams: ProvidersServiceParams = {
 };
 export const ProvidersService = {
     profiles: profilesFactory(factoryParams),
+    invitations: invitationsFactory(factoryParams),
     getDashboardProps: GetDashboardProps.factory({
         ...factoryParams,
         accountsService: AccountsService,

--- a/src/lib/modules/providers/service/invitations/create-practice-provider-invitation/createPracticeProviderInvitation.ts
+++ b/src/lib/modules/providers/service/invitations/create-practice-provider-invitation/createPracticeProviderInvitation.ts
@@ -1,0 +1,25 @@
+import { ProvidersServiceParams } from '../../params';
+import {
+    GetPractice,
+    transactionDefinition,
+    ValidateSeatAvailability,
+    CreateInvitation,
+} from './transaction';
+import { TransactionV1 } from '@/lib/shared/utils';
+import { CreatePracticeProviderInvitation } from '@/lib/modules/providers/features/invitations';
+
+export function factory(context: ProvidersServiceParams) {
+    return async function (params: CreatePracticeProviderInvitation.Input) {
+        return await TransactionV1.executeTransaction(
+            transactionDefinition,
+            { ...context },
+            {
+                validateSeatAvailability:
+                    ValidateSeatAvailability.factory(params),
+                getPractice: GetPractice.factory(params),
+                createInvitation: CreateInvitation.factory(params),
+            },
+            true
+        );
+    };
+}

--- a/src/lib/modules/providers/service/invitations/create-practice-provider-invitation/createPracticeProviderInvitation.ts
+++ b/src/lib/modules/providers/service/invitations/create-practice-provider-invitation/createPracticeProviderInvitation.ts
@@ -4,6 +4,7 @@ import {
     transactionDefinition,
     ValidateSeatAvailability,
     CreateInvitation,
+    ValidateUniqueEmail,
 } from './transaction';
 import { TransactionV1 } from '@/lib/shared/utils';
 import { CreatePracticeProviderInvitation } from '@/lib/modules/providers/features/invitations';
@@ -16,6 +17,7 @@ export function factory(context: ProvidersServiceParams) {
             {
                 validateSeatAvailability:
                     ValidateSeatAvailability.factory(params),
+                validateUniqueEmail: ValidateUniqueEmail.factory(params),
                 getPractice: GetPractice.factory(params),
                 createInvitation: CreateInvitation.factory(params),
             },

--- a/src/lib/modules/providers/service/invitations/create-practice-provider-invitation/index.ts
+++ b/src/lib/modules/providers/service/invitations/create-practice-provider-invitation/index.ts
@@ -1,0 +1,1 @@
+export * as CreatePracticeProviderInvitation from './createPracticeProviderInvitation';

--- a/src/lib/modules/providers/service/invitations/create-practice-provider-invitation/transaction/createInvitation.ts
+++ b/src/lib/modules/providers/service/invitations/create-practice-provider-invitation/transaction/createInvitation.ts
@@ -1,0 +1,35 @@
+import { CreatePracticeProviderInvitation } from '@/lib/modules/providers/features/invitations';
+import { InvitationStatus } from '@prisma/client';
+import { addDays } from 'date-fns';
+import { CreatePracticeProviderInvitationTransaction } from './definition';
+
+export const factory: (
+    input: CreatePracticeProviderInvitation.Input
+) => CreatePracticeProviderInvitationTransaction['createInvitation'] = ({
+    expiresInDays,
+    ...input
+}) => {
+    return {
+        async commit({ prisma }) {
+            const { id: invitationId } =
+                await prisma.practiceProviderInvitation.create({
+                    data: {
+                        ...input,
+                        status: InvitationStatus.pending,
+                        expiresAt:
+                            expiresInDays !== undefined && expiresInDays > 0
+                                ? addDays(new Date(), expiresInDays)
+                                : undefined,
+                    },
+                });
+            return {
+                invitationId,
+            };
+        },
+        rollback({ prisma }, { createInvitation: { invitationId } }) {
+            return prisma.practiceProviderInvitation.delete({
+                where: { id: invitationId },
+            });
+        },
+    };
+};

--- a/src/lib/modules/providers/service/invitations/create-practice-provider-invitation/transaction/definition.ts
+++ b/src/lib/modules/providers/service/invitations/create-practice-provider-invitation/transaction/definition.ts
@@ -1,0 +1,19 @@
+import { z } from 'zod';
+import { TransactionV1 } from '@/lib/shared/utils';
+import { ProvidersServiceParams } from '../../../params';
+
+export const transactionDefinition = z.object({
+    validateSeatAvailability: z.unknown(),
+    getPractice: z.object({
+        practiceId: z.string(),
+    }),
+    createInvitation: z.object({
+        invitationId: z.string(),
+    }),
+});
+
+export type CreatePracticeProviderInvitationTransaction =
+    TransactionV1.TransactionDefinition<
+        ProvidersServiceParams,
+        typeof transactionDefinition.shape
+    >;

--- a/src/lib/modules/providers/service/invitations/create-practice-provider-invitation/transaction/definition.ts
+++ b/src/lib/modules/providers/service/invitations/create-practice-provider-invitation/transaction/definition.ts
@@ -4,6 +4,7 @@ import { ProvidersServiceParams } from '../../../params';
 
 export const transactionDefinition = z.object({
     validateSeatAvailability: z.unknown(),
+    validateUniqueEmail: z.unknown(),
     getPractice: z.object({
         practiceId: z.string(),
     }),

--- a/src/lib/modules/providers/service/invitations/create-practice-provider-invitation/transaction/getPractice.ts
+++ b/src/lib/modules/providers/service/invitations/create-practice-provider-invitation/transaction/getPractice.ts
@@ -1,0 +1,24 @@
+import { CreatePracticeProviderInvitation } from '@/lib/modules/providers/features/invitations';
+import { CreatePracticeProviderInvitationTransaction } from './definition';
+
+export const factory: (
+    input: CreatePracticeProviderInvitation.Input
+) => CreatePracticeProviderInvitationTransaction['getPractice'] = ({
+    senderId,
+}) => {
+    return {
+        async commit({ prisma }) {
+            const { practice } = await prisma.user.findUniqueOrThrow({
+                where: { id: senderId },
+                select: {
+                    practice: true,
+                },
+            });
+            if (!practice) throw new Error('User is not a practice admin');
+            return {
+                practiceId: practice.id,
+            };
+        },
+        rollback() {},
+    };
+};

--- a/src/lib/modules/providers/service/invitations/create-practice-provider-invitation/transaction/index.ts
+++ b/src/lib/modules/providers/service/invitations/create-practice-provider-invitation/transaction/index.ts
@@ -1,0 +1,4 @@
+export { transactionDefinition } from './definition';
+export * as CreateInvitation from './createInvitation';
+export * as GetPractice from './getPractice';
+export * as ValidateSeatAvailability from './validateSeatAvailability';

--- a/src/lib/modules/providers/service/invitations/create-practice-provider-invitation/transaction/index.ts
+++ b/src/lib/modules/providers/service/invitations/create-practice-provider-invitation/transaction/index.ts
@@ -2,3 +2,4 @@ export { transactionDefinition } from './definition';
 export * as CreateInvitation from './createInvitation';
 export * as GetPractice from './getPractice';
 export * as ValidateSeatAvailability from './validateSeatAvailability';
+export * as ValidateUniqueEmail from './validateUniqueEmail';

--- a/src/lib/modules/providers/service/invitations/create-practice-provider-invitation/transaction/validateSeatAvailability.ts
+++ b/src/lib/modules/providers/service/invitations/create-practice-provider-invitation/transaction/validateSeatAvailability.ts
@@ -1,0 +1,79 @@
+import { CreatePracticeProviderInvitation } from '@/lib/modules/providers/features/invitations';
+import { InvitationStatus, PlanStatus } from '@prisma/client';
+import { isAfter } from 'date-fns';
+import { CreatePracticeProviderInvitationTransaction } from './definition';
+
+export const factory: (
+    input: CreatePracticeProviderInvitation.Input
+) => CreatePracticeProviderInvitationTransaction['validateSeatAvailability'] = ({
+    senderId,
+    profileId,
+}) => {
+    return {
+        async commit({ prisma }) {
+            const { plans } = await prisma.user.findUniqueOrThrow({
+                where: { id: senderId },
+                select: {
+                    plans: {
+                        orderBy: {
+                            createdAt: 'desc',
+                        },
+                        take: 1,
+                        select: {
+                            billingUserId: true,
+                            seats: true,
+                            status: true,
+                            endDate: true,
+                        },
+                    },
+                },
+            });
+            const [plan] = plans;
+            if (!plan) throw new Error('No plan found for user.');
+            if (plan.billingUserId !== senderId)
+                throw new Error('User is not a practice admin.');
+
+            const activeStatuses: PlanStatus[] = [
+                PlanStatus.active,
+                PlanStatus.trialing,
+            ];
+            if (!activeStatuses.includes(plan.status))
+                throw new Error('Plan is not active');
+            if (isAfter(new Date(), plan.endDate))
+                throw new Error('Plan has expired');
+
+            if (!profileId) return;
+            // Active/Pending invitations without a profileId count towards the seat limit
+            // because they represent the intent for the recipient to create a profile and take a seat.
+            const invitationsCount =
+                await prisma.practiceProviderInvitation.count({
+                    where: {
+                        practice: {
+                            userId: senderId,
+                        },
+                        status: {
+                            in: [
+                                InvitationStatus.pending,
+                                InvitationStatus.accepted,
+                            ],
+                        },
+                        profileId: null,
+                    },
+                });
+            const profilesCount = await prisma.practiceProfile.count({
+                where: {
+                    practice: {
+                        userId: senderId,
+                    },
+                },
+            });
+
+            if (invitationsCount + profilesCount >= plan.seats) {
+                throw new Error(
+                    'No seats available. Please upgrade your plan to invite a provider.'
+                );
+            }
+        },
+        rollback() {},
+    };
+};

--- a/src/lib/modules/providers/service/invitations/create-practice-provider-invitation/transaction/validateUniqueEmail.ts
+++ b/src/lib/modules/providers/service/invitations/create-practice-provider-invitation/transaction/validateUniqueEmail.ts
@@ -1,0 +1,44 @@
+import { CreatePracticeProviderInvitation } from '@/lib/modules/providers/features/invitations';
+import { InvitationStatus } from '@prisma/client';
+import { addDays } from 'date-fns';
+import { CreatePracticeProviderInvitationTransaction } from './definition';
+
+export const factory: (
+    input: CreatePracticeProviderInvitation.Input
+) => CreatePracticeProviderInvitationTransaction['validateUniqueEmail'] = ({
+    recipientEmail,
+}) => {
+    return {
+        async commit({ prisma }) {
+            const user = await prisma.user.findFirst({
+                where: {
+                    emailAddress: recipientEmail,
+                },
+            });
+
+            const activeInvitation =
+                await prisma.practiceProviderInvitation.findFirst({
+                    where: {
+                        recipientEmail,
+                        status: {
+                            in: [
+                                InvitationStatus.pending,
+                                InvitationStatus.accepted,
+                            ],
+                        },
+                    },
+                });
+            if (activeInvitation)
+                throw new Error(
+                    `${recipientEmail} has already been invited to join Therify. Emails can only have one active invitation at a time.`
+                );
+            if (user)
+                throw new Error(
+                    'A user already exists with this email address.'
+                );
+
+            return;
+        },
+        rollback() {},
+    };
+};

--- a/src/lib/modules/providers/service/invitations/delete-practice-provider-invitation/deletePracticeProviderInvitation.ts
+++ b/src/lib/modules/providers/service/invitations/delete-practice-provider-invitation/deletePracticeProviderInvitation.ts
@@ -1,0 +1,33 @@
+import { ProvidersServiceParams } from '../../params';
+import { DeletePracticeProviderInvitation } from '@/lib/modules/providers/features/invitations';
+
+export function factory({ prisma }: ProvidersServiceParams) {
+    return async function ({
+        userId,
+        invitationId,
+    }: DeletePracticeProviderInvitation.Input): Promise<{
+        success: DeletePracticeProviderInvitation.Output['success'];
+    }> {
+        const invitation =
+            await prisma.practiceProviderInvitation.findFirstOrThrow({
+                where: {
+                    id: invitationId,
+                    senderId: userId,
+                    practice: {
+                        userId,
+                    },
+                },
+                select: {
+                    id: true,
+                },
+            });
+
+        await prisma.practiceProviderInvitation.delete({
+            where: { id: invitation.id },
+        });
+
+        return {
+            success: true,
+        };
+    };
+}

--- a/src/lib/modules/providers/service/invitations/delete-practice-provider-invitation/index.ts
+++ b/src/lib/modules/providers/service/invitations/delete-practice-provider-invitation/index.ts
@@ -1,0 +1,1 @@
+export * as DeletePracticeProviderInvitation from './deletePracticeProviderInvitation';

--- a/src/lib/modules/providers/service/invitations/index.ts
+++ b/src/lib/modules/providers/service/invitations/index.ts
@@ -1,0 +1,11 @@
+import { ProvidersServiceParams } from '../params';
+import { CreatePracticeProviderInvitation } from './create-practice-provider-invitation';
+
+export const invitationsFactory = (params: ProvidersServiceParams) => ({
+    createPracticeProviderInvitation:
+        CreatePracticeProviderInvitation.factory(params),
+    acceptPracticeProviderInvitation: () => {},
+    declinePracticeProviderInvitation: () => {},
+    expirePracticeProviderInvitation: () => {},
+    deletePracticeProviderInvitation: () => {},
+});

--- a/src/lib/modules/providers/service/invitations/index.ts
+++ b/src/lib/modules/providers/service/invitations/index.ts
@@ -1,11 +1,12 @@
 import { ProvidersServiceParams } from '../params';
 import { CreatePracticeProviderInvitation } from './create-practice-provider-invitation';
+import { DeletePracticeProviderInvitation } from './delete-practice-provider-invitation';
 
 export const invitationsFactory = (params: ProvidersServiceParams) => ({
     createPracticeProviderInvitation:
         CreatePracticeProviderInvitation.factory(params),
-    acceptPracticeProviderInvitation: () => {},
     declinePracticeProviderInvitation: () => {},
     expirePracticeProviderInvitation: () => {},
-    deletePracticeProviderInvitation: () => {},
+    deletePracticeProviderInvitation:
+        DeletePracticeProviderInvitation.factory(params),
 });

--- a/src/lib/modules/providers/service/page-props/get-practice-profiles-page-props/getPracticeProfilesPageProps.ts
+++ b/src/lib/modules/providers/service/page-props/get-practice-profiles-page-props/getPracticeProfilesPageProps.ts
@@ -1,0 +1,60 @@
+import { ProviderProfileListing } from '@/lib/shared/types';
+import { TherifyUser } from '@/lib/shared/types/therify-user';
+import { getSession } from '@auth0/nextjs-auth0';
+import { GetServerSideProps } from 'next';
+import { AccountsService } from '@/lib/modules/accounts/service';
+import { profilesFactory } from '@/lib/modules/providers/service/profiles';
+import { ProvidersServiceParams } from '../../params';
+import { practiceFactory } from '../../practice';
+
+export interface PracticeProfilesPageProps {
+    profiles: ProviderProfileListing.Type[];
+    practice: { id: string; name: string };
+    user: TherifyUser.TherifyUser;
+}
+
+interface PracticeProfilesPagePropsParams extends ProvidersServiceParams {
+    accountsService: AccountsService;
+}
+
+export const factory = (params: PracticeProfilesPagePropsParams) => {
+    const getPracticeProfilesPageProps: GetServerSideProps<
+        PracticeProfilesPageProps
+    > = async (context) => {
+        console.log('gettting PracticeProfilesPageProps...');
+        const session = await getSession(context.req, context.res);
+        if (!session) {
+            return {
+                redirect: {
+                    destination: '/api/auth/login',
+                    permanent: false,
+                },
+            };
+        }
+        const { listPracticeProfilesByUserId } = profilesFactory(params);
+        const { getPracticeByUserId } = practiceFactory(params);
+
+        const [{ user }, { profiles }, { practice }] = await Promise.all([
+            params.accountsService.getUserDetailsById({
+                userId: session.user.sub,
+            }),
+            listPracticeProfilesByUserId({ userId: session.user.sub }),
+            getPracticeByUserId({ userId: session.user.sub }),
+        ]);
+        if (user === null) {
+            return {
+                redirect: {
+                    destination: '/api/auth/login',
+                    permanent: false,
+                },
+            };
+        }
+        const props: PracticeProfilesPageProps = {
+            profiles,
+            practice,
+            user,
+        };
+        return JSON.parse(JSON.stringify({ props }));
+    };
+    return getPracticeProfilesPageProps;
+};

--- a/src/lib/modules/providers/service/page-props/get-practice-profiles-page-props/index.ts
+++ b/src/lib/modules/providers/service/page-props/get-practice-profiles-page-props/index.ts
@@ -1,0 +1,1 @@
+export * as GetPracticeProfilesPageProps from './getPracticeProfilesPageProps';

--- a/src/lib/modules/providers/service/page-props/index.ts
+++ b/src/lib/modules/providers/service/page-props/index.ts
@@ -1,0 +1,10 @@
+import { AccountsService } from '@/lib/modules/accounts/service';
+import { ProvidersServiceParams } from '../params';
+import { GetPracticeProfilesPageProps } from './get-practice-profiles-page-props';
+
+export const pagePropsFactory = (params: ProvidersServiceParams) => ({
+    getPracticeProfilesPageProps: GetPracticeProfilesPageProps.factory({
+        ...params,
+        accountsService: AccountsService,
+    }),
+});

--- a/src/lib/modules/providers/service/practice/get-practice-by-user-id/getPracticeByUserId.ts
+++ b/src/lib/modules/providers/service/practice/get-practice-by-user-id/getPracticeByUserId.ts
@@ -1,0 +1,23 @@
+import { GetPracticeByUserId } from '@/lib/modules/providers/features/practice';
+import { ProviderPractice } from '@/lib/shared/types';
+import { ProvidersServiceParams } from '../../params';
+
+export const factory =
+    ({ prisma }: ProvidersServiceParams) =>
+    async ({
+        userId,
+    }: GetPracticeByUserId.Input): Promise<{
+        practice: GetPracticeByUserId.Output['practice'];
+    }> => {
+        const practice = await prisma.practice.findUniqueOrThrow({
+            where: {
+                userId,
+            },
+        });
+
+        return JSON.parse(
+            JSON.stringify({
+                practice: ProviderPractice.validate(practice),
+            })
+        );
+    };

--- a/src/lib/modules/providers/service/practice/get-practice-by-user-id/index.ts
+++ b/src/lib/modules/providers/service/practice/get-practice-by-user-id/index.ts
@@ -1,0 +1,1 @@
+export * as GetPracticeByUserId from './getPracticeByUserId';

--- a/src/lib/modules/providers/service/practice/index.ts
+++ b/src/lib/modules/providers/service/practice/index.ts
@@ -1,0 +1,6 @@
+import { ProvidersServiceParams } from '../params';
+import { GetPracticeByUserId } from './get-practice-by-user-id';
+
+export const practiceFactory = (params: ProvidersServiceParams) => ({
+    getPracticeByUserId: GetPracticeByUserId.factory(params),
+});

--- a/src/lib/modules/providers/service/profiles/create-provider-profile-for-practice/transaction/validateSeatAvailability.ts
+++ b/src/lib/modules/providers/service/profiles/create-provider-profile-for-practice/transaction/validateSeatAvailability.ts
@@ -15,8 +15,8 @@ export const factory: (
             // This is because a "seat" is 1:1 with a profile, but an invitation without
             // a profile id assigned represents the intention for a profile to be
             // created when accepted. Therefore, an invitation with no profileId
-            // should take a seat until that invitation is accepted (which creates the profile),
-            // rejected, or expired.
+            // should take a seat until that invitation is accepted (which creates the profile) or
+            // status becomes rejected or expired.
             const { plans } = await prisma.user.findUniqueOrThrow({
                 where: { id: userId },
                 select: {

--- a/src/lib/modules/providers/service/profiles/list-practice-profiles-by-user-id/listPracticeProfilesByUserId.ts
+++ b/src/lib/modules/providers/service/profiles/list-practice-profiles-by-user-id/listPracticeProfilesByUserId.ts
@@ -1,6 +1,7 @@
 import { ProvidersServiceParams } from '../../params';
 import { ListPracticeProfilesByUserId } from '@/lib/modules/providers/features/profiles';
-import { ProviderProfile } from '@/lib/shared/types';
+import { ProviderProfileListing } from '@/lib/shared/types';
+import { InvitationStatus } from '@prisma/client';
 
 export function factory({ prisma }: ProvidersServiceParams) {
     return async function ({
@@ -18,7 +19,7 @@ export function factory({ prisma }: ProvidersServiceParams) {
         });
         if (!practice) throw new Error('User is not a practice admin');
 
-        const profiles = await prisma.providerProfile.findMany({
+        const rawProfiles = await prisma.providerProfile.findMany({
             where: {
                 practiceProfile: {
                     practiceId: practice.id,
@@ -26,21 +27,41 @@ export function factory({ prisma }: ProvidersServiceParams) {
             },
             include: {
                 directoryListing: true,
+                // Latest pending or accepted invitation
+                invitations: {
+                    orderBy: {
+                        createdAt: 'desc',
+                    },
+                    take: 1,
+                    where: {
+                        status: {
+                            in: [
+                                InvitationStatus.pending,
+                                InvitationStatus.accepted,
+                            ],
+                        },
+                    },
+                    select: {
+                        id: true,
+                        status: true,
+                        recipientEmail: true,
+                    },
+                },
             },
         });
+        const profiles = rawProfiles.map(
+            ({ invitations, createdAt, updatedAt, ...profile }) => {
+                const [invitation] = invitations;
+                return ProviderProfileListing.validate({
+                    ...profile,
+                    invitation: invitation ?? null,
+                    createdAt: createdAt.toISOString(),
+                    updatedAt: updatedAt.toISOString(),
+                });
+            }
+        );
         return {
-            // TODO: This function doesnt need the entire profile
-            profiles: JSON.parse(
-                JSON.stringify(
-                    profiles.map((profile) =>
-                        ProviderProfile.validate({
-                            ...profile,
-                            practiceStartDate:
-                                profile.practiceStartDate?.toISOString(),
-                        })
-                    )
-                )
-            ),
+            profiles: JSON.parse(JSON.stringify(profiles)),
         };
     };
 }

--- a/src/lib/modules/providers/service/profiles/list-practice-profiles-by-user-id/listPracticeProfilesByUserId.ts
+++ b/src/lib/modules/providers/service/profiles/list-practice-profiles-by-user-id/listPracticeProfilesByUserId.ts
@@ -45,6 +45,7 @@ export function factory({ prisma }: ProvidersServiceParams) {
                         id: true,
                         status: true,
                         recipientEmail: true,
+                        expiresAt: true,
                     },
                 },
             },
@@ -52,9 +53,16 @@ export function factory({ prisma }: ProvidersServiceParams) {
         const profiles = rawProfiles.map(
             ({ invitations, createdAt, updatedAt, ...profile }) => {
                 const [invitation] = invitations;
+
                 return ProviderProfileListing.validate({
                     ...profile,
-                    invitation: invitation ?? null,
+                    invitation: invitation
+                        ? {
+                              ...invitation,
+                              expiresAt:
+                                  invitation.expiresAt?.toISOString() ?? null,
+                          }
+                        : null,
                     createdAt: createdAt.toISOString(),
                     updatedAt: updatedAt.toISOString(),
                 });

--- a/src/lib/shared/components/features/pages/SideNavigationPage/SideNavigationPage.tsx
+++ b/src/lib/shared/components/features/pages/SideNavigationPage/SideNavigationPage.tsx
@@ -23,7 +23,7 @@ export interface SideNavigationPageProps {
     onNavigate: (path: string) => void;
     user?: TherifyUser;
     actionLink?: NavigationLink;
-    isLoadingUser: boolean;
+    isLoadingUser?: boolean;
     children?: React.ReactNode;
 }
 
@@ -35,7 +35,7 @@ export const SideNavigationPage = ({
     onNavigate,
     user,
     actionLink,
-    isLoadingUser,
+    isLoadingUser = false,
     children,
 }: SideNavigationPageProps) => {
     const [isMobileMenuOpen, setIsMobileMenuOpen] = useState(false);

--- a/src/lib/shared/components/ui/FloatingList/FloatingList.tsx
+++ b/src/lib/shared/components/ui/FloatingList/FloatingList.tsx
@@ -21,12 +21,14 @@ interface FloatingListItemProps {
 interface FloatingListProps {
     listItems: FloatingListItemProps[];
     launcherIcon?: React.ReactNode;
+    headerSlot?: React.ReactNode;
     sx?: SxProps<Theme>;
 }
 
 export const FloatingList = ({
     launcherIcon,
     listItems,
+    headerSlot,
     sx,
 }: FloatingListProps) => {
     const [anchorElNav, setAnchorElNav] = useState<null | HTMLElement>(null);
@@ -69,6 +71,9 @@ export const FloatingList = ({
                     '& .MuiList-root': { width: '275px' },
                 }}
             >
+                {headerSlot && (
+                    <ListItem hoverable={false}>{headerSlot}</ListItem>
+                )}
                 {listItems.map(({ icon, onClick, text }, i) => (
                     <ListItem
                         key={i}
@@ -103,7 +108,9 @@ const Text = styled(ListItemText)(() => ({
     },
 }));
 
-const ListItem = styled(MuiListItem)(({ theme }) => ({
+const ListItem = styled(MuiListItem, {
+    shouldForwardProp: (prop) => prop !== 'hoverable',
+})<{ hoverable?: boolean }>(({ theme, hoverable = true }) => ({
     display: 'flex',
     position: 'relative',
     alignItems: 'center',
@@ -116,7 +123,11 @@ const ListItem = styled(MuiListItem)(({ theme }) => ({
     '& .navigation-icon + .MuiListItemText-root': {
         paddingLeft: theme.spacing(7),
     },
-    '&:hover': {
-        backgroundColor: theme.palette.action.hover,
-    },
+    ...(hoverable
+        ? {
+              '&:hover': {
+                  backgroundColor: theme.palette.action.hover,
+              },
+          }
+        : {}),
 }));

--- a/src/lib/shared/types/index.ts
+++ b/src/lib/shared/types/index.ts
@@ -18,6 +18,7 @@ export * from './communities-served';
 export * from './modality';
 export * from './age-group';
 export * from './provider-credential';
+export * from './provider-practice';
 export * from './provider-profile';
 export * from './provider-supervisor';
 export * from './accepted-insurance';

--- a/src/lib/shared/types/provider-practice/index.ts
+++ b/src/lib/shared/types/provider-practice/index.ts
@@ -1,0 +1,1 @@
+export * as ProviderPractice from './providerPractice';

--- a/src/lib/shared/types/provider-practice/providerPractice.ts
+++ b/src/lib/shared/types/provider-practice/providerPractice.ts
@@ -1,0 +1,26 @@
+import * as z from 'zod';
+import { PracticeSchema } from '../../schema';
+
+export const schema = PracticeSchema.pick({
+    id: true,
+    name: true,
+    city: true,
+    state: true,
+    website: true,
+    email: true,
+});
+
+export type Type = z.infer<typeof schema>;
+
+export const validate = (value: unknown): Type => {
+    return schema.parse(value);
+};
+
+export const isValid = (value: unknown): value is Type => {
+    try {
+        validate(value);
+        return true;
+    } catch {
+        return false;
+    }
+};

--- a/src/lib/shared/types/provider-profile/index.ts
+++ b/src/lib/shared/types/provider-profile/index.ts
@@ -1,1 +1,2 @@
 export * as ProviderProfile from './providerProfile';
+export * as ProviderProfileListing from './providerProfileListing';

--- a/src/lib/shared/types/provider-profile/providerProfileListing.ts
+++ b/src/lib/shared/types/provider-profile/providerProfileListing.ts
@@ -7,6 +7,7 @@ import {
 } from '../../schema';
 import { ProviderCredential } from '../provider-credential';
 import { AcceptedInsurance } from '../accepted-insurance';
+import { InvitationStatus } from '@prisma/client';
 
 export const schema = ProviderProfileSchema.pick({
     id: true,
@@ -27,7 +28,14 @@ export const schema = ProviderProfileSchema.pick({
     invitation: PracticeProviderInvitationSchema.omit({
         createdAt: true,
         updatedAt: true,
-    }).nullable(),
+    })
+        .extend({
+            status: z.enum([
+                InvitationStatus.accepted,
+                InvitationStatus.pending,
+            ]),
+        })
+        .nullable(),
     directoryListing: DirectoryListingSchema.omit({
         createdAt: true,
         updatedAt: true,

--- a/src/lib/shared/types/provider-profile/providerProfileListing.ts
+++ b/src/lib/shared/types/provider-profile/providerProfileListing.ts
@@ -21,15 +21,19 @@ export const schema = ProviderProfileSchema.pick({
     offersInPerson: true,
     offersVirtual: true,
     specialties: true,
+    designation: true,
 }).extend({
     pronouns: Pronoun.schema,
     credentials: ProviderCredential.schema.array(),
     acceptedInsurances: AcceptedInsurance.schema.array(),
-    invitation: PracticeProviderInvitationSchema.omit({
-        createdAt: true,
-        updatedAt: true,
+    invitation: PracticeProviderInvitationSchema.pick({
+        id: true,
+        status: true,
+        recipientEmail: true,
+        expiresAt: true,
     })
         .extend({
+            expiresAt: z.string().nullable(),
             status: z.enum([
                 InvitationStatus.accepted,
                 InvitationStatus.pending,

--- a/src/lib/shared/types/provider-profile/providerProfileListing.ts
+++ b/src/lib/shared/types/provider-profile/providerProfileListing.ts
@@ -1,0 +1,49 @@
+import * as z from 'zod';
+import * as Pronoun from '../pronoun';
+import {
+    DirectoryListingSchema,
+    PracticeProviderInvitationSchema,
+    ProviderProfileSchema,
+} from '../../schema';
+import { ProviderCredential } from '../provider-credential';
+import { AcceptedInsurance } from '../accepted-insurance';
+
+export const schema = ProviderProfileSchema.pick({
+    id: true,
+    firstName: true,
+    lastName: true,
+    maximumRate: true,
+    minimumRate: true,
+    createdAt: true,
+    updatedAt: true,
+    profileImageUrl: true,
+    offersInPerson: true,
+    offersVirtual: true,
+    specialties: true,
+})
+    .extend({
+        pronouns: Pronoun.schema,
+        credentials: ProviderCredential.schema.array(),
+        acceptedInsurances: AcceptedInsurance.schema.array(),
+        invitation: PracticeProviderInvitationSchema.nullable(),
+        directoryListing: DirectoryListingSchema,
+    })
+    .omit({
+        createdAt: true,
+        updatedAt: true,
+    });
+
+export type ProviderProfile = z.infer<typeof schema>;
+
+export const validate = (value: unknown): ProviderProfile => {
+    return schema.parse(value);
+};
+
+export const isValid = (value: unknown): value is ProviderProfile => {
+    try {
+        validate(value);
+        return true;
+    } catch {
+        return false;
+    }
+};

--- a/src/lib/shared/types/provider-profile/providerProfileListing.ts
+++ b/src/lib/shared/types/provider-profile/providerProfileListing.ts
@@ -10,8 +10,8 @@ import { AcceptedInsurance } from '../accepted-insurance';
 
 export const schema = ProviderProfileSchema.pick({
     id: true,
-    firstName: true,
-    lastName: true,
+    givenName: true,
+    surname: true,
     maximumRate: true,
     minimumRate: true,
     createdAt: true,
@@ -20,26 +20,29 @@ export const schema = ProviderProfileSchema.pick({
     offersInPerson: true,
     offersVirtual: true,
     specialties: true,
-})
-    .extend({
-        pronouns: Pronoun.schema,
-        credentials: ProviderCredential.schema.array(),
-        acceptedInsurances: AcceptedInsurance.schema.array(),
-        invitation: PracticeProviderInvitationSchema.nullable(),
-        directoryListing: DirectoryListingSchema,
-    })
-    .omit({
+}).extend({
+    pronouns: Pronoun.schema,
+    credentials: ProviderCredential.schema.array(),
+    acceptedInsurances: AcceptedInsurance.schema.array(),
+    invitation: PracticeProviderInvitationSchema.omit({
         createdAt: true,
         updatedAt: true,
-    });
+    }).nullable(),
+    directoryListing: DirectoryListingSchema.omit({
+        createdAt: true,
+        updatedAt: true,
+    }),
+    createdAt: z.string(),
+    updatedAt: z.string(),
+});
 
-export type ProviderProfile = z.infer<typeof schema>;
+export type Type = z.infer<typeof schema>;
 
-export const validate = (value: unknown): ProviderProfile => {
+export const validate = (value: unknown): Type => {
     return schema.parse(value);
 };
 
-export const isValid = (value: unknown): value is ProviderProfile => {
+export const isValid = (value: unknown): value is Type => {
     try {
         validate(value);
         return true;

--- a/src/pages/providers/practice/profiles/index.tsx
+++ b/src/pages/providers/practice/profiles/index.tsx
@@ -348,7 +348,7 @@ export default function PracticeProfilesPage() {
                                                         {profile.invitation
                                                             .status ===
                                                         InvitationStatus.pending
-                                                            ? 'Invitation Pending'
+                                                            ? 'Invitation Sent'
                                                             : 'Profile Claimed'}
                                                     </Badge>
                                                 )}
@@ -700,7 +700,7 @@ const getListingAction = (status?: ListingStatus) => {
         case ListingStatus.unlisted:
         default:
             return {
-                text: 'List Profile',
+                text: 'Publish Profile',
                 icon: <VisibilityRounded />,
                 onClick: () => {
                     console.log('TODO: handle activate');

--- a/src/pages/providers/practice/profiles/index.tsx
+++ b/src/pages/providers/practice/profiles/index.tsx
@@ -87,7 +87,6 @@ export default function PracticeProfilesPage() {
 
     //TODO: Get practice details
     const practiceId = 'cle33hlxp0005v7s8rrpyfh2q';
-    const [showNewProfileModal, setShowNewProfileModal] = useState(false);
     const [invitationProfile, setInvitationProfile] =
         useState<ProviderProfileListing.Type>();
     const [invitationToDelete, setInvitationToDelete] =
@@ -234,7 +233,12 @@ export default function PracticeProfilesPage() {
                         <Box className="admin-controls">
                             {canCreateProfile && (
                                 <Button
-                                    onClick={() => setShowNewProfileModal(true)}
+                                    onClick={() =>
+                                        router.push(
+                                            URL_PATHS.PROVIDERS.PRACTICE
+                                                .PROFILES_CREATE
+                                        )
+                                    }
                                 >
                                     New Profile
                                 </Button>
@@ -253,9 +257,12 @@ export default function PracticeProfilesPage() {
                                 No profiles to show.{' '}
                                 {canCreateProfile && (
                                     <Link
-                                        aria-label="Create a new profile"
+                                        aria-label="Create a profile"
                                         onClick={() =>
-                                            setShowNewProfileModal(true)
+                                            router.push(
+                                                URL_PATHS.PROVIDERS.PRACTICE
+                                                    .PROFILES_CREATE
+                                            )
                                         }
                                     >
                                         Create one!
@@ -392,30 +399,6 @@ export default function PracticeProfilesPage() {
                 </PageContentContainer>
             </LoadingContainer>
 
-            {canCreateProfile && (
-                <Modal
-                    isOpen={showNewProfileModal}
-                    onClose={() => setShowNewProfileModal(false)}
-                    title="Create New Profile"
-                    message="How would you like to create a profile?"
-                    fullWidthButtons
-                    shouldStackButtons
-                    primaryButtonText="Fill out the profile myself"
-                    primaryButtonOnClick={() => {
-                        router.push(
-                            URL_PATHS.PROVIDERS.PRACTICE.PROFILES_CREATE
-                        );
-                    }}
-                    primaryButtonEndIcon={<AddCircleOutlineRounded />}
-                    secondaryButtonText="Invite a provider to create their profile"
-                    secondaryButtonOnClick={() => {
-                        router.push(
-                            URL_PATHS.PROVIDERS.PRACTICE.PROVIDER_INVITE
-                        );
-                    }}
-                    secondaryButtonEndIcon={<SendRounded />}
-                />
-            )}
             {profileToDelete && (
                 <DeleteProfileModal
                     profile={profileToDelete}
@@ -591,9 +574,6 @@ const DeleteInvitaionModal = ({
     profile: ProviderProfileListing.Type;
     isDeleting: boolean;
 }) => {
-    const [value, setValue] = useState('');
-    const providerName = `${profile.givenName} ${profile.surname}`.trim();
-
     return (
         <Modal
             isOpen

--- a/src/pages/providers/practice/profiles/index.tsx
+++ b/src/pages/providers/practice/profiles/index.tsx
@@ -35,7 +35,7 @@ import { RBAC } from '@/lib/shared/utils';
 import { useEffect, useState } from 'react';
 import { ListingStatus, Role } from '@prisma/client';
 import { styled, useTheme } from '@mui/material/styles';
-import { Box, CircularProgress } from '@mui/material';
+import { Box, CircularProgress, Link } from '@mui/material';
 import {
     EditRounded,
     DeleteRounded,
@@ -50,11 +50,12 @@ import {
 import { DirectoryListingSchema } from '@/lib/shared/schema';
 import { z } from 'zod';
 import { trpc } from '@/lib/shared/utils/trpc';
-import { ProviderProfile } from '@/lib/shared/types';
+import { ProviderProfileListing } from '@/lib/shared/types';
 import {
     ListPracticeProfilesByUserId,
     DeleteProviderProfile,
 } from '@/lib/modules/providers/features/profiles';
+import { error } from '@/lib/shared/components/themes/therify-design-system/colors';
 
 export const getServerSideProps = RBAC.requireProviderAuth(
     withPageAuthRequired()
@@ -80,7 +81,7 @@ export default function PracticeProfilesPage() {
     const theme = useTheme();
     const [showNewProfileModal, setShowNewProfileModal] = useState(false);
     const [profileToDelete, setProfileToDelete] =
-        useState<ProviderProfile.ProviderProfile>();
+        useState<ProviderProfileListing.Type>();
     const {
         data,
         error: trpcError,
@@ -115,7 +116,7 @@ export default function PracticeProfilesPage() {
         });
 
     const { profiles, errors } = data ?? {
-        profiles: [] as ProviderProfile.ProviderProfile[],
+        profiles: [] as ProviderProfileListing.Type[],
         errors: [] as string[],
     };
     const isLoading =
@@ -194,12 +195,28 @@ export default function PracticeProfilesPage() {
                             )}
                         </Box>
                     </TitleContainer>
-                    {errorMessage && (
-                        <Alert type="error" title={errorMessage} />
-                    )}
                     <ListTitle>Provider Name</ListTitle>
-                    {profiles.length === 0 && (
-                        <Paragraph>No profiles.</Paragraph>
+                    {errorMessage && (
+                        <Box width="100%" marginTop={4}>
+                            <Alert type="error" title={errorMessage} />
+                        </Box>
+                    )}
+                    {profiles.length === 0 && !errorMessage && (
+                        <Box marginLeft={5} marginTop={4}>
+                            <Paragraph>
+                                No profiles to show.{' '}
+                                {canCreateProfile && (
+                                    <Link
+                                        aria-label="Create a new profile"
+                                        onClick={() =>
+                                            setShowNewProfileModal(true)
+                                        }
+                                    >
+                                        Create one!
+                                    </Link>
+                                )}
+                            </Paragraph>
+                        </Box>
                     )}
                     <ProfileList>
                         {profiles.map((profile) => {
@@ -339,7 +356,7 @@ const DeleteProfileModal = ({
 }: {
     onClose: () => void;
     onDelete: () => void;
-    profile: ProviderProfile.ProviderProfile;
+    profile: ProviderProfileListing.Type;
     isDeleting: boolean;
 }) => {
     const [value, setValue] = useState('');
@@ -423,7 +440,7 @@ const ProfileActions = ({
     onDelete,
     onInvite,
 }: {
-    profile: ProviderProfile.ProviderProfile & {
+    profile: ProviderProfileListing.Type & {
         directoryListing?: z.infer<typeof DirectoryListingSchema>;
     };
     onDelete: () => void;


### PR DESCRIPTION
# Description
Allows providers to be invited to claim a profile

# Closes issue(s)
[Trello: Practice Provider invitations](https://trello.com/c/P9ymmEKU)

# How to test / repro
Go tp practice providers page, create a profile and invite a user.

# Screenshots
#### Invite provider modal
![image](https://user-images.githubusercontent.com/25045075/218854410-279fbe38-906c-4bc5-ab85-d13a14aad694.png)
#### Invitation pending badge
![image](https://user-images.githubusercontent.com/25045075/218854156-16251445-87c6-4c69-8337-0dc09fb0adf9.png)
### Cancel Invitation(delete)
![image](https://user-images.githubusercontent.com/25045075/218854262-1f31ee83-bde6-4cc4-8ed7-0edcd45e5920.png)
#### Accepted invitation
![image](https://user-images.githubusercontent.com/25045075/218854795-90eb3fca-e223-40b9-9fa3-cdd4978fa4b3.png)

#### Mobile
![image](https://user-images.githubusercontent.com/25045075/218854683-454aabba-afb9-4235-a680-e750e8f33c45.png)


# Changes include

-   [ ] Bugfix (non-breaking change that solves an issue)
-   [x] New feature (non-breaking change that adds functionality)
-   [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Checklist

-   [ ] I have tested this code
-   [ ] I have updated the Readme

# Other comments
Follow up: Send email to recipient on invitation create