### PR TITLE
feat: add directory listing update functionality

### DIFF
--- a/src/lib/modules/providers/features/profiles/index.ts
+++ b/src/lib/modules/providers/features/profiles/index.ts
@@ -4,3 +4,4 @@ export * as CreateProviderProfileForPractice from './create-provider-profile-for
 export * as UpdateProviderProfile from './update-provider-profile';
 export * as DeleteProviderProfile from './delete-provider-profile';
 export * as ListPracticeProfilesByUserId from './list-practice-profiles-by-user-id';
+export * as UpdateDirectoryListing from './update-directory-listing';

--- a/src/lib/modules/providers/features/profiles/update-directory-listing/index.ts
+++ b/src/lib/modules/providers/features/profiles/update-directory-listing/index.ts
@@ -1,0 +1,5 @@
+export { ROUTE as TRPC_ROUTE } from './trpc';
+export { schema as inputSchema } from './input';
+export type { Input } from './input';
+export { schema as outputSchema } from './output';
+export type { Output } from './output';

--- a/src/lib/modules/providers/features/profiles/update-directory-listing/input.ts
+++ b/src/lib/modules/providers/features/profiles/update-directory-listing/input.ts
@@ -1,0 +1,23 @@
+import { DirectoryListingSchema } from '@/lib/shared/schema';
+import * as z from 'zod';
+
+export const schema = z.object({
+    profileId: z.string(),
+    status: DirectoryListingSchema.shape.status,
+    userId: z.string(),
+});
+
+export type Input = z.infer<typeof schema>;
+
+export const validate = (value: unknown): Input => {
+    return schema.parse(value);
+};
+
+export const isValid = (value: unknown): value is Input => {
+    try {
+        validate(value);
+        return true;
+    } catch {
+        return false;
+    }
+};

--- a/src/lib/modules/providers/features/profiles/update-directory-listing/output.ts
+++ b/src/lib/modules/providers/features/profiles/update-directory-listing/output.ts
@@ -1,0 +1,21 @@
+import * as z from 'zod';
+
+export const schema = z.object({
+    success: z.boolean(),
+    errors: z.array(z.string()),
+});
+
+export type Output = z.infer<typeof schema>;
+
+export const validate = (value: unknown): Output => {
+    return schema.parse(value);
+};
+
+export const isValid = (value: unknown): value is Output => {
+    try {
+        validate(value);
+        return true;
+    } catch {
+        return false;
+    }
+};

--- a/src/lib/modules/providers/features/profiles/update-directory-listing/trpc.ts
+++ b/src/lib/modules/providers/features/profiles/update-directory-listing/trpc.ts
@@ -1,0 +1,1 @@
+export const ROUTE = 'profiles.update-directory-listing' as const;

--- a/src/lib/modules/providers/routes/resolvers/index.ts
+++ b/src/lib/modules/providers/routes/resolvers/index.ts
@@ -6,3 +6,4 @@ export { deleteProviderProfileResolver } from './delete-provider-profile';
 export { createProviderProfileForPracticeResolver } from './create-provider-profile-for-practice';
 
 export { createPracticeProviderInvitationResolver } from './create-practice-provider-invitation';
+export { updateDirectoryListingResolver } from './update-directory-listing';

--- a/src/lib/modules/providers/routes/resolvers/update-directory-listing/index.ts
+++ b/src/lib/modules/providers/routes/resolvers/update-directory-listing/index.ts
@@ -1,0 +1,1 @@
+export { resolve as updateDirectoryListingResolver } from './resolver';

--- a/src/lib/modules/providers/routes/resolvers/update-directory-listing/resolver.ts
+++ b/src/lib/modules/providers/routes/resolvers/update-directory-listing/resolver.ts
@@ -1,14 +1,14 @@
 import { Context } from '@/lib/server/context';
-import { UpdateProviderProfile } from '@/lib/modules/providers/features/profiles';
+import { UpdateDirectoryListing } from '@/lib/modules/providers/features/profiles';
 import { ProcedureResolver } from '@trpc/server/dist/declarations/src/internals/procedure';
 
 export const resolve: ProcedureResolver<
     Context,
-    UpdateProviderProfile.Input,
-    UpdateProviderProfile.Output
-> = async function ({ input, ctx }): Promise<UpdateProviderProfile.Output> {
+    UpdateDirectoryListing.Input,
+    UpdateDirectoryListing.Output
+> = async function ({ input, ctx }): Promise<UpdateDirectoryListing.Output> {
     try {
-        const { success } = await ctx.providers.profiles.updateProviderProfile(
+        const { success } = await ctx.providers.profiles.updateDirectoryListing(
             input
         );
         return {
@@ -17,7 +17,7 @@ export const resolve: ProcedureResolver<
         };
     } catch (error) {
         console.log(error);
-        let errorMessage = 'Update profile failed.';
+        let errorMessage = 'Update directory listing failed.';
         if (error instanceof Error) {
             errorMessage = error.message;
         }

--- a/src/lib/modules/providers/routes/router.ts
+++ b/src/lib/modules/providers/routes/router.ts
@@ -8,6 +8,7 @@ import {
     updateProviderProfileResolver,
     deleteProviderProfileResolver,
     createPracticeProviderInvitationResolver,
+    updateDirectoryListingResolver,
 } from './resolvers';
 import { Context } from '@/lib/server/context';
 import {
@@ -17,6 +18,7 @@ import {
     GetProviderProfileById,
     UpdateProviderProfile,
     DeleteProviderProfile,
+    UpdateDirectoryListing,
 } from '@/lib/modules/providers/features/profiles';
 import {
     CreatePracticeProviderInvitation,
@@ -45,6 +47,11 @@ export const router = trpc
         input: CreateProviderProfileForPractice.inputSchema,
         output: CreateProviderProfileForPractice.outputSchema,
         resolve: createProviderProfileForPracticeResolver,
+    })
+    .mutation(UpdateDirectoryListing.TRPC_ROUTE, {
+        input: UpdateDirectoryListing.inputSchema,
+        output: UpdateDirectoryListing.outputSchema,
+        resolve: updateDirectoryListingResolver,
     })
     .mutation(UpdateProviderProfile.TRPC_ROUTE, {
         input: UpdateProviderProfile.inputSchema,

--- a/src/lib/modules/providers/service/profiles/index.ts
+++ b/src/lib/modules/providers/service/profiles/index.ts
@@ -5,6 +5,7 @@ import { GetProfileByUserId } from './get-profile-by-user-id';
 import { GetProfileById } from './get-profile-by-id';
 import { UpdateProviderProfile } from './update-provider-profile';
 import { DeleteProviderProfile } from './delete-provider-profile';
+import { UpdateDirectoryListing } from './update-directory-listing';
 
 export const profilesFactory = (params: ProvidersServiceParams) => ({
     createProfileForPractice: CreateProviceProfileForPractice.factory(params),
@@ -13,4 +14,5 @@ export const profilesFactory = (params: ProvidersServiceParams) => ({
     getProfileById: GetProfileById.factory(params),
     updateProviderProfile: UpdateProviderProfile.factory(params),
     deleteProviderProfile: DeleteProviderProfile.factory(params),
+    updateDirectoryListing: UpdateDirectoryListing.factory(params),
 });

--- a/src/lib/modules/providers/service/profiles/update-directory-listing/index.ts
+++ b/src/lib/modules/providers/service/profiles/update-directory-listing/index.ts
@@ -1,0 +1,1 @@
+export * as UpdateDirectoryListing from './updateDirectoryListing';

--- a/src/lib/modules/providers/service/profiles/update-directory-listing/updateDirectoryListing.ts
+++ b/src/lib/modules/providers/service/profiles/update-directory-listing/updateDirectoryListing.ts
@@ -1,0 +1,48 @@
+import { ProvidersServiceParams } from '../../params';
+import { UpdateDirectoryListing } from '@/lib/modules/providers/features/profiles';
+
+export function factory({ prisma }: ProvidersServiceParams) {
+    return async function ({
+        userId,
+        profileId,
+        status,
+    }: UpdateDirectoryListing.Input): Promise<{
+        success: UpdateDirectoryListing.Output['success'];
+    }> {
+        const { managedPractice } = await prisma.user.findUniqueOrThrow({
+            where: {
+                id: userId,
+            },
+            select: {
+                managedPractice: {
+                    select: {
+                        id: true,
+                    },
+                },
+            },
+        });
+
+        if (!managedPractice) {
+            throw new Error('User is not a practice owner.');
+        }
+
+        const { count } = await prisma.directoryListing.updateMany({
+            where: {
+                practiceId: managedPractice.id,
+                providerProfileId: profileId,
+            },
+            data: {
+                status,
+            },
+        });
+        if (count === 0) {
+            throw new Error(
+                'Directory listing not updated. Update count is 0.'
+            );
+        }
+
+        return {
+            success: count > 0,
+        };
+    };
+}


### PR DESCRIPTION
# Description
Adds `updateDirectoryListing` funtionality: Feature, providers service method, resolver, and TRPC mutation
Updates Practice Profiles UI to allow `ListingStatus`updates (`listed` and `unlisted`, no `pending` support for now)

# Closes issue(s)

# How to test / repro
- Log in as practice admin and 
- Visit `/providers/practice/profiles`
- List/unlist profiles in the list. 
- 
# Screenshots
![image](https://user-images.githubusercontent.com/25045075/219130367-0595ce64-d67f-40dc-9ca3-ee995946a62e.png)
![image](https://user-images.githubusercontent.com/25045075/219130398-d52c7226-5f7c-4acf-bf6d-01d978972a1b.png)
![image](https://user-images.githubusercontent.com/25045075/219130444-62d2b4bb-841f-480a-931a-12ee4ab81774.png)

# Changes include

-   [ ] Bugfix (non-breaking change that solves an issue)
-   [x] New feature (non-breaking change that adds functionality)
-   [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Checklist

-   [ ] I have tested this code
-   [ ] I have updated the Readme

# Other comments
