### PR TITLE
fix: set role cookie on first login

### DIFF
--- a/src/pages/api/auth/logout.ts
+++ b/src/pages/api/auth/logout.ts
@@ -1,4 +1,5 @@
 import { getUrls } from '@/lib/shared/utils';
+import nookies from 'nookies';
 import { handleLogout, LogoutHandlerError } from '@auth0/nextjs-auth0';
 import { NextApiRequest, NextApiResponse } from 'next';
 
@@ -8,6 +9,7 @@ export default async function login(req: NextApiRequest, res: NextApiResponse) {
         await handleLogout(req, res, {
             returnTo: returnTo,
         });
+        nookies.destroy({ res }, 'userRoles');
         res.end();
     } catch (error) {
         if (error instanceof LogoutHandlerError) {

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -18,7 +18,6 @@ import { getSession } from '@auth0/nextjs-auth0';
 import { AccountsService } from '@/lib/modules/accounts/service';
 import { Role } from '@prisma/client';
 import { TherifyUser } from '@/lib/shared/types';
-import { useTherifyUser } from '@/lib/shared/hooks';
 
 const ABSTRACT_SHAPE_URL =
     'https://res.cloudinary.com/dbrkfldqn/image/upload/v1673455675/app.therify.co/shapes/abstract-shape_fbvcil.svg' as const;

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useState } from 'react';
+import nookies, { destroyCookie } from 'nookies';
 import { TwoColumnGrid } from '@/lib/shared/components/ui/Grids/TwoColumnGrid';
 import {
     Caption,
@@ -17,6 +18,7 @@ import { getSession } from '@auth0/nextjs-auth0';
 import { AccountsService } from '@/lib/modules/accounts/service';
 import { Role } from '@prisma/client';
 import { TherifyUser } from '@/lib/shared/types';
+import { useTherifyUser } from '@/lib/shared/hooks';
 
 const ABSTRACT_SHAPE_URL =
     'https://res.cloudinary.com/dbrkfldqn/image/upload/v1673455675/app.therify.co/shapes/abstract-shape_fbvcil.svg' as const;
@@ -56,7 +58,6 @@ const getUserRedirectPath = (user: TherifyUser.TherifyUser): string => {
 
 export const getServerSideProps: GetServerSideProps = async (context) => {
     const session = await getSession(context.req, context.res);
-    console.log({ session });
     if (!session) {
         return {
             props: {
@@ -69,12 +70,18 @@ export const getServerSideProps: GetServerSideProps = async (context) => {
     });
 
     if (!user) {
-        console.info('User not found');
         return {
             props: {
                 user: null,
             },
         };
+    }
+    const cookies = nookies.get(context);
+    if (!cookies.userRoles) {
+        nookies.set(context, 'userRoles', user.roles.join(','), {
+            maxAge: 30 * 24 * 60 * 60,
+            path: '/',
+        });
     }
 
     return {
@@ -85,7 +92,11 @@ export const getServerSideProps: GetServerSideProps = async (context) => {
     };
 };
 
-export default function Home() {
+export default function Home({
+    user,
+}: {
+    user: TherifyUser.TherifyUser | null;
+}) {
     const theme = useTheme();
     const router = useRouter();
     const [randomLoginImage, setRandomLoginImage] = useState<string | null>(
@@ -96,6 +107,11 @@ export default function Home() {
             LOGIN_IMAGES[Math.floor(Math.random() * LOGIN_IMAGES.length)]
         );
     }, []);
+    useEffect(() => {
+        if (user === null) {
+            destroyCookie(null, 'userRoles');
+        }
+    }, [user]);
 
     return (
         <TwoColumnGrid


### PR DESCRIPTION
# Description
## The problem
Initial logins were resulting in a 404 redired. This is because when the index page's server-side routing occurs after initial login,  user would get routed to the appropriate landing page, but that page's RBAC protection would redirect to 404. This is because the role cookie hadn't been set yet. This cookie was getting set on the client side through the `TherifyUser` context so the initial RBAC protect always failed.

## Solution
Solution: Add a cookie check to the index page's getServerSideProps method and set cookie when not present on first login. 

Adds cookie destruction on the client side Login page, because this page only loads when a user is not present, and in the logout API route.

# Closes issue(s)
[Bug: 404 Page in Sign In](https://trello.com/c/z1TFXho5)
# How to test / repro
Open a new incognito browser window and login to the app to see the correct page load and not a 404 page. The fresh browser ensures no cookies are present at sign-in.

# Screenshots
![image](https://user-images.githubusercontent.com/25045075/219298659-c38ab0b5-6044-46a7-8663-d40ee344b156.png)

# Changes include

-   [x] Bugfix (non-breaking change that solves an issue)
-   [ ] New feature (non-breaking change that adds functionality)
-   [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Checklist

-   [ ] I have tested this code
-   [ ] I have updated the Readme

# Other comments
