### PR TITLE
chore: hide practice on therify therapist profile

### DIFF
--- a/src/lib/modules/directory/components/ProviderProfile/ProviderProfile.tsx
+++ b/src/lib/modules/directory/components/ProviderProfile/ProviderProfile.tsx
@@ -29,7 +29,7 @@ import {
 } from '@mui/icons-material';
 import { Box, Chip, Link, Stack, useMediaQuery } from '@mui/material';
 import { styled, Theme } from '@mui/material/styles';
-import { Practice, ProfileType } from '@prisma/client';
+import { ProfileType } from '@prisma/client';
 import { getYear, intervalToDuration } from 'date-fns';
 import { ConnectionWidget } from '../ConnectionWidget/ConnectionWidget';
 import { CalloutBanner } from './CalloutBanner';
@@ -80,6 +80,12 @@ export function ProviderProfile({
     onConnectionRequest,
 }: ProviderProfileProps & ProviderProfileType.ProviderProfile) {
     const isTherapist = designation === ProfileType.therapist;
+    // TODO: Remove `isTherifyTherapist` once we have distributed therapist profiles after launch.
+    //This is a temporary fix to prevent showing "Therify"
+    // as a practice for therapist profiles that are still in the process
+    // of being migrated to their respective practices.
+    const isTherifyTherapist =
+        isTherapist && practice?.name.toLowerCase().includes('therify');
     const isSmallScreen = useMediaQuery((theme: Theme) =>
         theme.breakpoints.down('sm')
     );
@@ -163,7 +169,7 @@ export function ProviderProfile({
                                 {designation === ProfileType.therapist
                                     ? 'Therapist'
                                     : 'Mental Health Coach'}
-                                {practice && (
+                                {practice && !isTherifyTherapist && (
                                     <>
                                         {'  '} at{'  '}
                                         {practice.website ? (
@@ -267,7 +273,7 @@ export function ProviderProfile({
                                     )}`}
                                 />
                             )}
-                        {offersInPerson && practice && (
+                        {offersInPerson && practice && !isTherifyTherapist && (
                             <CalloutBanner
                                 icon={<PersonPinCircleOutlined />}
                                 title={`In-person sessions in ${practice.city}, ${practice.state}`}


### PR DESCRIPTION
# Description
Therify Therapist profiles in prod are temporary until we can onboard their respective practices. Because of this, we don't want to misrepresent them as belonging to Therify. 

This PR hides practice details on therapist-designated profiles that belong to Therify's practice
# Closes issue(s)
[Trello: Hide practice details on Therify therapist profiles](https://trello.com/c/kZi5ZTt3)
# How to test / repro
Go to editor as a therify provider and change profile designation to therapist

# Screenshots
![image](https://user-images.githubusercontent.com/25045075/219307144-8f0451fe-187f-4733-930e-b59c2f0c16fe.png)

# Changes include

-   [x] Bugfix (non-breaking change that solves an issue)
-   [ ] New feature (non-breaking change that adds functionality)
-   [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Checklist

-   [ ] I have tested this code
-   [ ] I have updated the Readme

# Other comments
