### PR TITLE
chore: add stopgap content library

### DIFF
--- a/src/lib/modules/members/service/get-therify-user-props/getTherifyUserProps.ts
+++ b/src/lib/modules/members/service/get-therify-user-props/getTherifyUserProps.ts
@@ -1,0 +1,42 @@
+import { TherifyUser } from '@/lib/shared/types/therify-user';
+import { getSession } from '@auth0/nextjs-auth0';
+import { GetServerSideProps } from 'next';
+import { MembersServiceParams } from '../params';
+import { URL_PATHS } from '@/lib/sitemap';
+import { GetMemberTherifyUser } from '../get-member-therify-user';
+
+export interface MemberTherifyUserPageProps {
+    user: TherifyUser.TherifyUser;
+}
+
+export const factory = (params: MembersServiceParams) => {
+    const getMemberTherifyUserPageProps: GetServerSideProps<
+        MemberTherifyUserPageProps
+    > = async (context) => {
+        const session = await getSession(context.req, context.res);
+        if (!session) {
+            return {
+                redirect: {
+                    destination: URL_PATHS.AUTH.LOGIN,
+                    permanent: false,
+                },
+            };
+        }
+        const getUser = GetMemberTherifyUser.factory(params);
+        const { user } = await getUser({ userId: session.user.sub });
+
+        if (user === null) {
+            return {
+                redirect: {
+                    destination: URL_PATHS.AUTH.LOGIN,
+                    permanent: false,
+                },
+            };
+        }
+        const props: MemberTherifyUserPageProps = {
+            user,
+        };
+        return JSON.parse(JSON.stringify({ props }));
+    };
+    return getMemberTherifyUserPageProps;
+};

--- a/src/lib/modules/members/service/get-therify-user-props/index.ts
+++ b/src/lib/modules/members/service/get-therify-user-props/index.ts
@@ -1,0 +1,2 @@
+export * as GetTherifyUserPageProps from './getTherifyUserProps';
+export type { MemberTherifyUserPageProps } from './getTherifyUserProps';

--- a/src/lib/modules/members/service/index.ts
+++ b/src/lib/modules/members/service/index.ts
@@ -8,6 +8,7 @@ import { GetDirectoryProfilePageProps } from './get-directory-profile-props';
 import { FavoriteProfile } from './favorite-profile';
 import { GetFavoritesPageProps } from './get-favorites-page-props';
 import { GetMemberTherifyUser } from './get-member-therify-user';
+import { GetTherifyUserPageProps } from './get-therify-user-props';
 
 const factoryParams: MembersServiceParams = {
     prisma,
@@ -15,6 +16,7 @@ const factoryParams: MembersServiceParams = {
 };
 export const membersService = {
     getTherifyUser: GetMemberTherifyUser.factory(factoryParams),
+    getTherifyUserPageProps: GetTherifyUserPageProps.factory(factoryParams),
     selfAssessments: selfAssessmentsFactory(factoryParams),
     getHomePageProps: GetHomePageProps.factory(factoryParams),
     getDirectoryPageProps: GetDirectoryPageProps.factory(factoryParams),

--- a/src/lib/shared/components/ui/Navigation/TopNavigationBar/TopNavigationBar.tsx
+++ b/src/lib/shared/components/ui/Navigation/TopNavigationBar/TopNavigationBar.tsx
@@ -50,7 +50,14 @@ export const TopNavigationBar = ({
                         );
                         return (
                             <LinkItem key={link.path}>
-                                <Link href={link.path}>
+                                <Link
+                                    href={link.path}
+                                    target={
+                                        link.path.startsWith('http')
+                                            ? '_blank'
+                                            : undefined
+                                    }
+                                >
                                     {link.displayName}
                                     {isPathActive && (
                                         <ActiveTab

--- a/src/lib/sitemap/menus/member-menu/links.ts
+++ b/src/lib/sitemap/menus/member-menu/links.ts
@@ -22,5 +22,6 @@ export const DIRECTORY: NavigationLink = {
 export const CONTENT_LIBRARY: NavigationLink = {
     icon: NAVIGATION_ICON.LIBRARY,
     displayName: 'Library',
-    path: URL_PATHS.CONTENT.LIBRARY,
+    path: URL_PATHS.EXTERNAL.VIMEO.CHANNEL,
+    // path: URL_PATHS.MEMBERS.CONTENT.LIBRARY,
 } as const;

--- a/src/lib/sitemap/urlPaths.ts
+++ b/src/lib/sitemap/urlPaths.ts
@@ -2,7 +2,6 @@ import { API_PATHS } from './urls/api';
 import { AUTHENTICATION_PATHS } from './urls/authentication';
 import { MEMBER_PATHS } from './urls/members';
 import { DIRECTORY_PATHS } from './urls/directory';
-import { CONTENT_PATHS } from './urls/content';
 import { PROVIDERS_PATHS } from './urls/providers';
 import { EXTERNAL_URLS } from './urls/external';
 
@@ -12,7 +11,6 @@ export const URL_PATHS = {
     PROVIDERS: PROVIDERS_PATHS,
     MEMBERS: MEMBER_PATHS,
     DIRECTORY: DIRECTORY_PATHS,
-    CONTENT: CONTENT_PATHS,
     EXTERNAL: EXTERNAL_URLS,
     404: '/404',
     ROOT: '/',

--- a/src/lib/sitemap/urls/external/index.ts
+++ b/src/lib/sitemap/urls/external/index.ts
@@ -5,4 +5,7 @@ export const EXTERNAL_URLS = {
         FOR_EMPLOYERS: 'https://therify.co/employers',
         ABOUT: 'https://therify.co/about',
     },
+    VIMEO: {
+        CHANNEL: 'https://vimeo.com/user/193734284/folder/14788097',
+    },
 } as const;

--- a/src/lib/sitemap/urls/members/content/index.ts
+++ b/src/lib/sitemap/urls/members/content/index.ts
@@ -1,3 +1,3 @@
 export const CONTENT_PATHS = {
-    LIBRARY: '/content/library',
+    LIBRARY: '/members/content/library',
 } as const;

--- a/src/lib/sitemap/urls/members/index.ts
+++ b/src/lib/sitemap/urls/members/index.ts
@@ -1,7 +1,10 @@
+import { CONTENT_PATHS } from './content';
+
 export const MEMBER_PATHS = {
     REGISTER: '/members/register',
     REGISTER_SUCCESS: '/members/register/success',
     HOME: './members/home',
     FAVORITES: '/members/favorites',
     DIRECTORY: '/members/directory',
+    CONTENT: CONTENT_PATHS,
 } as const;

--- a/src/pages/members/content/library.tsx
+++ b/src/pages/members/content/library.tsx
@@ -1,0 +1,28 @@
+import { MemberNavigationPage } from '@/lib/shared/components/features/pages/MemberNavigationPage';
+import { membersService } from '@/lib/modules/members/service';
+import { URL_PATHS } from '@/lib/sitemap/urlPaths';
+import { RBAC } from '@/lib/shared/utils';
+import { withPageAuthRequired } from '@auth0/nextjs-auth0';
+import { styled } from '@mui/material/styles';
+import React from 'react';
+import { MemberTherifyUserPageProps } from '@/lib/modules/members/service/get-therify-user-props';
+import { CenteredContainer, H1 } from '@/lib/shared/components/ui';
+
+export const getServerSideProps = RBAC.requireMemberAuth(
+    withPageAuthRequired({
+        getServerSideProps: membersService.getTherifyUserPageProps,
+    })
+);
+
+export default function ContentLibrary({ user }: MemberTherifyUserPageProps) {
+    return (
+        <MemberNavigationPage
+            currentPath={URL_PATHS.MEMBERS.CONTENT.LIBRARY}
+            user={user}
+        >
+            <CenteredContainer fillSpace>
+                <H1>Coming soon</H1>
+            </CenteredContainer>
+        </MemberNavigationPage>
+    );
+}


### PR DESCRIPTION
# Description
Turns out, Vimeo does not allow channels to be loaded in an iframe. 

Adds placeholder content page (not used).
Adds an external link to Therify Vimeo account and ability to open in a new window from Top Navigation bar
Adds GetMemberTherifyUserProps for `TODO:` content page

# Closes issue(s)
[Content Library](https://trello.com/c/orbmtFLy)
# How to test / repro
Log in as member and click `Library` in the top bar
# Screenshots
![image](https://user-images.githubusercontent.com/25045075/219322955-de136a32-0173-457e-b383-9b36e943855f.png)

# Changes include

-   [ ] Bugfix (non-breaking change that solves an issue)
-   [ ] New feature (non-breaking change that adds functionality)
-   [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Checklist

-   [ ] I have tested this code
-   [ ] I have updated the Readme

# Other comments
