### PR TITLE
chore: remove auth0 email verification

### DIFF
--- a/src/lib/modules/accounts/service/service/register-member/transaction/createAuth0User.ts
+++ b/src/lib/modules/accounts/service/service/register-member/transaction/createAuth0User.ts
@@ -1,11 +1,13 @@
-import { withNodeEnvironmentConfiguration } from '@/lib/shared/configuration';
+// import { withNodeEnvironmentConfiguration } from '@/lib/shared/configuration';
 import { TRANSACTION_STEPS, RegisterMemberTransaction } from './definition';
 
 export const createAuth0User: RegisterMemberTransaction['CREATE_AUTH0_USER'] = {
     async commit(input, { auth0 }) {
-        const shouldVerifyEmail = withNodeEnvironmentConfiguration(
-            (CONFIG) => CONFIG.NODE_ENV === 'production'
-        );
+        // TODO: Turn back on when Auth0 email is designed
+        // const shouldVerifyEmail = withNodeEnvironmentConfiguration(
+        //     (CONFIG) => CONFIG.NODE_ENV === 'production'
+        // );
+        const shouldVerifyEmail = false;
         const user = await auth0.createUser({
             email: input.emailAddress,
             password: input.password,
@@ -17,7 +19,7 @@ export const createAuth0User: RegisterMemberTransaction['CREATE_AUTH0_USER'] = {
         };
     },
     async rollback(
-        input,
+        _,
         { auth0 },
         { [TRANSACTION_STEPS.CREATE_AUTH0_USER]: { auth0UserId } }
     ) {

--- a/src/lib/modules/accounts/service/service/register-provider-with-invitation/transaction/createAuth0User.ts
+++ b/src/lib/modules/accounts/service/service/register-provider-with-invitation/transaction/createAuth0User.ts
@@ -11,11 +11,15 @@ interface CreateAuth0UserFactory {
 export const factory: CreateAuth0UserFactory = ({ emailAddress, password }) => {
     return {
         async commit({ auth0 }) {
+            // TODO: Turn back on when Auth0 email is designed
+            // const shouldVerifyEmail = withNodeEnvironmentConfiguration(
+            //     (CONFIG) => CONFIG.NODE_ENV === 'production'
+            // );
+            const shouldVerifyEmail = false;
             const { user_id: auth0UserId } = await auth0.createUser({
                 email: emailAddress,
                 password,
-                verify_email:
-                    getNodeEnvironmentConfiguration().NODE_ENV === 'production',
+                verify_email: shouldVerifyEmail,
             });
             if (!auth0UserId) throw new Error('No Auth0 user ID was returned.');
             return {

--- a/src/lib/modules/accounts/service/service/register-provider/transaction/createAuth0User.ts
+++ b/src/lib/modules/accounts/service/service/register-provider/transaction/createAuth0User.ts
@@ -11,11 +11,15 @@ interface CreateAuth0UserFactory {
 export const factory: CreateAuth0UserFactory = ({ emailAddress, password }) => {
     return {
         async commit({ auth0 }) {
+            // TODO: Turn back on when Auth0 email is designed
+            // const shouldVerifyEmail = withNodeEnvironmentConfiguration(
+            //     (CONFIG) => CONFIG.NODE_ENV === 'production'
+            // );
+            const shouldVerifyEmail = false;
             const { user_id: auth0UserId } = await auth0.createUser({
                 email: emailAddress,
                 password,
-                verify_email:
-                    getNodeEnvironmentConfiguration().NODE_ENV === 'production',
+                verify_email: shouldVerifyEmail,
             });
             if (!auth0UserId) throw new Error('No Auth0 user ID was returned.');
             return {

--- a/src/lib/modules/registration/components/MemberRegistrationSuccess/MemberRegistrationSuccess.tsx
+++ b/src/lib/modules/registration/components/MemberRegistrationSuccess/MemberRegistrationSuccess.tsx
@@ -12,9 +12,9 @@ import {
     CenteredContainer,
 } from '@/lib/shared/components/ui';
 import { useRouter } from 'next/router';
-import { useEmailVerification } from '@/lib/modules/registration/components/MemberRegistrationFlow/hooks';
+// import { useEmailVerification } from '@/lib/modules/registration/components/MemberRegistrationFlow/hooks';
 import { ReactNode } from 'react';
-import { motion } from 'framer-motion';
+// import { motion } from 'framer-motion';
 import { URL_PATHS } from '@/lib/sitemap';
 
 interface MemberRegistrationSuccessProps {
@@ -28,32 +28,32 @@ export const MemberRegistrationSuccess = ({
 }: MemberRegistrationSuccessProps) => {
     const theme = useTheme();
     const router = useRouter();
-    const {
-        getVerificationEmailSentStatus,
-        sendVerificationEmail,
-        emailStatus,
-    } = useEmailVerification(userId?.toString());
-    if (!(email && userId)) {
-        return (
-            <CenteredContainer fillSpace>
-                <Box width="100%" maxWidth="800px">
-                    <ErrorAlert
-                        title="Oh no! Something went wrong."
-                        message={
-                            "Looks like you're missing details in your registration link. Try checking the email you registered with to see if you have login instructions from us. If not, try logging in. If that doesn't work, you can alway try registering again."
-                        }
-                    />
-                </Box>
-            </CenteredContainer>
-        );
-    }
+    // const {
+    //     getVerificationEmailSentStatus,
+    //     sendVerificationEmail,
+    //     emailStatus,
+    // } = useEmailVerification(userId?.toString());
+    // if (!(email && userId)) {
+    //     return (
+    //         <CenteredContainer fillSpace>
+    //             <Box width="100%" maxWidth="800px">
+    //                 <ErrorAlert
+    //                     title="Oh no! Something went wrong."
+    //                     message={
+    //                         "Looks like you're missing details in your registration link. Try checking the email you registered with to see if you have login instructions from us. If not, try logging in. If that doesn't work, you can alway try registering again."
+    //                     }
+    //                 />
+    //             </Box>
+    //         </CenteredContainer>
+    //     );
+    // }
 
-    const errorMessage =
-        sendVerificationEmail.error || getVerificationEmailSentStatus.error;
-    const isVerificationEmailSent = emailStatus === 'completed';
+    // const errorMessage =
+    //     sendVerificationEmail.error || getVerificationEmailSentStatus.error;
+    // const isVerificationEmailSent = emailStatus === 'completed';
 
-    const isVerificationEmailLoading =
-        sendVerificationEmail.isLoading || emailStatus === 'pending';
+    // const isVerificationEmailLoading =
+    //     sendVerificationEmail.isLoading || emailStatus === 'pending';
 
     return (
         <CelebrationContainer
@@ -79,15 +79,18 @@ export const MemberRegistrationSuccess = ({
                 <CheckIcon sx={{ fontSize: 100 }} />
                 <H1>You did it!</H1>
                 <Paragraph>
+                    You have successfully registered with Therify!
+                </Paragraph>
+                {/* <Paragraph>
                     You have successfully registered with Therify! Please check{' '}
                     <b>{email}</b> for instructions on how to verify your
                     account. If you don&apos;t see an email from Therify, check
                     your spam folder. If you still can&apos;t find it, resend
                     your verification email.
-                </Paragraph>
+                </Paragraph> */}
 
                 <Box maxWidth="800px" width="100%" display="flex">
-                    <Button
+                    {/* <Button
                         onClick={() => sendVerificationEmail.send()}
                         isLoading={isVerificationEmailLoading}
                         disabled={isVerificationEmailSent}
@@ -103,7 +106,7 @@ export const MemberRegistrationSuccess = ({
                         {isVerificationEmailSent
                             ? 'Verification email sent!'
                             : 'Resend verification email'}
-                    </Button>
+                    </Button> */}
                     <Button
                         onClick={() => router.push(URL_PATHS.AUTH.LOGIN)}
                         style={{
@@ -117,8 +120,7 @@ export const MemberRegistrationSuccess = ({
                     </Button>
                 </Box>
                 <Paragraph style={{ marginTop: theme.spacing(4) }}>
-                    If you need support verifying your email, please contact us
-                    at{' '}
+                    If you need support, please contact us at{' '}
                     <Link
                         href="mailto:help@therify.co?subject=Email%20Verification%20Support"
                         style={{
@@ -130,7 +132,7 @@ export const MemberRegistrationSuccess = ({
                     </Link>
                     .
                 </Paragraph>
-                {errorMessage && (
+                {/* {errorMessage && (
                     <motion.div
                         initial={{ opacity: 0, scale: 0.7 }}
                         animate={{ opacity: 1, scale: 1 }}
@@ -138,7 +140,7 @@ export const MemberRegistrationSuccess = ({
                     >
                         <ErrorAlert title={errorMessage ?? ''} darker />
                     </motion.div>
-                )}
+                )} */}
             </Box>
         </CelebrationContainer>
     );

--- a/src/lib/modules/registration/components/ProviderRegistrationSuccess/ProviderRegistrationSuccess.tsx
+++ b/src/lib/modules/registration/components/ProviderRegistrationSuccess/ProviderRegistrationSuccess.tsx
@@ -28,32 +28,32 @@ export const ProviderRegistrationSuccess = ({
 }: ProviderRegistrationSuccessProps) => {
     const theme = useTheme();
     const router = useRouter();
-    const {
-        getVerificationEmailSentStatus,
-        sendVerificationEmail,
-        emailStatus,
-    } = useEmailVerification(userId?.toString());
-    if (!(email && userId)) {
-        return (
-            <CenteredContainer fillSpace>
-                <Box width="100%" maxWidth="800px">
-                    <ErrorAlert
-                        title="Oh no! Something went wrong."
-                        message={
-                            "Looks like you're missing details in your registration link. Try checking the email you registered with to see if you have login instructions from us. If not, try logging in. If that doesn't work, you can alway try registering again."
-                        }
-                    />
-                </Box>
-            </CenteredContainer>
-        );
-    }
+    // const {
+    //     getVerificationEmailSentStatus,
+    //     sendVerificationEmail,
+    //     emailStatus,
+    // } = useEmailVerification(userId?.toString());
+    // if (!(email && userId)) {
+    //     return (
+    //         <CenteredContainer fillSpace>
+    //             <Box width="100%" maxWidth="800px">
+    //                 <ErrorAlert
+    //                     title="Oh no! Something went wrong."
+    //                     message={
+    //                         "Looks like you're missing details in your registration link. Try checking the email you registered with to see if you have login instructions from us. If not, try logging in. If that doesn't work, you can alway try registering again."
+    //                     }
+    //                 />
+    //             </Box>
+    //         </CenteredContainer>
+    //     );
+    // }
 
-    const errorMessage =
-        sendVerificationEmail.error || getVerificationEmailSentStatus.error;
-    const isVerificationEmailSent = emailStatus === 'completed';
+    // const errorMessage =
+    //     sendVerificationEmail.error || getVerificationEmailSentStatus.error;
+    // const isVerificationEmailSent = emailStatus === 'completed';
 
-    const isVerificationEmailLoading =
-        sendVerificationEmail.isLoading || emailStatus === 'pending';
+    // const isVerificationEmailLoading =
+    //     sendVerificationEmail.isLoading || emailStatus === 'pending';
 
     return (
         <CelebrationContainer
@@ -79,15 +79,18 @@ export const ProviderRegistrationSuccess = ({
                 <CheckIcon sx={{ fontSize: 100 }} />
                 <H1>You did it!</H1>
                 <Paragraph>
+                    You have successfully registered with Therify!
+                </Paragraph>
+                {/* <Paragraph>
                     You have successfully registered with Therify! Please check{' '}
                     <b>{email}</b> for instructions on how to verify your
                     account. If you don&apos;t see an email from Therify, check
                     your spam folder. If you still can&apos;t find it, resend
                     your verification email.
-                </Paragraph>
+                </Paragraph> */}
 
                 <Box maxWidth="800px" width="100%" display="flex">
-                    <Button
+                    {/* <Button
                         onClick={() => sendVerificationEmail.send()}
                         isLoading={isVerificationEmailLoading}
                         disabled={isVerificationEmailSent}
@@ -103,7 +106,7 @@ export const ProviderRegistrationSuccess = ({
                         {isVerificationEmailSent
                             ? 'Verification email sent!'
                             : 'Resend verification email'}
-                    </Button>
+                    </Button> */}
                     <Button
                         onClick={() => router.push(URL_PATHS.AUTH.LOGIN)}
                         style={{
@@ -117,8 +120,7 @@ export const ProviderRegistrationSuccess = ({
                     </Button>
                 </Box>
                 <Paragraph style={{ marginTop: theme.spacing(4) }}>
-                    If you need support verifying your email, please contact us
-                    at{' '}
+                    If you need support, please contact us at{' '}
                     <Link
                         href="mailto:help@therify.co?subject=Email%20Verification%20Support"
                         style={{
@@ -130,7 +132,7 @@ export const ProviderRegistrationSuccess = ({
                     </Link>
                     .
                 </Paragraph>
-                {errorMessage && (
+                {/* {errorMessage && (
                     <motion.div
                         initial={{ opacity: 0, scale: 0.7 }}
                         animate={{ opacity: 1, scale: 1 }}
@@ -138,7 +140,7 @@ export const ProviderRegistrationSuccess = ({
                     >
                         <ErrorAlert title={errorMessage ?? ''} darker />
                     </motion.div>
-                )}
+                )} */}
             </Box>
         </CelebrationContainer>
     );


### PR DESCRIPTION
# Description
- Comments out Auth0 email language and functionality on registration success pages. 
- sets `verify_email` param `false` when creating auth0 user in registrations

# Closes issue(s)
[Remove Auth0 Email Verification](https://trello.com/c/F10ZIMaJ)

# How to test / repro
Register

# Screenshots
![image](https://user-images.githubusercontent.com/25045075/219326776-263df480-2d1e-405b-aa7b-d7c6d992bc69.png)

# Changes include

-   [ ] Bugfix (non-breaking change that solves an issue)
-   [ ] New feature (non-breaking change that adds functionality)
-   [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Checklist

-   [ ] I have tested this code
-   [ ] I have updated the Readme

# Other comments
