### PR TITLE
fix: solve stripping supervisor from profile

### DIFF
--- a/src/lib/modules/providers/service/profiles/create-provider-profile-for-practice/transaction/createProviderProfile.ts
+++ b/src/lib/modules/providers/service/profiles/create-provider-profile-for-practice/transaction/createProviderProfile.ts
@@ -17,7 +17,7 @@ export const factory: (
         async commit({ prisma }) {
             const supervisor = rawSupervisor
                 ? ProviderSupervisor.validate(rawSupervisor)
-                : null;
+                : {};
             const credentials = rawCredentials.map(ProviderCredential.validate);
 
             const profile = {
@@ -34,7 +34,6 @@ export const factory: (
                         id: true,
                         createdAt: true,
                         updatedAt: true,
-                        supervisor: true,
                     }).parse(profile),
                 },
             });

--- a/src/lib/modules/providers/service/profiles/get-profile-by-id/getProfileById.ts
+++ b/src/lib/modules/providers/service/profiles/get-profile-by-id/getProfileById.ts
@@ -17,9 +17,6 @@ export const factory =
         });
 
         return {
-            profile: ProviderProfile.validate({
-                ...profile,
-                practiceStartDate: profile.practiceStartDate?.toISOString(),
-            }),
+            profile: ProviderProfile.validate(profile),
         };
     };

--- a/src/lib/modules/providers/service/profiles/get-profile-by-user-id/getProfileByUserId.ts
+++ b/src/lib/modules/providers/service/profiles/get-profile-by-user-id/getProfileByUserId.ts
@@ -30,10 +30,6 @@ export const factory =
         }
 
         return {
-            profile: ProviderProfile.validate({
-                ...providerProfile,
-                practiceStartDate:
-                    providerProfile.practiceStartDate?.toISOString(),
-            }),
+            profile: ProviderProfile.validate(providerProfile),
         };
     };

--- a/src/lib/modules/providers/service/profiles/update-provider-profile/updateProviderProfile.ts
+++ b/src/lib/modules/providers/service/profiles/update-provider-profile/updateProviderProfile.ts
@@ -46,24 +46,23 @@ export function factory({ prisma }: ProvidersServiceParams) {
         }
         const supervisor = rawSupervisor
             ? ProviderSupervisor.validate(rawSupervisor)
-            : null;
+            : {};
         const credentials = rawCredentials.map(ProviderCredential.validate);
 
         const profile = {
             ...rawProfile,
             practiceStartDate: practiceStartDate && new Date(practiceStartDate),
-            supervisor,
             credentials,
+            supervisor,
         };
+        const payload = ProviderProfileSchema.omit({
+            createdAt: true,
+            updatedAt: true,
+        }).parse(profile);
+
         await prisma.providerProfile.update({
             where: { id: profile.id },
-            data: {
-                ...ProviderProfileSchema.omit({
-                    createdAt: true,
-                    updatedAt: true,
-                    supervisor: true,
-                }).parse(profile),
-            },
+            data: { ...payload },
         });
 
         return {

--- a/src/lib/shared/types/provider-profile/providerProfile.spec.ts
+++ b/src/lib/shared/types/provider-profile/providerProfile.spec.ts
@@ -1,0 +1,105 @@
+import {
+    NewClientStatus,
+    ProfileType,
+    ProviderProfile as PrismaProviderProfile,
+} from '@prisma/client';
+import { Pronoun } from '..';
+import { validate } from './providerProfile';
+import { ENTRIES as STATES } from '../state';
+
+const mockProfile: PrismaProviderProfile = {
+    id: '1',
+    givenName: 'John',
+    surname: 'Doe',
+    contactEmail: 'test@therify.co',
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    userId: 'user-id-1',
+    bio: 'This is a bio',
+    npiNumber: '1234567890',
+    offersSlidingScale: false,
+    profileImageUrl: null,
+    yearsOfExperience: null,
+    minimumRate: 40,
+    maximumRate: null,
+    idealClientDescription: null,
+    practiceNotes: null,
+    gender: 'male',
+    credentials: [],
+    acceptedInsurances: [],
+    supervisor: null,
+    specialties: [],
+    ethnicity: [],
+    communitiesServed: [],
+    religions: [],
+    evidenceBasedPractices: [],
+    modalities: [],
+    languagesSpoken: [],
+    pronouns: Pronoun.MAP.HE_HIM,
+    ageGroups: [],
+    offersInPerson: false,
+    offersMedicationManagement: false,
+    offersPhoneConsultations: false,
+    offersVirtual: false,
+    designation: ProfileType.therapist,
+    newClientStatus: NewClientStatus.accepting,
+    practiceStartDate: new Date(),
+};
+
+describe('ProviderProfile.validate', () => {
+    it('should validate a valid profile', () => {
+        expect(() => validate(mockProfile)).not.toThrow();
+    });
+    it('should throw with invalid profile', () => {
+        expect(() => validate({ ...mockProfile, givenName: {} })).toThrow();
+    });
+    describe('supervisor', () => {
+        it('should throw with invalid supervisor', () => {
+            expect(() =>
+                validate({
+                    ...mockProfile,
+                    supervisor: {
+                        name: 'John Doe',
+                    },
+                })
+            ).toThrow();
+        });
+        it('should convert {} to null', () => {
+            const { supervisor } = validate({
+                ...mockProfile,
+                supervisor: {},
+            });
+            expect(supervisor).toBeNull();
+        });
+        it('should allow null as value', () => {
+            const { supervisor } = validate({
+                ...mockProfile,
+                supervisor: null,
+            });
+            expect(supervisor).toBeNull();
+        });
+        it('should validate a valid supervisor', () => {
+            const mockSupervisor = {
+                name: 'John Doe',
+                npiNumber: '123',
+                supervisorLicense: {
+                    expiration: new Date(),
+                    licenseNumber: '123',
+                    state: STATES[0],
+                },
+            };
+            const { supervisor } = validate({
+                ...mockProfile,
+                supervisor: mockSupervisor,
+            });
+            expect(supervisor).toEqual({
+                ...mockSupervisor,
+                supervisorLicense: {
+                    ...mockSupervisor.supervisorLicense,
+                    expiration:
+                        mockSupervisor.supervisorLicense.expiration.toISOString(),
+                },
+            });
+        });
+    });
+});


### PR DESCRIPTION
# Description
Supervisor data was getting omitted by profile schema validation. This allows supervisor data to be validated and saved.

### Important:
Prisma does not allow JSON types to save `null` as its value. However, because the supervisor column was getting saved without a default value, the initial value in the db was `null`. After a supervisor had been set on the profile in the db, the only way to remove it now is to set the value to '{}' to satisfy the `JSON` type. 

Our application layer wants the supervisor property to be nullable in our ProviderProfile. Therefore, now we must transform that empty JSON object value to be `null` when adapting the supervisor database schema to an application schema and that `null` supervisor back to `{}` when adapting back. 

This adaption to the nullable application type now happens in the ProviderProfile.validate function from the types lib. 

The conversion of a null supervisor also happens in the createProfileForPractice and updateProviderProfile service methods and saves that empty supervisor value as `{}`.

# Closes issue(s)
[Bug: Editor not saving supervisor data](https://trello.com/c/0iTIjKv0)
# How to test / repro
Create and update profiles with supervisor data. Refresh the page to see it take effect

# Screenshots
NA
# Changes include

-   [x] Bugfix (non-breaking change that solves an issue)
-   [ ] New feature (non-breaking change that adds functionality)
-   [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Checklist

-   [ ] I have tested this code
-   [ ] I have updated the Readme

# Other comments
