### PR TITLE
feat: add termination to connection request

### DIFF
--- a/prisma/migrations/20230228074118_add_terminated_connection_status/migration.sql
+++ b/prisma/migrations/20230228074118_add_terminated_connection_status/migration.sql
@@ -1,0 +1,2 @@
+-- AlterEnum
+ALTER TYPE "ConnectionStatus" ADD VALUE 'terminated';

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -331,6 +331,7 @@ enum ConnectionStatus {
   pending
   accepted
   declined
+  terminated
 }
 
 model ConnectionRequest {

--- a/src/lib/modules/providers/components/Clients/ActionConfirmationModal/ActionConfirmationModal.tsx
+++ b/src/lib/modules/providers/components/Clients/ActionConfirmationModal/ActionConfirmationModal.tsx
@@ -1,0 +1,115 @@
+import {
+    CenteredContainer,
+    Modal,
+    Divider,
+    Textarea,
+} from '@/lib/shared/components/ui';
+import { ConnectionRequest } from '@/lib/shared/types';
+import { Box, CircularProgress } from '@mui/material';
+import { useState } from 'react';
+
+interface ActionConfirmationModalProps {
+    action: 'accept' | 'decline' | 'terminate';
+    connectionRequest: ConnectionRequest.Type;
+    isLoading: boolean;
+    onClose: () => void;
+    onPrimaryButtonClick: (message?: string) => void;
+}
+
+export const ActionConfirmationModal = ({
+    action,
+    connectionRequest,
+    isLoading,
+    onClose,
+    onPrimaryButtonClick,
+}: ActionConfirmationModalProps) => {
+    const [confirmationMessage, setConfirmationMessage] = useState('');
+    const {
+        title,
+        message,
+        primaryButtonColor,
+        primaryButtonText,
+        textareaLabel,
+        textareaPlaceholder,
+    } = getConfirmationModalContent(action, connectionRequest);
+    return (
+        <Modal
+            isOpen
+            title={title}
+            message={!isLoading ? message : undefined}
+            onClose={onClose}
+            fullWidthButtons
+            primaryButtonColor={primaryButtonColor}
+            primaryButtonText={primaryButtonText}
+            primaryButtonOnClick={() =>
+                onPrimaryButtonClick(
+                    confirmationMessage.trim() === ''
+                        ? undefined
+                        : confirmationMessage
+                )
+            }
+            primaryButtonDisabled={isLoading}
+            secondaryButtonText="Cancel"
+            secondaryButtonDisabled={isLoading}
+            secondaryButtonOnClick={onClose}
+            postBodySlot={
+                isLoading ? (
+                    <CenteredContainer width="100%">
+                        <CircularProgress />
+                    </CenteredContainer>
+                ) : (
+                    <Box width="100%">
+                        <Divider />
+                        <Textarea
+                            fullWidth
+                            label={textareaLabel}
+                            placeholder={textareaPlaceholder}
+                            value={confirmationMessage}
+                            onChange={(e) =>
+                                setConfirmationMessage(e.target.value)
+                            }
+                        />
+                    </Box>
+                )
+            }
+        />
+    );
+};
+
+const getConfirmationModalContent = (
+    action: 'accept' | 'decline' | 'terminate',
+    connectionRequst: ConnectionRequest.Type
+) => {
+    switch (action) {
+        case 'decline':
+            return {
+                title: 'Decline New Client',
+                message: `Declining ${connectionRequst.member.givenName} will notify them that you are unable to accept them as a client at this time.`,
+                primaryButtonColor: 'error' as const,
+                primaryButtonText: 'Decline',
+                textareaLabel: 'Reason for declining (optional)',
+                textareaPlaceholder:
+                    'Let them know why you cannot accept at this time',
+            };
+        case 'terminate':
+            return {
+                title: 'End Client Relationship',
+                message: `Removing ${connectionRequst.member.givenName} as a client will notify them that you are no longer able to provide services.`,
+                primaryButtonColor: 'error' as const,
+                primaryButtonText: 'Remove Client',
+                textareaLabel: 'Note to client (optional)',
+                textareaPlaceholder:
+                    'Let them know why you are no longer able to provide services',
+            };
+        case 'accept':
+        default:
+            return {
+                title: 'Accept New Client?',
+                message: `Accepting ${connectionRequst.member.givenName} will notify them that you are ready to start working with them.`,
+                primaryButtonColor: 'primary' as const,
+                primaryButtonText: 'Accept',
+                textareaLabel: 'Additional Information (optional)',
+                textareaPlaceholder: `Share any additional details here`,
+            };
+    }
+};

--- a/src/lib/modules/providers/components/Clients/ActionConfirmationModal/index.ts
+++ b/src/lib/modules/providers/components/Clients/ActionConfirmationModal/index.ts
@@ -1,0 +1,1 @@
+export * from './ActionConfirmationModal';

--- a/src/lib/modules/providers/components/Clients/ClientList/ClientList.tsx
+++ b/src/lib/modules/providers/components/Clients/ClientList/ClientList.tsx
@@ -1,0 +1,95 @@
+import { ConnectionRequest } from '@/lib/shared/types';
+import { Box, useMediaQuery } from '@mui/material';
+import { styled, Theme } from '@mui/material/styles';
+import { List, Paragraph, Caption, ListItem } from '@/lib/shared/components/ui';
+import { CellContainer, ClientListItem, ClientListItemContainer } from './ui';
+import { ProfileType } from '@prisma/client';
+
+type HandleConnectionRequestAction = (
+    connectionRequest: ConnectionRequest.Type
+) => void;
+
+interface ClientListProps {
+    designation: ProfileType;
+    connectionRequests: ConnectionRequest.Type[];
+    onAcceptConnectionRequest: HandleConnectionRequestAction;
+    onDeclineConnectionRequest: HandleConnectionRequestAction;
+    onTerminateConnectionRequest: HandleConnectionRequestAction;
+    onReimbursmentRequest: HandleConnectionRequestAction;
+    onViewMemberDetails: HandleConnectionRequestAction;
+    onOpenChat: (memberId: string) => void;
+}
+
+export const ClientList = ({
+    designation,
+    connectionRequests,
+    onAcceptConnectionRequest,
+    onDeclineConnectionRequest,
+    onTerminateConnectionRequest,
+    onReimbursmentRequest,
+    onOpenChat,
+    onViewMemberDetails,
+}: ClientListProps) => {
+    const isCoach = designation === ProfileType.coach;
+    const isSmallScreen = useMediaQuery((theme: Theme) =>
+        theme.breakpoints.down('md')
+    );
+    const hasConnectionRequests = connectionRequests.length > 0;
+    return (
+        <ClientListContainer>
+            <ListItem sx={{ width: '100%', '& > div': { paddingY: 0 } }}>
+                <ClientListItemContainer paddingBottom={0}>
+                    <CellContainer>
+                        <Caption margin={0}>Name</Caption>
+                    </CellContainer>
+                    <CellContainer>
+                        <Caption margin={0}>Email</Caption>
+                    </CellContainer>
+                    <CellContainer>
+                        <Caption margin={0}>Account</Caption>
+                    </CellContainer>
+                    <CellContainer></CellContainer>
+                </ClientListItemContainer>
+            </ListItem>
+            {!hasConnectionRequests && (
+                <Box margin={5}>
+                    <Paragraph color="text-secondary">
+                        No clients to show. Your future referrals will appear
+                        here.
+                    </Paragraph>
+                </Box>
+            )}
+            {connectionRequests.map((connectionRequest) => {
+                return (
+                    <ClientListItem
+                        key={connectionRequest.member.id}
+                        isSmallScreen={isSmallScreen}
+                        connectionRequest={connectionRequest}
+                        onAccept={() =>
+                            onAcceptConnectionRequest(connectionRequest)
+                        }
+                        onDecline={() =>
+                            onDeclineConnectionRequest(connectionRequest)
+                        }
+                        onTerminate={() =>
+                            onTerminateConnectionRequest(connectionRequest)
+                        }
+                        onView={() => onViewMemberDetails(connectionRequest)}
+                        onOpenChat={
+                            isCoach
+                                ? () => onOpenChat(connectionRequest.member.id)
+                                : undefined
+                        }
+                        onReimbursmentRequest={() => {
+                            onReimbursmentRequest(connectionRequest);
+                        }}
+                    />
+                );
+            })}
+        </ClientListContainer>
+    );
+};
+
+const ClientListContainer = styled(List)(({ theme }) => ({
+    width: '100%',
+}));

--- a/src/lib/modules/providers/components/Clients/ClientList/index.ts
+++ b/src/lib/modules/providers/components/Clients/ClientList/index.ts
@@ -1,0 +1,1 @@
+export * from './ClientList';

--- a/src/lib/modules/providers/components/Clients/ClientList/ui/ActionButtons.tsx
+++ b/src/lib/modules/providers/components/Clients/ClientList/ui/ActionButtons.tsx
@@ -1,0 +1,69 @@
+import { Button } from '@/lib/shared/components/ui';
+import { ConnectionRequest } from '@/lib/shared/types';
+import { ConnectionStatus } from '@prisma/client';
+
+export const ActionButtons = ({
+    connectionRequest,
+    onAccept,
+    onDecline,
+    onView,
+    onOpenChat,
+}: {
+    connectionRequest: ConnectionRequest.Type;
+    onAccept: () => void;
+    onDecline: () => void;
+    onView?: () => void;
+    onOpenChat?: () => void;
+}) => {
+    const isPending =
+        connectionRequest.connectionStatus === ConnectionStatus.pending;
+    const isAccepted =
+        connectionRequest.connectionStatus === ConnectionStatus.accepted;
+    return (
+        <>
+            {isPending && (
+                <>
+                    <Button
+                        size="small"
+                        onClick={onAccept}
+                        sx={{ marginRight: 2 }}
+                    >
+                        Accept
+                    </Button>
+                    <Button
+                        size="small"
+                        type="outlined"
+                        color="info"
+                        onClick={onDecline}
+                    >
+                        Decline
+                    </Button>
+                </>
+            )}
+            {isAccepted && (
+                <>
+                    {!onOpenChat && (
+                        <Button
+                            size="small"
+                            color="info"
+                            type="outlined"
+                            onClick={onView}
+                        >
+                            View Member
+                        </Button>
+                    )}
+                    {onOpenChat && (
+                        <Button
+                            size="small"
+                            color="info"
+                            type="outlined"
+                            onClick={onOpenChat}
+                        >
+                            Chat
+                        </Button>
+                    )}
+                </>
+            )}
+        </>
+    );
+};

--- a/src/lib/modules/providers/components/Clients/ClientList/ui/ClientListItem.tsx
+++ b/src/lib/modules/providers/components/Clients/ClientList/ui/ClientListItem.tsx
@@ -1,0 +1,232 @@
+import { ConnectionRequest } from '@/lib/shared/types';
+import {
+    MailOutline,
+    PaidOutlined,
+    PendingOutlined,
+    ChatBubbleOutlineRounded,
+    CircleRounded,
+    DoNotDisturbAltRounded,
+    CheckCircleOutlineRounded,
+    PreviewRounded,
+    PersonRemoveOutlined,
+} from '@mui/icons-material';
+
+import {
+    Paragraph,
+    FloatingList,
+    Avatar,
+    AVATAR_SIZE,
+    Badge,
+    BADGE_SIZE,
+    BADGE_COLOR,
+    ListItem,
+} from '@/lib/shared/components/ui';
+import { ConnectionStatus } from '@prisma/client';
+import { Box, Link } from '@mui/material';
+import { styled } from '@mui/material/styles';
+import { ActionButtons } from './ActionButtons';
+import { CellContainer, ClientListItemContainer } from './ListCells';
+
+export const ClientListItem = ({
+    connectionRequest,
+    isSmallScreen,
+    onAccept,
+    onDecline,
+    onTerminate,
+    onView,
+    onOpenChat,
+    onReimbursmentRequest,
+}: {
+    connectionRequest: ConnectionRequest.Type;
+    isSmallScreen?: boolean;
+    onAccept: () => void;
+    onDecline: () => void;
+    onTerminate: () => void;
+    onView?: () => void;
+    onOpenChat?: () => void;
+    onReimbursmentRequest: () => void;
+}) => {
+    const isPending =
+        connectionRequest.connectionStatus === ConnectionStatus.pending;
+    const isAccepted =
+        connectionRequest.connectionStatus === ConnectionStatus.accepted;
+    const mobileActions = [
+        ...(isPending
+            ? [
+                  {
+                      icon: <CheckCircleOutlineRounded color="success" />,
+                      text: 'Accept',
+                      onClick: onAccept,
+                  },
+                  {
+                      icon: <DoNotDisturbAltRounded color="error" />,
+                      text: 'Decline',
+                      onClick: onDecline,
+                  },
+              ]
+            : []),
+        ...(!onOpenChat
+            ? [
+                  {
+                      icon: <PreviewRounded />,
+                      text: ' View Member Details',
+                      onClick: onView,
+                  },
+              ]
+            : []),
+        ...(onOpenChat
+            ? [
+                  {
+                      icon: <ChatBubbleOutlineRounded />,
+                      text: 'Chat',
+                      onClick: onOpenChat,
+                  },
+              ]
+            : []),
+    ];
+    const actionList = [
+        ...(isSmallScreen ? mobileActions : []),
+        ...(isAccepted
+            ? [
+                  {
+                      text: 'Reimbursement Request',
+                      icon: <PaidOutlined />,
+                      onClick: onReimbursmentRequest,
+                  },
+                  {
+                      text: 'Remove Client',
+                      icon: <PersonRemoveOutlined />,
+                      onClick: onTerminate,
+                  },
+              ]
+            : []),
+    ];
+
+    return (
+        <ListItem
+            key={connectionRequest.member.id}
+            sx={{ width: '100%', paddingX: 0 }}
+            onClick={onView}
+        >
+            <ClientListItemContainer>
+                <CellContainer>
+                    <Avatar
+                        size={AVATAR_SIZE.EXTRA_SMALL}
+                        sx={{ marginRight: 4 }}
+                    />
+                    <MemberName
+                        sx={{
+                            marginRight:
+                                isPending && !isSmallScreen ? 4 : undefined,
+                        }}
+                    >
+                        {connectionRequest.member.givenName}{' '}
+                        {connectionRequest.member.surname}
+                    </MemberName>
+                    {isPending && !isSmallScreen && (
+                        <Badge
+                            color={BADGE_COLOR.WARNING}
+                            icon={<PendingOutlined />}
+                            size={BADGE_SIZE.SMALL}
+                        >
+                            Pending
+                        </Badge>
+                    )}
+                </CellContainer>
+                <CellContainer>
+                    <MemberEmailAddress>
+                        <Link
+                            title={`Send email to ${connectionRequest.member.givenName}`}
+                            onClick={(e) => e.stopPropagation()}
+                            href={`mailto:${connectionRequest.member.emailAddress}`}
+                            target="_blank"
+                        >
+                            <MailOutline />
+                        </Link>
+                        <Paragraph noMargin>
+                            {connectionRequest.member.emailAddress}
+                        </Paragraph>
+                    </MemberEmailAddress>
+                </CellContainer>
+                <CellContainer>
+                    <Paragraph noMargin>
+                        {connectionRequest.member.account.name}
+                    </Paragraph>
+                </CellContainer>
+                <CellContainer onClick={(e) => e.stopPropagation()}>
+                    {!isSmallScreen && (
+                        <ActionButtons
+                            connectionRequest={connectionRequest}
+                            onAccept={onAccept}
+                            onDecline={onDecline}
+                            onView={onView}
+                            onOpenChat={onOpenChat}
+                        />
+                    )}
+                    {isPending && isSmallScreen && (
+                        <CircleRounded
+                            color="warning"
+                            sx={{
+                                height: '12px',
+                                width: '12px',
+                            }}
+                        />
+                    )}
+                    {actionList.length > 0 && (
+                        <FloatingList
+                            sx={{ marginLeft: 2 }}
+                            headerSlot={
+                                isPending &&
+                                isSmallScreen && (
+                                    <Badge
+                                        color={BADGE_COLOR.WARNING}
+                                        icon={<PendingOutlined />}
+                                        size={BADGE_SIZE.SMALL}
+                                    >
+                                        Pending
+                                    </Badge>
+                                )
+                            }
+                            listItems={actionList}
+                        />
+                    )}
+                </CellContainer>
+            </ClientListItemContainer>
+        </ListItem>
+    );
+};
+
+const MemberName = styled(Paragraph)(({ theme }) => ({
+    fontWeight: 500,
+    margin: 0,
+}));
+
+const MemberEmailAddress = styled(Box)(({ theme }) => ({
+    ...theme.typography.body1,
+    color: theme.palette.text.primary,
+    textDecoration: 'none',
+    display: 'flex',
+    alignItems: 'center',
+    flex: 1,
+    maxWidth: '100%',
+    '& a': {
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+    },
+    '& p': {
+        flex: 1,
+        maxWidth: '100%',
+        overflow: 'hidden',
+        whiteSpace: 'nowrap',
+        textOverflow: 'ellipsis',
+        alignItems: 'center',
+    },
+    '& svg': {
+        color: theme.palette.grey[400],
+        marginRight: theme.spacing(2),
+        '&:hover': {
+            color: theme.palette.primary.main,
+        },
+    },
+}));

--- a/src/lib/modules/providers/components/Clients/ClientList/ui/ListCells.tsx
+++ b/src/lib/modules/providers/components/Clients/ClientList/ui/ListCells.tsx
@@ -1,0 +1,41 @@
+import { Box } from '@mui/material';
+import { styled } from '@mui/material/styles';
+
+export const CellContainer = styled(Box)(({ theme }) => ({
+    display: 'flex',
+    alignItems: 'center',
+    flexWrap: 'wrap',
+    paddingRight: theme.spacing(2),
+    '&:nth-of-type(1)': {
+        flex: 1,
+        [theme.breakpoints.up('md')]: {
+            width: '25%',
+        },
+    },
+    '&:nth-of-type(2)': {
+        display: 'none',
+        [theme.breakpoints.up('md')]: {
+            width: '25%',
+            display: 'flex',
+        },
+    },
+    '&:nth-of-type(3)': {
+        display: 'none',
+        [theme.breakpoints.up('md')]: {
+            width: '25%',
+            display: 'flex',
+        },
+    },
+    '&:nth-of-type(4)': {
+        width: '25%',
+        justifyContent: 'flex-end',
+    },
+}));
+
+export const ClientListItemContainer = styled(Box)(({ theme }) => ({
+    padding: theme.spacing(2),
+    display: 'flex',
+    width: '100%',
+    flexDirection: 'row',
+    alignItems: 'center',
+}));

--- a/src/lib/modules/providers/components/Clients/ClientList/ui/index.ts
+++ b/src/lib/modules/providers/components/Clients/ClientList/ui/index.ts
@@ -1,0 +1,2 @@
+export * from './ListCells';
+export * from './ClientListItem';

--- a/src/lib/modules/providers/components/Clients/MemberDetailsModal/MemberDetailsModal.tsx
+++ b/src/lib/modules/providers/components/Clients/MemberDetailsModal/MemberDetailsModal.tsx
@@ -1,0 +1,97 @@
+import {
+    DisplayModal,
+    Paragraph,
+    PARAGRAPH_SIZE,
+} from '@/lib/shared/components/ui';
+import { ConnectionRequest } from '@/lib/shared/types';
+import { Link } from '@mui/material';
+import { useTheme } from '@mui/material/styles';
+import { format } from 'date-fns';
+
+interface MemberDetailsModalProps {
+    connectionRequest: ConnectionRequest.Type;
+    onClose: () => void;
+}
+export const MemberDetailsModal = ({
+    connectionRequest,
+    onClose,
+}: MemberDetailsModalProps) => {
+    const theme = useTheme();
+    return (
+        <DisplayModal
+            isOpen
+            title={`${connectionRequest.member.givenName} ${connectionRequest.member.surname}`}
+            onClose={onClose}
+            fullWidthButtons
+            secondaryButtonText="Close"
+            secondaryButtonOnClick={onClose}
+        >
+            <Paragraph bold size={PARAGRAPH_SIZE.LARGE}>
+                Account
+            </Paragraph>
+            <Paragraph size={PARAGRAPH_SIZE.SMALL}>
+                {connectionRequest.member.account.name}
+            </Paragraph>
+            <Paragraph bold size={PARAGRAPH_SIZE.LARGE}>
+                Payment
+            </Paragraph>
+            <Paragraph size={PARAGRAPH_SIZE.SMALL}>
+                {connectionRequest.member.plan &&
+                connectionRequest.member.plan.coveredSessions > 0
+                    ? `${connectionRequest.member.givenName} has ${
+                          connectionRequest.member.plan.coveredSessions
+                      } covered sessions from Therify until ${format(
+                          new Date(connectionRequest.member.plan.endDate),
+                          'MMMM dd, yyyy'
+                      )}`
+                    : 'No covered sessions. They will use their insurance benefit to cover sessions or pay out of pocket.'}
+            </Paragraph>
+            <Paragraph bold size={PARAGRAPH_SIZE.LARGE}>
+                Contact
+            </Paragraph>
+            <Link
+                href={'mailto:' + connectionRequest.member.emailAddress}
+                target="_blank"
+                sx={{ color: theme.palette.text.secondary }}
+            >
+                <Paragraph size={PARAGRAPH_SIZE.SMALL}>
+                    {connectionRequest.member.emailAddress}
+                </Paragraph>
+            </Link>
+            <Paragraph bold size={PARAGRAPH_SIZE.LARGE}>
+                Located in
+            </Paragraph>
+            <Paragraph size={PARAGRAPH_SIZE.SMALL}>
+                {connectionRequest.member.memberProfile.state}
+            </Paragraph>
+            <Paragraph bold size={PARAGRAPH_SIZE.LARGE}>
+                Insurance Provider
+            </Paragraph>
+            <Paragraph size={PARAGRAPH_SIZE.SMALL}>
+                {connectionRequest.member.memberProfile.insurance}
+            </Paragraph>
+            <Paragraph bold size={PARAGRAPH_SIZE.LARGE}>
+                Concerns
+            </Paragraph>
+            <Paragraph size={PARAGRAPH_SIZE.SMALL}>
+                {connectionRequest.member.memberProfile.concerns.join(', ')}
+            </Paragraph>
+            <Paragraph bold size={PARAGRAPH_SIZE.LARGE}>
+                Goals
+            </Paragraph>
+            <Paragraph size={PARAGRAPH_SIZE.SMALL}>
+                {connectionRequest.member.memberProfile.goals.join(', ')}
+            </Paragraph>
+            {connectionRequest.connectionMessage && (
+                <>
+                    <Paragraph bold size={PARAGRAPH_SIZE.LARGE}>
+                        Message
+                    </Paragraph>
+                    <Paragraph size={PARAGRAPH_SIZE.SMALL}>
+                        {connectionRequest.connectionMessage}
+                    </Paragraph>
+                </>
+            )}
+        </DisplayModal>
+    );
+};

--- a/src/lib/modules/providers/components/Clients/MemberDetailsModal/index.ts
+++ b/src/lib/modules/providers/components/Clients/MemberDetailsModal/index.ts
@@ -1,0 +1,1 @@
+export * from './MemberDetailsModal';

--- a/src/lib/modules/providers/components/Clients/index.ts
+++ b/src/lib/modules/providers/components/Clients/index.ts
@@ -1,0 +1,3 @@
+export * from './ActionConfirmationModal';
+export * from './ClientList';
+export * from './MemberDetailsModal';

--- a/src/lib/modules/providers/components/hooks/index.ts
+++ b/src/lib/modules/providers/components/hooks/index.ts
@@ -1,0 +1,1 @@
+export * from './useProviderConnectionRequests';

--- a/src/lib/modules/providers/components/hooks/useProviderConnectionRequests.ts
+++ b/src/lib/modules/providers/components/hooks/useProviderConnectionRequests.ts
@@ -32,13 +32,10 @@ export const useProviderConnectionRequests = (
                     if (success) {
                         createAlert({
                             type: 'success',
-                            title:
-                                connectionStatus === ConnectionStatus.accepted
-                                    ? `${confirmationConnectionRequest?.connectionRequest.member.givenName} is now your client!`
-                                    : connectionStatus ===
-                                      ConnectionStatus.terminated
-                                    ? `${confirmationConnectionRequest?.connectionRequest.member.givenName} is no longer your client`
-                                    : `Declined successfully`,
+                            title: getSuccessAlertText(
+                                connectionStatus,
+                                confirmationConnectionRequest?.connectionRequest
+                            ),
                         });
                         setConfirmationConnectionRequest(undefined);
                         if (connectionStatus === ConnectionStatus.accepted) {
@@ -119,4 +116,23 @@ export const useProviderConnectionRequests = (
         setConfirmationConnectionRequest,
         confirmationConnectionRequest,
     };
+};
+
+const getSuccessAlertText = (
+    status: ConnectionStatus,
+    connectionRequest?: ConnectionRequest.Type
+) => {
+    switch (status) {
+        case ConnectionStatus.accepted:
+            return `${
+                connectionRequest?.member.givenName ?? 'Member'
+            } is now your client!`;
+        case ConnectionStatus.terminated:
+            return `${
+                connectionRequest?.member.givenName ?? 'Member'
+            } is no longer your client`;
+        case ConnectionStatus.declined:
+        default:
+            return `Declined successfully`;
+    }
 };

--- a/src/lib/modules/providers/components/hooks/useProviderConnectionRequests.ts
+++ b/src/lib/modules/providers/components/hooks/useProviderConnectionRequests.ts
@@ -1,0 +1,122 @@
+import { useContext, useState } from 'react';
+import { Alerts } from '@/lib/modules/alerts/context';
+import { ConnectionRequest } from '@/lib/shared/types';
+import { UpdateConnectionRequestStatus } from '@/lib/modules/directory/features';
+import { trpc } from '@/lib/shared/utils/trpc';
+import { ConnectionStatus } from '@prisma/client';
+
+type ConnectionAction = 'accept' | 'decline' | 'terminate';
+
+export const useProviderConnectionRequests = (
+    userId: string,
+    baseConnectionRequests: ConnectionRequest.Type[]
+) => {
+    const [connectionRequests, setConnectionRequests] = useState(
+        baseConnectionRequests
+    );
+    const { createAlert } = useContext(Alerts.Context);
+    const [confirmationConnectionRequest, setConfirmationConnectionRequest] =
+        useState<{
+            action: ConnectionAction;
+            connectionRequest: ConnectionRequest.Type;
+        }>();
+
+    const { mutate: updateConnectionRequestStatus, isLoading } =
+        trpc.useMutation(
+            `directory.${UpdateConnectionRequestStatus.TRPC_ROUTE}`,
+            {
+                onSuccess: (
+                    { success, errors },
+                    { memberId, profileId, connectionStatus }
+                ) => {
+                    if (success) {
+                        createAlert({
+                            type: 'success',
+                            title:
+                                connectionStatus === ConnectionStatus.accepted
+                                    ? `${confirmationConnectionRequest?.connectionRequest.member.givenName} is now your client!`
+                                    : connectionStatus ===
+                                      ConnectionStatus.terminated
+                                    ? `${confirmationConnectionRequest?.connectionRequest.member.givenName} is no longer your client`
+                                    : `Declined successfully`,
+                        });
+                        setConfirmationConnectionRequest(undefined);
+                        if (connectionStatus === ConnectionStatus.accepted) {
+                            return setConnectionRequests(
+                                connectionRequests.map((cr) => {
+                                    if (
+                                        cr.member.id === memberId &&
+                                        cr.providerProfile.id === profileId
+                                    ) {
+                                        return {
+                                            ...cr,
+                                            connectionStatus,
+                                        };
+                                    }
+                                    return cr;
+                                })
+                            );
+                        }
+                        return setConnectionRequests(
+                            connectionRequests.filter((cr) => {
+                                const isDeclinedRequest =
+                                    cr.member.id == memberId &&
+                                    cr.providerProfile.id === profileId;
+                                return !isDeclinedRequest;
+                            })
+                        );
+                    }
+                    const [error] = errors;
+                    if (error) {
+                        console.error(error);
+                        createAlert({
+                            type: 'error',
+                            title: error,
+                        });
+                    }
+                },
+                onError: (error) => {
+                    setConfirmationConnectionRequest(undefined);
+                    console.error(error);
+                    const errorMessage =
+                        error instanceof Error
+                            ? error.message
+                            : 'An error occurred';
+                    createAlert({
+                        type: 'error',
+                        title: errorMessage,
+                    });
+                },
+            }
+        );
+
+    const handleUpdateConnectionRequest = ({
+        action,
+        connectionRequest,
+        message,
+    }: {
+        connectionRequest: ConnectionRequest.Type;
+        action: ConnectionAction;
+        message?: string;
+    }) =>
+        updateConnectionRequestStatus({
+            memberId: connectionRequest.member.id,
+            profileId: connectionRequest.providerProfile.id,
+            connectionStatus:
+                action === 'accept'
+                    ? ConnectionStatus.accepted
+                    : action === 'terminate'
+                    ? ConnectionStatus.terminated
+                    : ConnectionStatus.declined,
+            userId,
+            message,
+        });
+
+    return {
+        connectionRequests,
+        handleUpdateConnectionRequest,
+        isUpdatingConnectionRequestStatus: isLoading,
+        setConfirmationConnectionRequest,
+        confirmationConnectionRequest,
+    };
+};

--- a/src/lib/shared/components/features/pages/PracticeClientListPage/PracticeClientListPage.tsx
+++ b/src/lib/shared/components/features/pages/PracticeClientListPage/PracticeClientListPage.tsx
@@ -166,7 +166,7 @@ export function PracticeClientListPage({
                             const isRequests = requests.length > 0;
                             const isPendingRequests = i === 0;
                             return (
-                                <>
+                                <Box width="100%" key={i}>
                                     {isPendingRequests && isRequests && (
                                         <Badge
                                             color="warning"
@@ -262,7 +262,7 @@ export function PracticeClientListPage({
                                             </div>
                                         );
                                     })}
-                                </>
+                                </Box>
                             );
                         }
                     )}

--- a/src/lib/shared/components/features/pages/ProviderClientListPage/ProviderClientListPage.tsx
+++ b/src/lib/shared/components/features/pages/ProviderClientListPage/ProviderClientListPage.tsx
@@ -28,6 +28,7 @@ import {
     DoNotDisturbAltRounded,
     CheckCircleOutlineRounded,
     PreviewRounded,
+    PersonRemoveOutlined,
 } from '@mui/icons-material';
 import { ConnectionStatus, ProfileType } from '@prisma/client';
 import { format } from 'date-fns';
@@ -35,15 +36,15 @@ import { format } from 'date-fns';
 const REIMBURSEMENT_REQUEST_URL =
     'https://hipaa.jotform.com/221371005584146?' as const;
 
+type HandleConnectionRequestAction = (
+    connectionRequest: ConnectionRequest.Type
+) => void;
 interface ProviderClientListPageProps {
     connectionRequests: ConnectionRequest.Type[];
     designation: ProfileType;
-    onAcceptConnectionRequest: (
-        connectionRequest: ConnectionRequest.Type
-    ) => void;
-    onDeclineConnectionRequest: (
-        connectionRequest: ConnectionRequest.Type
-    ) => void;
+    onAcceptConnectionRequest: HandleConnectionRequestAction;
+    onDeclineConnectionRequest: HandleConnectionRequestAction;
+    onTerminateConnectionRequest: HandleConnectionRequestAction;
 }
 
 export function ProviderClientListPage({
@@ -51,6 +52,7 @@ export function ProviderClientListPage({
     designation,
     onAcceptConnectionRequest,
     onDeclineConnectionRequest,
+    onTerminateConnectionRequest,
 }: ProviderClientListPageProps) {
     const theme = useTheme();
     const isCoach = designation === ProfileType.coach;
@@ -68,11 +70,6 @@ export function ProviderClientListPage({
                 marginX={theme.spacing(5)}
             >
                 <Title>Clients</Title>
-                {hasConnectionRequests && (
-                    <Paragraph color="text-secondary">
-                        Select a client to see their plan details
-                    </Paragraph>
-                )}
             </Box>
             <ClientList>
                 <ListItem sx={{ width: '100%', '& > div': { paddingY: 0 } }}>
@@ -113,6 +110,11 @@ export function ProviderClientListPage({
                                 }
                                 onDecline={() =>
                                     onDeclineConnectionRequest(
+                                        connectionRequest
+                                    )
+                                }
+                                onTerminate={() =>
+                                    onTerminateConnectionRequest(
                                         connectionRequest
                                     )
                                 }
@@ -311,6 +313,7 @@ const ClientListItem = ({
     isSmallScreen,
     onAccept,
     onDecline,
+    onTerminate,
     onView,
     onOpenChat,
 }: {
@@ -318,6 +321,7 @@ const ClientListItem = ({
     isSmallScreen?: boolean;
     onAccept: () => void;
     onDecline: () => void;
+    onTerminate: () => void;
     onView?: () => void;
     onOpenChat?: () => void;
 }) => {
@@ -375,6 +379,11 @@ const ClientListItem = ({
                               '_blank'
                           );
                       },
+                  },
+                  {
+                      text: 'Remove Client',
+                      icon: <PersonRemoveOutlined />,
+                      onClick: onTerminate,
                   },
               ]
             : []),

--- a/src/lib/shared/components/features/pages/ProviderClientListPage/ProviderClientListPage.tsx
+++ b/src/lib/shared/components/features/pages/ProviderClientListPage/ProviderClientListPage.tsx
@@ -1,66 +1,43 @@
 import { useState } from 'react';
-import { ConnectionRequest } from '@/lib/shared/types';
-import { Stack, Link, Box, useMediaQuery } from '@mui/material';
-import { styled, Theme, useTheme } from '@mui/material/styles';
+import { ConnectionRequest, TherifyUser } from '@/lib/shared/types';
+import { Box } from '@mui/material';
+import { styled, useTheme } from '@mui/material/styles';
 import { formatReimbursementRequestUrl } from '@/lib/shared/utils';
 import {
-    List,
-    H1,
-    Paragraph,
-    PARAGRAPH_SIZE,
-    FloatingList,
-    Avatar,
-    Button,
-    AVATAR_SIZE,
-    Caption,
-    Badge,
-    BADGE_SIZE,
-    BADGE_COLOR,
-    ListItem,
-    DisplayModal,
-} from '@/lib/shared/components/ui';
-import {
-    MailOutline,
-    PaidOutlined,
-    PendingOutlined,
-    ChatBubbleOutlineRounded,
-    CircleRounded,
-    DoNotDisturbAltRounded,
-    CheckCircleOutlineRounded,
-    PreviewRounded,
-    PersonRemoveOutlined,
-} from '@mui/icons-material';
-import { ConnectionStatus, ProfileType } from '@prisma/client';
-import { format } from 'date-fns';
+    ActionConfirmationModal,
+    ClientList,
+    MemberDetailsModal,
+} from '@/lib/modules/providers/components/Clients';
+import { useProviderConnectionRequests } from '@/lib/modules/providers/components/hooks';
+import { H1 } from '@/lib/shared/components/ui';
+import { ProfileType } from '@prisma/client';
 
 const REIMBURSEMENT_REQUEST_URL =
     'https://hipaa.jotform.com/221371005584146?' as const;
 
-type HandleConnectionRequestAction = (
-    connectionRequest: ConnectionRequest.Type
-) => void;
 interface ProviderClientListPageProps {
-    connectionRequests: ConnectionRequest.Type[];
+    baseConnectionRequests: ConnectionRequest.Type[];
     designation: ProfileType;
-    onAcceptConnectionRequest: HandleConnectionRequestAction;
-    onDeclineConnectionRequest: HandleConnectionRequestAction;
-    onTerminateConnectionRequest: HandleConnectionRequestAction;
+    user: TherifyUser.TherifyUser;
 }
 
 export function ProviderClientListPage({
-    connectionRequests,
+    baseConnectionRequests,
     designation,
-    onAcceptConnectionRequest,
-    onDeclineConnectionRequest,
-    onTerminateConnectionRequest,
+    user,
 }: ProviderClientListPageProps) {
     const theme = useTheme();
-    const isCoach = designation === ProfileType.coach;
-    const isSmallScreen = useMediaQuery((theme: Theme) =>
-        theme.breakpoints.down('md')
+    const {
+        connectionRequests,
+        confirmationConnectionRequest,
+        setConfirmationConnectionRequest,
+        handleUpdateConnectionRequest,
+        isUpdatingConnectionRequestStatus,
+    } = useProviderConnectionRequests(
+        user.userId,
+        baseConnectionRequests ?? []
     );
-    const hasConnectionRequests = connectionRequests.length > 0;
-    const [targetConnection, setTargetConnection] =
+    const [memberDetails, setMemberDetails] =
         useState<ConnectionRequest.Type>();
     return (
         <PageContainer>
@@ -71,157 +48,66 @@ export function ProviderClientListPage({
             >
                 <Title>Clients</Title>
             </Box>
-            <ClientList>
-                <ListItem sx={{ width: '100%', '& > div': { paddingY: 0 } }}>
-                    <ClientListItemContainer paddingBottom={0}>
-                        <CellContainer>
-                            <Caption margin={0}>Name</Caption>
-                        </CellContainer>
-                        <CellContainer>
-                            <Caption margin={0}>Email</Caption>
-                        </CellContainer>
-                        <CellContainer>
-                            <Caption margin={0}>Account</Caption>
-                        </CellContainer>
-                        <CellContainer></CellContainer>
-                    </ClientListItemContainer>
-                </ListItem>
-                {!hasConnectionRequests && (
-                    <Box margin={5}>
-                        <Paragraph
-                            style={{
-                                color: theme.palette.text.secondary,
-                            }}
-                        >
-                            No clients to show. Your future referrals will
-                            appear here.
-                        </Paragraph>
-                    </Box>
-                )}
-                {hasConnectionRequests &&
-                    connectionRequests.map((connectionRequest) => {
-                        return (
-                            <ClientListItem
-                                key={connectionRequest.member.id}
-                                isSmallScreen={isSmallScreen}
-                                connectionRequest={connectionRequest}
-                                onAccept={() =>
-                                    onAcceptConnectionRequest(connectionRequest)
-                                }
-                                onDecline={() =>
-                                    onDeclineConnectionRequest(
-                                        connectionRequest
-                                    )
-                                }
-                                onTerminate={() =>
-                                    onTerminateConnectionRequest(
-                                        connectionRequest
-                                    )
-                                }
-                                onView={() =>
-                                    setTargetConnection(connectionRequest)
-                                }
-                                onOpenChat={
-                                    isCoach
-                                        ? () => {
-                                              console.log(
-                                                  'TODO: implement chat'
-                                              );
-                                          }
-                                        : undefined
-                                }
-                            />
-                        );
-                    })}
-            </ClientList>
-            {targetConnection && (
-                <DisplayModal
-                    isOpen
-                    title={`${targetConnection.member.givenName} ${targetConnection.member.surname}`}
-                    onClose={() => setTargetConnection(undefined)}
-                    fullWidthButtons
-                    secondaryButtonText="Close"
-                    secondaryButtonOnClick={() =>
-                        setTargetConnection(undefined)
+            <ClientList
+                connectionRequests={connectionRequests}
+                designation={designation}
+                onViewMemberDetails={setMemberDetails}
+                onAcceptConnectionRequest={(connectionRequest) =>
+                    setConfirmationConnectionRequest({
+                        action: 'accept',
+                        connectionRequest,
+                    })
+                }
+                onDeclineConnectionRequest={(connectionRequest) =>
+                    setConfirmationConnectionRequest({
+                        action: 'decline',
+                        connectionRequest,
+                    })
+                }
+                onTerminateConnectionRequest={(connectionRequest) =>
+                    setConfirmationConnectionRequest({
+                        action: 'terminate',
+                        connectionRequest,
+                    })
+                }
+                onOpenChat={(memberId) =>
+                    console.log('TODO: Open chat with member', memberId)
+                }
+                onReimbursmentRequest={(connectionRequest) =>
+                    window?.open(
+                        formatReimbursementRequestUrl(
+                            REIMBURSEMENT_REQUEST_URL,
+                            connectionRequest
+                        ),
+                        '_blank'
+                    )
+                }
+            />
+            {memberDetails && (
+                <MemberDetailsModal
+                    connectionRequest={memberDetails}
+                    onClose={() => setMemberDetails(undefined)}
+                />
+            )}
+            {confirmationConnectionRequest && (
+                <ActionConfirmationModal
+                    action={confirmationConnectionRequest.action}
+                    connectionRequest={
+                        confirmationConnectionRequest.connectionRequest
                     }
-                >
-                    <Paragraph bold size={PARAGRAPH_SIZE.LARGE}>
-                        Account
-                    </Paragraph>
-                    <Paragraph size={PARAGRAPH_SIZE.SMALL}>
-                        {targetConnection.member.account.name}
-                    </Paragraph>
-                    <Paragraph bold size={PARAGRAPH_SIZE.LARGE}>
-                        Payment
-                    </Paragraph>
-                    <Paragraph size={PARAGRAPH_SIZE.SMALL}>
-                        {targetConnection.member.plan &&
-                        targetConnection.member.plan.coveredSessions > 0
-                            ? `${targetConnection.member.givenName} has ${
-                                  targetConnection.member.plan.coveredSessions
-                              } covered sessions from Therify until ${format(
-                                  new Date(
-                                      targetConnection.member.plan.endDate
-                                  ),
-                                  'MMMM dd, yyyy'
-                              )}`
-                            : 'No covered sessions. They will likely be using their insurance benefit to cover session costs or will pay out of pocket.'}
-                    </Paragraph>
-                    <Paragraph bold size={PARAGRAPH_SIZE.LARGE}>
-                        Contact
-                    </Paragraph>
-                    <Link
-                        href={'mailto:' + targetConnection.member.emailAddress}
-                        target="_blank"
-                        sx={{ color: theme.palette.text.secondary }}
-                    >
-                        <Paragraph size={PARAGRAPH_SIZE.SMALL}>
-                            {targetConnection.member.emailAddress}
-                        </Paragraph>
-                    </Link>
-                    <Paragraph bold size={PARAGRAPH_SIZE.LARGE}>
-                        Located in
-                    </Paragraph>
-                    <Paragraph size={PARAGRAPH_SIZE.SMALL}>
-                        {targetConnection.member.memberProfile.state}
-                    </Paragraph>
-                    <Paragraph bold size={PARAGRAPH_SIZE.LARGE}>
-                        Insurance Provider
-                    </Paragraph>
-                    <Paragraph size={PARAGRAPH_SIZE.SMALL}>
-                        {targetConnection.member.memberProfile.insurance}
-                    </Paragraph>
-                    <Paragraph bold size={PARAGRAPH_SIZE.LARGE}>
-                        Concerns
-                    </Paragraph>
-                    <Paragraph size={PARAGRAPH_SIZE.SMALL}>
-                        {targetConnection.member.memberProfile.concerns.join(
-                            ', '
-                        )}
-                    </Paragraph>
-                    <Paragraph bold size={PARAGRAPH_SIZE.LARGE}>
-                        Goals
-                    </Paragraph>
-                    <Paragraph size={PARAGRAPH_SIZE.SMALL}>
-                        {targetConnection.member.memberProfile.goals.join(', ')}
-                    </Paragraph>
-                    {targetConnection.connectionMessage && (
-                        <>
-                            <Paragraph bold size={PARAGRAPH_SIZE.LARGE}>
-                                Message
-                            </Paragraph>
-                            <Paragraph size={PARAGRAPH_SIZE.SMALL}>
-                                {targetConnection.connectionMessage}
-                            </Paragraph>
-                        </>
-                    )}
-                </DisplayModal>
+                    isLoading={isUpdatingConnectionRequestStatus}
+                    onClose={() => setConfirmationConnectionRequest(undefined)}
+                    onPrimaryButtonClick={(message) =>
+                        handleUpdateConnectionRequest({
+                            ...confirmationConnectionRequest,
+                            message,
+                        })
+                    }
+                />
             )}
         </PageContainer>
     );
 }
-
-/* ---------------------------- Styled components --------------------------- */
 
 const PageContainer = styled(Box)(({ theme }) => ({
     width: '100%',
@@ -230,321 +116,3 @@ const PageContainer = styled(Box)(({ theme }) => ({
 const Title = styled(H1)(({ theme }) => ({
     ...theme.typography.h3,
 }));
-
-const ClientList = styled(List)(({ theme }) => ({
-    width: '100%',
-}));
-
-const ClientListItemContainer = styled(Stack)(({ theme }) => ({
-    padding: theme.spacing(2),
-    display: 'flex',
-    width: '100%',
-    flexDirection: 'row',
-    alignItems: 'center',
-}));
-
-const MemberName = styled(Paragraph)(({ theme }) => ({
-    fontWeight: 500,
-    margin: 0,
-}));
-
-const MemberEmailAddress = styled(Box)(({ theme }) => ({
-    ...theme.typography.body1,
-    color: theme.palette.text.primary,
-    textDecoration: 'none',
-    display: 'flex',
-    alignItems: 'center',
-    flex: 1,
-    maxWidth: '100%',
-    '& a': {
-        display: 'flex',
-        alignItems: 'center',
-        justifyContent: 'center',
-    },
-    '& p': {
-        flex: 1,
-        maxWidth: '100%',
-        overflow: 'hidden',
-        whiteSpace: 'nowrap',
-        textOverflow: 'ellipsis',
-        alignItems: 'center',
-    },
-    '& svg': {
-        color: theme.palette.grey[400],
-        marginRight: theme.spacing(2),
-        '&:hover': {
-            color: theme.palette.primary.main,
-        },
-    },
-}));
-const CellContainer = styled(Box)(({ theme }) => ({
-    display: 'flex',
-    alignItems: 'center',
-    flexWrap: 'wrap',
-    paddingRight: theme.spacing(2),
-    '&:nth-of-type(1)': {
-        flex: 1,
-        [theme.breakpoints.up('md')]: {
-            width: '25%',
-        },
-    },
-    '&:nth-of-type(2)': {
-        display: 'none',
-        [theme.breakpoints.up('md')]: {
-            width: '25%',
-            display: 'flex',
-        },
-    },
-    '&:nth-of-type(3)': {
-        display: 'none',
-        [theme.breakpoints.up('md')]: {
-            width: '25%',
-            display: 'flex',
-        },
-    },
-    '&:nth-of-type(4)': {
-        width: '25%',
-        justifyContent: 'flex-end',
-    },
-}));
-
-const ClientListItem = ({
-    connectionRequest,
-    isSmallScreen,
-    onAccept,
-    onDecline,
-    onTerminate,
-    onView,
-    onOpenChat,
-}: {
-    connectionRequest: ConnectionRequest.Type;
-    isSmallScreen?: boolean;
-    onAccept: () => void;
-    onDecline: () => void;
-    onTerminate: () => void;
-    onView?: () => void;
-    onOpenChat?: () => void;
-}) => {
-    const isPending =
-        connectionRequest.connectionStatus === ConnectionStatus.pending;
-    const isAccepted =
-        connectionRequest.connectionStatus === ConnectionStatus.accepted;
-    const mobileActions = [
-        ...(isPending
-            ? [
-                  {
-                      icon: <CheckCircleOutlineRounded color="success" />,
-                      text: 'Accept',
-                      onClick: onAccept,
-                  },
-                  {
-                      icon: <DoNotDisturbAltRounded color="error" />,
-                      text: 'Decline',
-                      onClick: onDecline,
-                  },
-              ]
-            : []),
-        ...(!onOpenChat
-            ? [
-                  {
-                      icon: <PreviewRounded />,
-                      text: ' View Member Details',
-                      onClick: onView,
-                  },
-              ]
-            : []),
-        ...(onOpenChat
-            ? [
-                  {
-                      icon: <ChatBubbleOutlineRounded />,
-                      text: 'Chat',
-                      onClick: onOpenChat,
-                  },
-              ]
-            : []),
-    ];
-    const actionList = [
-        ...(isSmallScreen ? mobileActions : []),
-        ...(isAccepted
-            ? [
-                  {
-                      text: 'Reimbursement Request',
-                      icon: <PaidOutlined />,
-                      onClick: () => {
-                          window.open(
-                              formatReimbursementRequestUrl(
-                                  REIMBURSEMENT_REQUEST_URL,
-                                  connectionRequest
-                              ),
-                              '_blank'
-                          );
-                      },
-                  },
-                  {
-                      text: 'Remove Client',
-                      icon: <PersonRemoveOutlined />,
-                      onClick: onTerminate,
-                  },
-              ]
-            : []),
-    ];
-
-    return (
-        <ListItem
-            key={connectionRequest.member.id}
-            sx={{ width: '100%', paddingX: 0 }}
-            onClick={onView}
-        >
-            <ClientListItemContainer>
-                <CellContainer>
-                    <Avatar
-                        size={AVATAR_SIZE.EXTRA_SMALL}
-                        sx={{ marginRight: 4 }}
-                    />
-                    <MemberName
-                        sx={{
-                            marginRight:
-                                isPending && !isSmallScreen ? 4 : undefined,
-                        }}
-                    >
-                        {connectionRequest.member.givenName}{' '}
-                        {connectionRequest.member.surname}
-                    </MemberName>
-                    {isPending && !isSmallScreen && (
-                        <Badge
-                            color={BADGE_COLOR.WARNING}
-                            icon={<PendingOutlined />}
-                            size={BADGE_SIZE.SMALL}
-                        >
-                            Pending
-                        </Badge>
-                    )}
-                </CellContainer>
-                <CellContainer>
-                    <MemberEmailAddress>
-                        <Link
-                            title={`Send email to ${connectionRequest.member.givenName}`}
-                            onClick={(e) => e.stopPropagation()}
-                            href={`mailto:${connectionRequest.member.emailAddress}`}
-                            target="_blank"
-                        >
-                            <MailOutline />
-                        </Link>
-                        <Paragraph noMargin>
-                            {connectionRequest.member.emailAddress}
-                        </Paragraph>
-                    </MemberEmailAddress>
-                </CellContainer>
-                <CellContainer>
-                    <Paragraph noMargin>
-                        {connectionRequest.member.account.name}
-                    </Paragraph>
-                </CellContainer>
-                <CellContainer onClick={(e) => e.stopPropagation()}>
-                    {!isSmallScreen && (
-                        <ActionButtons
-                            connectionRequest={connectionRequest}
-                            onAccept={onAccept}
-                            onDecline={onDecline}
-                            onView={onView}
-                            onOpenChat={onOpenChat}
-                        />
-                    )}
-                    {isPending && isSmallScreen && (
-                        <CircleRounded
-                            color="warning"
-                            sx={{
-                                height: '12px',
-                                width: '12px',
-                            }}
-                        />
-                    )}
-                    {actionList.length > 0 && (
-                        <FloatingList
-                            sx={{ marginLeft: 2 }}
-                            headerSlot={
-                                isPending &&
-                                isSmallScreen && (
-                                    <Badge
-                                        color={BADGE_COLOR.WARNING}
-                                        icon={<PendingOutlined />}
-                                        size={BADGE_SIZE.SMALL}
-                                    >
-                                        Pending
-                                    </Badge>
-                                )
-                            }
-                            listItems={actionList}
-                        />
-                    )}
-                </CellContainer>
-            </ClientListItemContainer>
-        </ListItem>
-    );
-};
-
-const ActionButtons = ({
-    connectionRequest,
-    onAccept,
-    onDecline,
-    onView,
-    onOpenChat,
-}: {
-    connectionRequest: ConnectionRequest.Type;
-    onAccept: () => void;
-    onDecline: () => void;
-    onView?: () => void;
-    onOpenChat?: () => void;
-}) => {
-    const isPending =
-        connectionRequest.connectionStatus === ConnectionStatus.pending;
-    const isAccepted =
-        connectionRequest.connectionStatus === ConnectionStatus.accepted;
-    return (
-        <>
-            {isPending && (
-                <>
-                    <Button
-                        size="small"
-                        onClick={onAccept}
-                        sx={{ marginRight: 2 }}
-                    >
-                        Accept
-                    </Button>
-                    <Button
-                        size="small"
-                        type="outlined"
-                        color="info"
-                        onClick={onDecline}
-                    >
-                        Decline
-                    </Button>
-                </>
-            )}
-            {isAccepted && (
-                <>
-                    {!onOpenChat && (
-                        <Button
-                            size="small"
-                            color="info"
-                            type="outlined"
-                            onClick={onView}
-                        >
-                            View Member
-                        </Button>
-                    )}
-                    {onOpenChat && (
-                        <Button
-                            size="small"
-                            color="info"
-                            type="outlined"
-                            onClick={onOpenChat}
-                        >
-                            Chat
-                        </Button>
-                    )}
-                </>
-            )}
-        </>
-    );
-};

--- a/src/lib/shared/components/ui/Typography/Paragraph/index.tsx
+++ b/src/lib/shared/components/ui/Typography/Paragraph/index.tsx
@@ -103,14 +103,14 @@ export const Paragraph = styled(MuiParagraph, {
         fontWeight = PARAGRAPH_FONT_WEIGHT.NORMAL,
         textDecoration,
         noMargin,
-        color = 'text-primary',
+        color,
     }) => {
         return {
             ...getParagraphStyle({ size, theme }),
             fontStyle: italic ? 'italic' : undefined,
             textDecoration: textDecoration ?? 'none',
             fontWeight: bold ? 'bold' : fontWeight,
-            color: getColor(color, theme),
+            color: color ? getColor(color, theme) : undefined,
             ...(noMargin ? { margin: 0 } : {}),
         };
     }

--- a/src/lib/sitemap/menus/therapist-menu/menu.tsx
+++ b/src/lib/sitemap/menus/therapist-menu/menu.tsx
@@ -5,7 +5,6 @@ import {
 } from './links';
 import {
     // ACCOUNT,
-    BILLING_AND_SUBSCRIPTION,
     LOGOUT,
 } from '../accountLinks';
 
@@ -18,7 +17,6 @@ export const THERAPIST_MAIN_MENU = [
 
 export const THERAPIST_SECONDARY_MENU = [
     // { ...ACCOUNT, icon: undefined },
-    BILLING_AND_SUBSCRIPTION,
     LOGOUT,
 ] as const;
 

--- a/src/pages/providers/coach/clients.tsx
+++ b/src/pages/providers/coach/clients.tsx
@@ -5,19 +5,7 @@ import { RBAC } from '@/lib/shared/utils';
 import { ProviderNavigationPage } from '@/lib/shared/components/features/pages/ProviderNavigationPage';
 import { ProviderClientsPageProps } from '@/lib/modules/providers/service/page-props/get-clients-page-props/getProviderClientsPageProps';
 import { ProviderClientListPage } from '@/lib/shared/components/features/pages/ProviderClientListPage/ProviderClientListPage';
-import { ConnectionStatus, ProfileType } from '@prisma/client';
-import { trpc } from '@/lib/shared/utils/trpc';
-import { UpdateConnectionRequestStatus } from '@/lib/modules/directory/features';
-import { useContext, useState } from 'react';
-import { Alerts } from '@/lib/modules/alerts/context';
-import { ConnectionRequest } from '@/lib/shared/types';
-import {
-    CenteredContainer,
-    Modal,
-    Textarea,
-    Divider,
-} from '@/lib/shared/components/ui';
-import { CircularProgress, Box } from '@mui/material';
+import { ProfileType } from '@prisma/client';
 
 export const getServerSideProps = RBAC.requireCoachAuth(
     withPageAuthRequired({
@@ -26,248 +14,22 @@ export const getServerSideProps = RBAC.requireCoachAuth(
     })
 );
 
-type ConnectionAction = 'accept' | 'decline' | 'terminate';
-
 export default function CoachClientsPage({
     user,
-    connectionRequests: baseConnectionRequests,
+    connectionRequests,
 }: ProviderClientsPageProps) {
-    const [connectionRequests, setConnectionRequests] = useState(
-        baseConnectionRequests ?? []
-    );
-    const { createAlert } = useContext(Alerts.Context);
-    const [updateMessage, setUpdateMessage] = useState('');
-    const [targetConnection, setTargetConnection] = useState<{
-        action: ConnectionAction;
-        connectionRequest: ConnectionRequest.Type;
-    }>();
-    const closeModal = () => {
-        setUpdateMessage('');
-        setTargetConnection(undefined);
-    };
-
-    const { mutate: updateConnectionRequestStatus, isLoading } =
-        trpc.useMutation(
-            `directory.${UpdateConnectionRequestStatus.TRPC_ROUTE}`,
-            {
-                onSuccess: (
-                    { success, errors },
-                    { memberId, profileId, connectionStatus }
-                ) => {
-                    if (success) {
-                        createAlert({
-                            type: 'success',
-                            title:
-                                connectionStatus === ConnectionStatus.accepted
-                                    ? `${targetConnection?.connectionRequest.member.givenName} is now your client!`
-                                    : connectionStatus ===
-                                      ConnectionStatus.terminated
-                                    ? `${targetConnection?.connectionRequest.member.givenName} is no longer your client`
-                                    : `Declined successfully`,
-                        });
-                        closeModal();
-                        if (connectionStatus === ConnectionStatus.accepted) {
-                            return setConnectionRequests(
-                                connectionRequests.map((cr) => {
-                                    if (
-                                        cr.member.id === memberId &&
-                                        cr.providerProfile.id === profileId
-                                    ) {
-                                        return {
-                                            ...cr,
-                                            connectionStatus,
-                                        };
-                                    }
-                                    return cr;
-                                })
-                            );
-                        }
-                        return setConnectionRequests(
-                            connectionRequests.filter((cr) => {
-                                const isDeclinedRequest =
-                                    cr.member.id == memberId &&
-                                    cr.providerProfile.id === profileId;
-                                return !isDeclinedRequest;
-                            })
-                        );
-                    }
-                    const [error] = errors;
-                    if (error) {
-                        console.error(error);
-                        createAlert({
-                            type: 'error',
-                            title: error,
-                        });
-                    }
-                },
-                onError: (error) => {
-                    closeModal();
-                    console.error(error);
-                    const errorMessage =
-                        error instanceof Error
-                            ? error.message
-                            : 'An error occurred';
-                    createAlert({
-                        type: 'error',
-                        title: errorMessage,
-                    });
-                },
-            }
-        );
-
-    const handleUpdateConnectionRequest = ({
-        action,
-        connectionRequest,
-    }: {
-        connectionRequest: ConnectionRequest.Type;
-        action: ConnectionAction;
-    }) =>
-        updateConnectionRequestStatus({
-            memberId: connectionRequest.member.id,
-            profileId: connectionRequest.providerProfile.id,
-            connectionStatus:
-                action === 'accept'
-                    ? ConnectionStatus.accepted
-                    : action === 'terminate'
-                    ? ConnectionStatus.terminated
-                    : ConnectionStatus.declined,
-            userId: user.userId,
-            message: updateMessage.trim() !== '' ? updateMessage : undefined,
-        });
-
     return (
         <ProviderNavigationPage
-            currentPath={URL_PATHS.PROVIDERS.THERAPIST.CLIENTS}
+            currentPath={URL_PATHS.PROVIDERS.COACH.CLIENTS}
             user={user}
         >
-            <ProviderClientListPage
-                designation={ProfileType.coach}
-                connectionRequests={connectionRequests}
-                onAcceptConnectionRequest={(connectionRequest) =>
-                    setTargetConnection({
-                        action: 'accept',
-                        connectionRequest,
-                    })
-                }
-                onDeclineConnectionRequest={(connectionRequest) =>
-                    setTargetConnection({
-                        action: 'decline',
-                        connectionRequest,
-                    })
-                }
-                onTerminateConnectionRequest={(connectionRequest) =>
-                    setTargetConnection({
-                        action: 'terminate',
-                        connectionRequest,
-                    })
-                }
-            />
-            {targetConnection && (
-                <ConfirmationModal
-                    action={targetConnection.action}
-                    connectionRequest={targetConnection.connectionRequest}
-                    isLoading={isLoading}
-                    textAreaValue={updateMessage}
-                    onTextAreaChange={setUpdateMessage}
-                    onClose={closeModal}
-                    onPrimaryButtonClick={() =>
-                        handleUpdateConnectionRequest(targetConnection)
-                    }
+            {user && (
+                <ProviderClientListPage
+                    user={user}
+                    designation={ProfileType.coach}
+                    baseConnectionRequests={connectionRequests}
                 />
             )}
         </ProviderNavigationPage>
     );
 }
-
-const ConfirmationModal = (props: {
-    action: ConnectionAction;
-    connectionRequest: ConnectionRequest.Type;
-    isLoading: boolean;
-    textAreaValue: string;
-    onTextAreaChange: (message: string) => void;
-    onClose: () => void;
-    onPrimaryButtonClick: () => void;
-}) => {
-    const {
-        title,
-        message,
-        primaryButtonColor,
-        primaryButtonText,
-        textareaLabel,
-        textareaPlaceholder,
-    } = getConfirmationModalContent(props.action, props.connectionRequest);
-    return (
-        <Modal
-            isOpen
-            title={title}
-            message={!props.isLoading ? message : undefined}
-            onClose={props.onClose}
-            fullWidthButtons
-            primaryButtonColor={primaryButtonColor}
-            primaryButtonText={primaryButtonText}
-            primaryButtonOnClick={props.onPrimaryButtonClick}
-            primaryButtonDisabled={props.isLoading}
-            secondaryButtonText="Cancel"
-            secondaryButtonDisabled={props.isLoading}
-            secondaryButtonOnClick={props.onClose}
-            postBodySlot={
-                props.isLoading ? (
-                    <CenteredContainer width="100%">
-                        <CircularProgress />
-                    </CenteredContainer>
-                ) : (
-                    <Box width="100%">
-                        <Divider />
-                        <Textarea
-                            fullWidth
-                            label={textareaLabel}
-                            placeholder={textareaPlaceholder}
-                            value={props.textAreaValue}
-                            onChange={(e) =>
-                                props.onTextAreaChange(e.target.value)
-                            }
-                        />
-                    </Box>
-                )
-            }
-        />
-    );
-};
-
-const getConfirmationModalContent = (
-    action: ConnectionAction,
-    connectionRequst: ConnectionRequest.Type
-) => {
-    switch (action) {
-        case 'decline':
-            return {
-                title: 'Decline New Client',
-                message: `Declining ${connectionRequst.member.givenName} will notify them that you are unable to accept them as a client at this time.`,
-                primaryButtonColor: 'error' as const,
-                primaryButtonText: 'Decline',
-                textareaLabel: 'Reason for declining (optional)',
-                textareaPlaceholder:
-                    'Let them know why you cannot accept at this time',
-            };
-        case 'terminate':
-            return {
-                title: 'End Client Relationship',
-                message: `Removing ${connectionRequst.member.givenName} as a client will notify them that you are no longer able to provide services.`,
-                primaryButtonColor: 'error' as const,
-                primaryButtonText: 'Remove Client',
-                textareaLabel: 'Note to client (optional)',
-                textareaPlaceholder:
-                    'Let them know why you are no longer able to provide services',
-            };
-        case 'accept':
-        default:
-            return {
-                title: 'Accept New Client?',
-                message: `Accepting ${connectionRequst.member.givenName} will notify them that you are ready to start working with them.`,
-                primaryButtonColor: 'primary' as const,
-                primaryButtonText: 'Accept',
-                textareaLabel: 'Additional Information (optional)',
-                textareaPlaceholder: `Share any additional details here`,
-            };
-    }
-};

--- a/src/pages/providers/practice/clients.tsx
+++ b/src/pages/providers/practice/clients.tsx
@@ -16,7 +16,7 @@ import { trpc } from '@/lib/shared/utils/trpc';
 import { withPageAuthRequired } from '@auth0/nextjs-auth0';
 import { Box, CircularProgress } from '@mui/material';
 import { ConnectionStatus } from '@prisma/client';
-import { useContext, useEffect, useState } from 'react';
+import { useContext, useMemo, useState } from 'react';
 
 export const getServerSideProps = RBAC.requireProviderAuth(
     withPageAuthRequired({
@@ -24,9 +24,12 @@ export const getServerSideProps = RBAC.requireProviderAuth(
             ProvidersService.pageProps.getPracticeClientsPageProps,
     })
 );
-type ProfileConnectionRequest =
-    PracticeProfileConnectionRequests.Type['profileConnectionRequests'][number]['connectionRequests'][number];
-
+type ConfirmationConnectionRequest =
+    | (PracticeProfileConnectionRequests.Type['profileConnectionRequests'][number]['connectionRequests'][number] & {
+          profile: PracticeProfileConnectionRequests.Type['profileConnectionRequests'][number]['providerProfile'];
+      })
+    | undefined;
+type ConnectionAction = 'accept' | 'decline' | 'terminate';
 export default function PracticeClientsPage({
     practiceConnectionRequests: basePracticeConnectionRequests,
     user,
@@ -34,61 +37,46 @@ export default function PracticeClientsPage({
     const { createAlert } = useContext(Alerts.Context);
     const [practiceConnectionRequests, setPracticeConnectionRequests] =
         useState(basePracticeConnectionRequests);
-    const [confirmAction, setConfirmAction] = useState<'accept' | 'decline'>();
     const [updateMessage, setUpdateMessage] = useState('');
-    const [confirmationConnectionRequest, setConfirmationConnectionRequest] =
-        useState<
-            ProfileConnectionRequest & {
-                profile: PracticeProfileConnectionRequests.Type['profileConnectionRequests'][number]['providerProfile'];
-            }
-        >();
     const [targetConnection, setTargetConnection] = useState<{
-        memberId: string;
-        profileId: string;
+        action: ConnectionAction;
+        ids: {
+            memberId: string;
+            profileId: string;
+        };
     }>();
+    const closeModal = () => {
+        setUpdateMessage('');
+        setTargetConnection(undefined);
+    };
 
-    useEffect(() => {
-        if (targetConnection === undefined)
-            return setConfirmationConnectionRequest(undefined);
-        const confirmationProvider =
-            practiceConnectionRequests?.profileConnectionRequests.find(
-                (connection) => {
-                    return (
-                        connection.providerProfile.id ===
-                        targetConnection?.profileId
-                    );
-                }
+    const confirmationConnectionRequest: ConfirmationConnectionRequest =
+        useMemo(() => {
+            if (targetConnection === undefined) return undefined;
+            const provider =
+                practiceConnectionRequests?.profileConnectionRequests.find(
+                    (connection) => {
+                        return (
+                            connection.providerProfile.id ===
+                            targetConnection?.ids.profileId
+                        );
+                    }
+                );
+            const connectionRequest = provider?.connectionRequests.find(
+                (memberRequests) =>
+                    memberRequests.member.id === targetConnection?.ids.memberId
             );
-        const connectionRequest = confirmationProvider?.connectionRequests.find(
-            (memberRequests) =>
-                memberRequests.member.id === targetConnection?.memberId
-        );
-        const confirmationPayload =
-            !!confirmationProvider?.providerProfile && !!connectionRequest
+            return provider?.providerProfile !== undefined &&
+                connectionRequest !== undefined
                 ? {
                       ...connectionRequest,
-                      profile: confirmationProvider.providerProfile,
+                      profile: provider.providerProfile,
                   }
                 : undefined;
-
-        setConfirmationConnectionRequest(confirmationPayload);
-    }, [
-        practiceConnectionRequests?.profileConnectionRequests,
-        targetConnection,
-    ]);
-
-    const setUpConfirmationModal = (
-        action: 'accept' | 'decline',
-        request: { memberId: string; profileId: string }
-    ) => {
-        setTargetConnection(request);
-        setConfirmAction(action);
-    };
-
-    const clearConfirmationModal = () => {
-        setTargetConnection(undefined);
-        setConfirmAction(undefined);
-    };
+        }, [
+            practiceConnectionRequests?.profileConnectionRequests,
+            targetConnection,
+        ]);
 
     const handleSuccess = ({
         connectionStatus,
@@ -107,6 +95,11 @@ export default function PracticeClientsPage({
                           confirmationConnectionRequest?.member.givenName ??
                           'The member'
                       } is now a client!`
+                    : connectionStatus === ConnectionStatus.terminated
+                    ? `Removed ${
+                          confirmationConnectionRequest?.member.givenName ??
+                          'the member'
+                      } as a client`
                     : `Declined successfully`,
         });
         if (connectionStatus === ConnectionStatus.accepted) {
@@ -139,7 +132,7 @@ export default function PracticeClientsPage({
                     ),
             });
         }
-        // Remove the declined connection request
+        // Remove the declined or terminated connection request
         return setPracticeConnectionRequests({
             ...practiceConnectionRequests,
             profileConnectionRequests:
@@ -172,7 +165,6 @@ export default function PracticeClientsPage({
                     { success, errors },
                     { memberId, profileId, connectionStatus }
                 ) => {
-                    clearConfirmationModal();
                     if (success) {
                         return handleSuccess({
                             connectionStatus,
@@ -180,6 +172,7 @@ export default function PracticeClientsPage({
                             profileId,
                         });
                     }
+                    closeModal();
                     const [error] = errors;
                     if (error) {
                         console.error(error);
@@ -190,7 +183,7 @@ export default function PracticeClientsPage({
                     }
                 },
                 onError: (error) => {
-                    clearConfirmationModal();
+                    closeModal();
                     console.error(error);
                     const errorMessage =
                         error instanceof Error
@@ -204,19 +197,24 @@ export default function PracticeClientsPage({
             }
         );
 
-    const handleUpdateConnectionRequest = (
-        { memberId, profileId }: { memberId: string; profileId: string },
-        action: 'accept' | 'decline'
-    ) =>
+    const handleUpdateConnectionRequest = ({
+        ids: { memberId, profileId },
+        action,
+    }: {
+        ids: { memberId: string; profileId: string };
+        action: ConnectionAction;
+    }) =>
         updateConnectionRequestStatus({
             memberId,
             profileId,
             connectionStatus:
                 action === 'accept'
                     ? ConnectionStatus.accepted
+                    : action === 'terminate'
+                    ? ConnectionStatus.terminated
                     : ConnectionStatus.declined,
             userId: user.userId,
-            message: updateMessage.trim() === '' ? updateMessage : undefined,
+            message: updateMessage.trim() !== '' ? updateMessage : undefined,
         });
     return (
         <PracticeAdminNavigationPage
@@ -226,77 +224,131 @@ export default function PracticeClientsPage({
             {practiceConnectionRequests && (
                 <PracticeClientListPage
                     practiceConnectionRequests={practiceConnectionRequests}
-                    onAcceptConnectionRequest={(input) => {
-                        setUpConfirmationModal('accept', input);
-                    }}
-                    onDeclineConnectionRequest={(input) => {
-                        setUpConfirmationModal('decline', input);
-                    }}
+                    onAcceptConnectionRequest={(ids) =>
+                        setTargetConnection({
+                            action: 'accept',
+                            ids,
+                        })
+                    }
+                    onDeclineConnectionRequest={(ids) =>
+                        setTargetConnection({
+                            action: 'decline',
+                            ids,
+                        })
+                    }
+                    onTerminateConnectionRequest={(ids) =>
+                        setTargetConnection({
+                            action: 'terminate',
+                            ids,
+                        })
+                    }
                 />
             )}
-            {confirmAction &&
-                targetConnection &&
-                confirmationConnectionRequest && (
-                    <Modal
-                        isOpen
-                        title={
-                            confirmAction === 'accept'
-                                ? 'Accept new client?'
-                                : 'Decline new client'
-                        }
-                        message={
-                            confirmAction === 'accept' && !isLoading
-                                ? `Accepting ${confirmationConnectionRequest.member.givenName} will notify them that ${confirmationConnectionRequest.profile.givenName} is ready to start working with them.`
-                                : undefined
-                        }
-                        onClose={clearConfirmationModal}
-                        fullWidthButtons
-                        primaryButtonColor={
-                            confirmAction === 'accept' ? 'primary' : 'error'
-                        }
-                        primaryButtonText={
-                            confirmAction === 'accept' ? 'Accept' : 'Decline'
-                        }
-                        primaryButtonOnClick={() => {
-                            handleUpdateConnectionRequest(
-                                targetConnection,
-                                confirmAction
-                            );
-                        }}
-                        primaryButtonDisabled={isLoading}
-                        secondaryButtonText="Cancel"
-                        secondaryButtonDisabled={isLoading}
-                        secondaryButtonOnClick={clearConfirmationModal}
-                        postBodySlot={
-                            isLoading ? (
-                                <CenteredContainer width="100%">
-                                    <CircularProgress />
-                                </CenteredContainer>
-                            ) : (
-                                <Box width="100%">
-                                    {confirmAction === 'accept' && <Divider />}
-                                    <Textarea
-                                        fullWidth
-                                        label={
-                                            confirmAction === 'accept'
-                                                ? 'Share any additional details here (optional)'
-                                                : 'Reason for declining (optional)'
-                                        }
-                                        placeholder={
-                                            confirmAction === 'accept'
-                                                ? 'Let them know about any unique next steps'
-                                                : 'Let them know why you cannot accept at this time'
-                                        }
-                                        value={updateMessage}
-                                        onChange={(e) =>
-                                            setUpdateMessage(e.target.value)
-                                        }
-                                    />
-                                </Box>
-                            )
-                        }
-                    />
-                )}
+            {targetConnection && confirmationConnectionRequest && (
+                <ConfirmationModal
+                    action={targetConnection.action}
+                    connectionRequest={confirmationConnectionRequest}
+                    onClose={closeModal}
+                    onPrimaryButtonClick={() => {
+                        handleUpdateConnectionRequest(targetConnection);
+                    }}
+                    isLoading={isLoading}
+                    textAreaValue={updateMessage}
+                    onTextAreaChange={(message) => setUpdateMessage(message)}
+                />
+            )}
         </PracticeAdminNavigationPage>
     );
 }
+
+const ConfirmationModal = (props: {
+    action: ConnectionAction;
+    connectionRequest: Exclude<ConfirmationConnectionRequest, undefined>;
+    isLoading: boolean;
+    textAreaValue: string;
+    onTextAreaChange: (message: string) => void;
+    onClose: () => void;
+    onPrimaryButtonClick: () => void;
+}) => {
+    const {
+        title,
+        message,
+        primaryButtonColor,
+        primaryButtonText,
+        textareaLabel,
+        textareaPlaceholder,
+    } = getConfirmationModalContent(props.action, props.connectionRequest);
+    return (
+        <Modal
+            isOpen
+            title={title}
+            message={message}
+            onClose={props.onClose}
+            fullWidthButtons
+            primaryButtonColor={primaryButtonColor}
+            primaryButtonText={primaryButtonText}
+            primaryButtonOnClick={props.onPrimaryButtonClick}
+            primaryButtonDisabled={props.isLoading}
+            secondaryButtonText="Cancel"
+            secondaryButtonDisabled={props.isLoading}
+            secondaryButtonOnClick={props.onClose}
+            postBodySlot={
+                props.isLoading ? (
+                    <CenteredContainer width="100%">
+                        <CircularProgress />
+                    </CenteredContainer>
+                ) : (
+                    <Box width="100%">
+                        <Divider />
+                        <Textarea
+                            fullWidth
+                            label={textareaLabel}
+                            helperText="* This note will be shared with the client."
+                            placeholder={textareaPlaceholder}
+                            value={props.textAreaValue}
+                            onChange={(e) =>
+                                props.onTextAreaChange(e.target.value)
+                            }
+                        />
+                    </Box>
+                )
+            }
+        />
+    );
+};
+
+const getConfirmationModalContent = (
+    action: ConnectionAction,
+    connectionRequst: Exclude<ConfirmationConnectionRequest, undefined>
+) => {
+    switch (action) {
+        case 'decline':
+            return {
+                title: 'Decline New Client',
+                message: `Declining ${connectionRequst.member.givenName} will notify them that ${connectionRequst.profile.givenName} is unable to accept them as a client at this time.`,
+                primaryButtonColor: 'error' as const,
+                primaryButtonText: 'Decline',
+                textareaLabel: 'Reason for declining (optional)',
+                textareaPlaceholder: `Let them know why ${connectionRequst.profile.givenName} cannot accept at this time`,
+            };
+        case 'terminate':
+            return {
+                title: 'End Client Relationship',
+                message: `Removing ${connectionRequst.member.givenName} as a client will notify them that ${connectionRequst.profile.givenName} is no longer able to provide services.`,
+                primaryButtonColor: 'error' as const,
+                primaryButtonText: 'Remove Client',
+                textareaLabel: 'Note to client (optional)',
+                textareaPlaceholder: `Let them know why ${connectionRequst.profile.givenName} is no longer able to provide services`,
+            };
+        case 'accept':
+        default:
+            return {
+                title: 'Accept New Client?',
+                message: `Accepting ${connectionRequst.member.givenName} will notify them that ${connectionRequst.profile.givenName} is ready to start working with them.`,
+                primaryButtonColor: 'primary' as const,
+                primaryButtonText: 'Accept',
+                textareaLabel: 'Additional Information (optional)',
+                textareaPlaceholder: `Share any additional details here`,
+            };
+    }
+};

--- a/src/pages/providers/practice/clients.tsx
+++ b/src/pages/providers/practice/clients.tsx
@@ -166,7 +166,7 @@ export default function PracticeClientsPage({
                     { memberId, profileId, connectionStatus }
                 ) => {
                     if (success) {
-                        return handleSuccess({
+                        handleSuccess({
                             connectionStatus,
                             memberId,
                             profileId,

--- a/src/pages/providers/practice/profiles/index.tsx
+++ b/src/pages/providers/practice/profiles/index.tsx
@@ -154,6 +154,15 @@ export default function PracticeProfilesPage({
                     });
                 }
             },
+            onError: (error) => {
+                console.error(error);
+                createAlert({
+                    type: 'error',
+                    title:
+                        error?.message ??
+                        'There was an issue updating the directory listing',
+                });
+            },
         });
 
     const { mutate: createInvitation, isLoading: isCreatingInvitation } =
@@ -177,6 +186,15 @@ export default function PracticeProfilesPage({
                             title: error,
                         });
                     }
+                },
+                onError: (error) => {
+                    console.error(error);
+                    createAlert({
+                        type: 'error',
+                        title:
+                            error?.message ??
+                            'There was an issue sending the invitation',
+                    });
                 },
             }
         );

--- a/src/pages/providers/therapist/clients.tsx
+++ b/src/pages/providers/therapist/clients.tsx
@@ -5,19 +5,7 @@ import { RBAC } from '@/lib/shared/utils';
 import { ProviderNavigationPage } from '@/lib/shared/components/features/pages/ProviderNavigationPage';
 import { ProviderClientsPageProps } from '@/lib/modules/providers/service/page-props/get-clients-page-props/getProviderClientsPageProps';
 import { ProviderClientListPage } from '@/lib/shared/components/features/pages/ProviderClientListPage/ProviderClientListPage';
-import { ConnectionStatus, ProfileType } from '@prisma/client';
-import { trpc } from '@/lib/shared/utils/trpc';
-import { UpdateConnectionRequestStatus } from '@/lib/modules/directory/features';
-import { useContext, useState } from 'react';
-import { Alerts } from '@/lib/modules/alerts/context';
-import { ConnectionRequest } from '@/lib/shared/types';
-import {
-    CenteredContainer,
-    Modal,
-    Textarea,
-    Divider,
-} from '@/lib/shared/components/ui';
-import { CircularProgress, Box } from '@mui/material';
+import { ProfileType } from '@prisma/client';
 
 export const getServerSideProps = RBAC.requireTherapistAuth(
     withPageAuthRequired({
@@ -26,248 +14,22 @@ export const getServerSideProps = RBAC.requireTherapistAuth(
     })
 );
 
-type ConnectionAction = 'accept' | 'decline' | 'terminate';
-
 export default function TherapistClientsPage({
     user,
-    connectionRequests: baseConnectionRequests,
+    connectionRequests,
 }: ProviderClientsPageProps) {
-    const [connectionRequests, setConnectionRequests] = useState(
-        baseConnectionRequests ?? []
-    );
-    const { createAlert } = useContext(Alerts.Context);
-    const [updateMessage, setUpdateMessage] = useState('');
-    const [targetConnection, setTargetConnection] = useState<{
-        action: ConnectionAction;
-        connectionRequest: ConnectionRequest.Type;
-    }>();
-    const closeModal = () => {
-        setUpdateMessage('');
-        setTargetConnection(undefined);
-    };
-
-    const { mutate: updateConnectionRequestStatus, isLoading } =
-        trpc.useMutation(
-            `directory.${UpdateConnectionRequestStatus.TRPC_ROUTE}`,
-            {
-                onSuccess: (
-                    { success, errors },
-                    { memberId, profileId, connectionStatus }
-                ) => {
-                    if (success) {
-                        createAlert({
-                            type: 'success',
-                            title:
-                                connectionStatus === ConnectionStatus.accepted
-                                    ? `${targetConnection?.connectionRequest.member.givenName} is now your client!`
-                                    : connectionStatus ===
-                                      ConnectionStatus.terminated
-                                    ? `${targetConnection?.connectionRequest.member.givenName} is no longer your client`
-                                    : `Declined successfully`,
-                        });
-                        closeModal();
-                        if (connectionStatus === ConnectionStatus.accepted) {
-                            return setConnectionRequests(
-                                connectionRequests.map((cr) => {
-                                    if (
-                                        cr.member.id === memberId &&
-                                        cr.providerProfile.id === profileId
-                                    ) {
-                                        return {
-                                            ...cr,
-                                            connectionStatus,
-                                        };
-                                    }
-                                    return cr;
-                                })
-                            );
-                        }
-                        return setConnectionRequests(
-                            connectionRequests.filter((cr) => {
-                                const isDeclinedRequest =
-                                    cr.member.id == memberId &&
-                                    cr.providerProfile.id === profileId;
-                                return !isDeclinedRequest;
-                            })
-                        );
-                    }
-                    const [error] = errors;
-                    if (error) {
-                        console.error(error);
-                        createAlert({
-                            type: 'error',
-                            title: error,
-                        });
-                    }
-                },
-                onError: (error) => {
-                    closeModal();
-                    console.error(error);
-                    const errorMessage =
-                        error instanceof Error
-                            ? error.message
-                            : 'An error occurred';
-                    createAlert({
-                        type: 'error',
-                        title: errorMessage,
-                    });
-                },
-            }
-        );
-
-    const handleUpdateConnectionRequest = ({
-        action,
-        connectionRequest,
-    }: {
-        connectionRequest: ConnectionRequest.Type;
-        action: ConnectionAction;
-    }) =>
-        updateConnectionRequestStatus({
-            memberId: connectionRequest.member.id,
-            profileId: connectionRequest.providerProfile.id,
-            connectionStatus:
-                action === 'accept'
-                    ? ConnectionStatus.accepted
-                    : action === 'terminate'
-                    ? ConnectionStatus.terminated
-                    : ConnectionStatus.declined,
-            userId: user.userId,
-            message: updateMessage.trim() !== '' ? updateMessage : undefined,
-        });
-
     return (
         <ProviderNavigationPage
             currentPath={URL_PATHS.PROVIDERS.THERAPIST.CLIENTS}
             user={user}
         >
-            <ProviderClientListPage
-                designation={ProfileType.therapist}
-                connectionRequests={connectionRequests}
-                onAcceptConnectionRequest={(connectionRequest) =>
-                    setTargetConnection({
-                        action: 'accept',
-                        connectionRequest,
-                    })
-                }
-                onDeclineConnectionRequest={(connectionRequest) =>
-                    setTargetConnection({
-                        action: 'decline',
-                        connectionRequest,
-                    })
-                }
-                onTerminateConnectionRequest={(connectionRequest) =>
-                    setTargetConnection({
-                        action: 'terminate',
-                        connectionRequest,
-                    })
-                }
-            />
-            {targetConnection && (
-                <ConfirmationModal
-                    action={targetConnection.action}
-                    connectionRequest={targetConnection.connectionRequest}
-                    isLoading={isLoading}
-                    textAreaValue={updateMessage}
-                    onTextAreaChange={setUpdateMessage}
-                    onClose={closeModal}
-                    onPrimaryButtonClick={() =>
-                        handleUpdateConnectionRequest(targetConnection)
-                    }
+            {user && (
+                <ProviderClientListPage
+                    user={user}
+                    designation={ProfileType.therapist}
+                    baseConnectionRequests={connectionRequests}
                 />
             )}
         </ProviderNavigationPage>
     );
 }
-
-const ConfirmationModal = (props: {
-    action: ConnectionAction;
-    connectionRequest: ConnectionRequest.Type;
-    isLoading: boolean;
-    textAreaValue: string;
-    onTextAreaChange: (message: string) => void;
-    onClose: () => void;
-    onPrimaryButtonClick: () => void;
-}) => {
-    const {
-        title,
-        message,
-        primaryButtonColor,
-        primaryButtonText,
-        textareaLabel,
-        textareaPlaceholder,
-    } = getConfirmationModalContent(props.action, props.connectionRequest);
-    return (
-        <Modal
-            isOpen
-            title={title}
-            message={!props.isLoading ? message : undefined}
-            onClose={props.onClose}
-            fullWidthButtons
-            primaryButtonColor={primaryButtonColor}
-            primaryButtonText={primaryButtonText}
-            primaryButtonOnClick={props.onPrimaryButtonClick}
-            primaryButtonDisabled={props.isLoading}
-            secondaryButtonText="Cancel"
-            secondaryButtonDisabled={props.isLoading}
-            secondaryButtonOnClick={props.onClose}
-            postBodySlot={
-                props.isLoading ? (
-                    <CenteredContainer width="100%">
-                        <CircularProgress />
-                    </CenteredContainer>
-                ) : (
-                    <Box width="100%">
-                        <Divider />
-                        <Textarea
-                            fullWidth
-                            label={textareaLabel}
-                            placeholder={textareaPlaceholder}
-                            value={props.textAreaValue}
-                            onChange={(e) =>
-                                props.onTextAreaChange(e.target.value)
-                            }
-                        />
-                    </Box>
-                )
-            }
-        />
-    );
-};
-
-const getConfirmationModalContent = (
-    action: ConnectionAction,
-    connectionRequst: ConnectionRequest.Type
-) => {
-    switch (action) {
-        case 'decline':
-            return {
-                title: 'Decline New Client',
-                message: `Declining ${connectionRequst.member.givenName} will notify them that you are unable to accept them as a client at this time.`,
-                primaryButtonColor: 'error' as const,
-                primaryButtonText: 'Decline',
-                textareaLabel: 'Reason for declining (optional)',
-                textareaPlaceholder:
-                    'Let them know why you cannot accept at this time',
-            };
-        case 'terminate':
-            return {
-                title: 'End Client Relationship',
-                message: `Removing ${connectionRequst.member.givenName} as a client will notify them that you are no longer able to provide services.`,
-                primaryButtonColor: 'error' as const,
-                primaryButtonText: 'Remove Client',
-                textareaLabel: 'Note to client (optional)',
-                textareaPlaceholder:
-                    'Let them know why you are no longer able to provide services',
-            };
-        case 'accept':
-        default:
-            return {
-                title: 'Accept New Client?',
-                message: `Accepting ${connectionRequst.member.givenName} will notify them that you are ready to start working with them.`,
-                primaryButtonColor: 'primary' as const,
-                primaryButtonText: 'Accept',
-                textareaLabel: 'Additional Information (optional)',
-                textareaPlaceholder: `Share any additional details here`,
-            };
-    }
-};

--- a/src/pages/providers/therapist/clients.tsx
+++ b/src/pages/providers/therapist/clients.tsx
@@ -26,6 +26,8 @@ export const getServerSideProps = RBAC.requireTherapistAuth(
     })
 );
 
+type ConnectionAction = 'accept' | 'decline' | 'terminate';
+
 export default function TherapistClientsPage({
     user,
     connectionRequests: baseConnectionRequests,
@@ -34,22 +36,14 @@ export default function TherapistClientsPage({
         baseConnectionRequests ?? []
     );
     const { createAlert } = useContext(Alerts.Context);
-    const [confirmAction, setConfirmAction] = useState<'accept' | 'decline'>();
     const [updateMessage, setUpdateMessage] = useState('');
-    const [targetConnection, setTargetConnection] =
-        useState<ConnectionRequest.Type>();
-
-    const setUpConfirmationModal = (
-        action: 'accept' | 'decline',
-        request: ConnectionRequest.Type
-    ) => {
-        setTargetConnection(request);
-        setConfirmAction(action);
-    };
-
-    const clearConfirmationModal = () => {
+    const [targetConnection, setTargetConnection] = useState<{
+        action: ConnectionAction;
+        connectionRequest: ConnectionRequest.Type;
+    }>();
+    const closeModal = () => {
+        setUpdateMessage('');
         setTargetConnection(undefined);
-        setConfirmAction(undefined);
     };
 
     const { mutate: updateConnectionRequestStatus, isLoading } =
@@ -60,15 +54,18 @@ export default function TherapistClientsPage({
                     { success, errors },
                     { memberId, profileId, connectionStatus }
                 ) => {
-                    clearConfirmationModal();
                     if (success) {
                         createAlert({
                             type: 'success',
                             title:
                                 connectionStatus === ConnectionStatus.accepted
-                                    ? `${targetConnection?.member.givenName} is now your client!`
+                                    ? `${targetConnection?.connectionRequest.member.givenName} is now your client!`
+                                    : connectionStatus ===
+                                      ConnectionStatus.terminated
+                                    ? `${targetConnection?.connectionRequest.member.givenName} is no longer your client`
                                     : `Declined successfully`,
                         });
+                        closeModal();
                         if (connectionStatus === ConnectionStatus.accepted) {
                             return setConnectionRequests(
                                 connectionRequests.map((cr) => {
@@ -104,7 +101,7 @@ export default function TherapistClientsPage({
                     }
                 },
                 onError: (error) => {
-                    clearConfirmationModal();
+                    closeModal();
                     console.error(error);
                     const errorMessage =
                         error instanceof Error
@@ -118,19 +115,24 @@ export default function TherapistClientsPage({
             }
         );
 
-    const handleUpdateConnectionRequest = (
-        request: ConnectionRequest.Type,
-        action: 'accept' | 'decline'
-    ) =>
+    const handleUpdateConnectionRequest = ({
+        action,
+        connectionRequest,
+    }: {
+        connectionRequest: ConnectionRequest.Type;
+        action: ConnectionAction;
+    }) =>
         updateConnectionRequestStatus({
-            memberId: request.member.id,
-            profileId: request.providerProfile.id,
+            memberId: connectionRequest.member.id,
+            profileId: connectionRequest.providerProfile.id,
             connectionStatus:
                 action === 'accept'
                     ? ConnectionStatus.accepted
+                    : action === 'terminate'
+                    ? ConnectionStatus.terminated
                     : ConnectionStatus.declined,
             userId: user.userId,
-            message: updateMessage.trim() === '' ? updateMessage : undefined,
+            message: updateMessage.trim() !== '' ? updateMessage : undefined,
         });
 
     return (
@@ -141,74 +143,131 @@ export default function TherapistClientsPage({
             <ProviderClientListPage
                 designation={ProfileType.therapist}
                 connectionRequests={connectionRequests}
-                onAcceptConnectionRequest={(request) =>
-                    setUpConfirmationModal('accept', request)
+                onAcceptConnectionRequest={(connectionRequest) =>
+                    setTargetConnection({
+                        action: 'accept',
+                        connectionRequest,
+                    })
                 }
-                onDeclineConnectionRequest={(request) =>
-                    setUpConfirmationModal('decline', request)
+                onDeclineConnectionRequest={(connectionRequest) =>
+                    setTargetConnection({
+                        action: 'decline',
+                        connectionRequest,
+                    })
+                }
+                onTerminateConnectionRequest={(connectionRequest) =>
+                    setTargetConnection({
+                        action: 'terminate',
+                        connectionRequest,
+                    })
                 }
             />
-            {confirmAction && targetConnection && (
-                <Modal
-                    isOpen
-                    title={
-                        confirmAction === 'accept'
-                            ? 'Accept new client?'
-                            : 'Decline new client'
-                    }
-                    message={
-                        confirmAction === 'accept' && !isLoading
-                            ? `Accepting ${targetConnection.member.givenName} will notify them that you are ready to start working together.`
-                            : undefined
-                    }
-                    onClose={clearConfirmationModal}
-                    fullWidthButtons
-                    primaryButtonColor={
-                        confirmAction === 'accept' ? 'primary' : 'error'
-                    }
-                    primaryButtonText={
-                        confirmAction === 'accept' ? 'Accept' : 'Decline'
-                    }
-                    primaryButtonOnClick={() => {
-                        handleUpdateConnectionRequest(
-                            targetConnection,
-                            confirmAction
-                        );
-                    }}
-                    primaryButtonDisabled={isLoading}
-                    secondaryButtonText="Cancel"
-                    secondaryButtonDisabled={isLoading}
-                    secondaryButtonOnClick={clearConfirmationModal}
-                    postBodySlot={
-                        isLoading ? (
-                            <CenteredContainer width="100%">
-                                <CircularProgress />
-                            </CenteredContainer>
-                        ) : (
-                            <Box width="100%">
-                                {confirmAction === 'accept' && <Divider />}
-                                <Textarea
-                                    fullWidth
-                                    label={
-                                        confirmAction === 'accept'
-                                            ? 'Share any additional details here (optional)'
-                                            : 'Reason for declining (optional)'
-                                    }
-                                    placeholder={
-                                        confirmAction === 'accept'
-                                            ? 'Let them know about any unique next steps'
-                                            : 'Let them know why you cannot accept at this time'
-                                    }
-                                    value={updateMessage}
-                                    onChange={(e) =>
-                                        setUpdateMessage(e.target.value)
-                                    }
-                                />
-                            </Box>
-                        )
+            {targetConnection && (
+                <ConfirmationModal
+                    action={targetConnection.action}
+                    connectionRequest={targetConnection.connectionRequest}
+                    isLoading={isLoading}
+                    textAreaValue={updateMessage}
+                    onTextAreaChange={setUpdateMessage}
+                    onClose={closeModal}
+                    onPrimaryButtonClick={() =>
+                        handleUpdateConnectionRequest(targetConnection)
                     }
                 />
             )}
         </ProviderNavigationPage>
     );
 }
+
+const ConfirmationModal = (props: {
+    action: ConnectionAction;
+    connectionRequest: ConnectionRequest.Type;
+    isLoading: boolean;
+    textAreaValue: string;
+    onTextAreaChange: (message: string) => void;
+    onClose: () => void;
+    onPrimaryButtonClick: () => void;
+}) => {
+    const {
+        title,
+        message,
+        primaryButtonColor,
+        primaryButtonText,
+        textareaLabel,
+        textareaPlaceholder,
+    } = getConfirmationModalContent(props.action, props.connectionRequest);
+    return (
+        <Modal
+            isOpen
+            title={title}
+            message={!props.isLoading ? message : undefined}
+            onClose={props.onClose}
+            fullWidthButtons
+            primaryButtonColor={primaryButtonColor}
+            primaryButtonText={primaryButtonText}
+            primaryButtonOnClick={props.onPrimaryButtonClick}
+            primaryButtonDisabled={props.isLoading}
+            secondaryButtonText="Cancel"
+            secondaryButtonDisabled={props.isLoading}
+            secondaryButtonOnClick={props.onClose}
+            postBodySlot={
+                props.isLoading ? (
+                    <CenteredContainer width="100%">
+                        <CircularProgress />
+                    </CenteredContainer>
+                ) : (
+                    <Box width="100%">
+                        <Divider />
+                        <Textarea
+                            fullWidth
+                            label={textareaLabel}
+                            placeholder={textareaPlaceholder}
+                            value={props.textAreaValue}
+                            onChange={(e) =>
+                                props.onTextAreaChange(e.target.value)
+                            }
+                        />
+                    </Box>
+                )
+            }
+        />
+    );
+};
+
+const getConfirmationModalContent = (
+    action: ConnectionAction,
+    connectionRequst: ConnectionRequest.Type
+) => {
+    switch (action) {
+        case 'decline':
+            return {
+                title: 'Decline New Client',
+                message: `Declining ${connectionRequst.member.givenName} will notify them that you are unable to accept them as a client at this time.`,
+                primaryButtonColor: 'error' as const,
+                primaryButtonText: 'Decline',
+                textareaLabel: 'Reason for declining (optional)',
+                textareaPlaceholder:
+                    'Let them know why you cannot accept at this time',
+            };
+        case 'terminate':
+            return {
+                title: 'End Client Relationship',
+                message: `Removing ${connectionRequst.member.givenName} as a client will notify them that you are no longer able to provide services.`,
+                primaryButtonColor: 'error' as const,
+                primaryButtonText: 'Remove Client',
+                textareaLabel: 'Note to client (optional)',
+                textareaPlaceholder:
+                    'Let them know why you are no longer able to provide services',
+            };
+        case 'accept':
+        default:
+            return {
+                title: 'Accept New Client?',
+                message: `Accepting ${connectionRequst.member.givenName} will notify them that you are ready to start working with them.`,
+                primaryButtonColor: 'primary' as const,
+                primaryButtonText: 'Accept',
+                textareaLabel: 'Additional Information (optional)',
+                textareaPlaceholder: `Share any additional details here`,
+            };
+    }
+};


### PR DESCRIPTION
# Description
Adds termination connection request status and UI support to terminate clients.
Refactors Therapist and Coach client pages to reuse the same UI

# Closes issue(s)

# How to test / repro

# Screenshots
![image](https://user-images.githubusercontent.com/25045075/221799453-a1642422-9ad8-48a6-a028-e5aebe61e8fd.png)
![image](https://user-images.githubusercontent.com/25045075/221799487-86c03315-a250-47d7-add1-c9b468aceeaa.png)


# Changes include

-   [ ] Bugfix (non-breaking change that solves an issue)
-   [x] New feature (non-breaking change that adds functionality)
-   [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Checklist

-   [ ] I have tested this code
-   [ ] I have updated the Readme

# Other comments
