### PR TITLE
chore: v1 directory results filtering

### DIFF
--- a/src/lib/modules/directory/features/provider-search/input.ts
+++ b/src/lib/modules/directory/features/provider-search/input.ts
@@ -1,6 +1,8 @@
+import { State } from '@/lib/shared/types';
 import * as z from 'zod';
 
 export const schema = z.object({
+    state: z.enum(State.ENTRIES),
     memberPreferences: z
         .object({
             insuranceProvider: z.string().optional(),
@@ -9,7 +11,6 @@ export const schema = z.object({
             languages: z.string().array().optional(),
         })
         .optional(),
-    state: z.string().optional(),
     insuranceProvider: z.string().optional(),
     gender: z.string().optional(),
     specialties: z.string().array().optional(),

--- a/src/lib/modules/directory/features/provider-search/output.ts
+++ b/src/lib/modules/directory/features/provider-search/output.ts
@@ -1,6 +1,9 @@
+import { DirectoryProfile } from '@/lib/shared/types/presentation';
 import * as z from 'zod';
 
-export const schema = z.object({});
+export const schema = z.object({
+    profiles: DirectoryProfile.schema.array(),
+});
 
 export type Output = z.infer<typeof schema>;
 

--- a/src/lib/modules/directory/service/execute-provider-search/executeProviderSearch.spec.ts
+++ b/src/lib/modules/directory/service/execute-provider-search/executeProviderSearch.spec.ts
@@ -1,0 +1,200 @@
+import { factory } from './executeProviderSearch';
+import { prismaMock } from '@/lib/prisma/__mock__';
+import { addYears } from 'date-fns';
+import { ProviderProfile, ProfileType, NewClientStatus } from '@prisma/client';
+import {
+    AgeGroup,
+    AreaOfFocus,
+    CommunitiesServed,
+    Ethnicity,
+    EvidenceBasedApproach,
+    Gender,
+    InsuranceProvider,
+    Language,
+    Modality,
+    Pronoun,
+} from '@/lib/shared/types';
+
+const mockProviderProfile: ProviderProfile = {
+    createdAt: new Date('2021-03-01'),
+    updatedAt: new Date('2021-03-01'),
+    id: 'test-provider-profile-id',
+    supervisor: null,
+    givenName: 'John',
+    surname: 'Doe',
+    contactEmail: 'test@test.com',
+    userId: 'test-user-id',
+    bio: 'Seeking therapy is a big step that provokes pressing emotional questions: “How can therapy help me? Am I ready to spill my guts to a stranger?” There are logistical challenges: “What will this cost? How can I make the time?” In these days of navigating the ongoing impacts of the pandemic, you likely need support more than ever as you evaluate how you want to live, love, and work. In my practice, I help clients confront the challenges in their lives, including depression, anxiety, substance misuse, and relationship difficulties.',
+    npiNumber: '12345',
+    offersSlidingScale: true,
+    profileImageUrl:
+        'https://images.pexels.com/photos/1722198/pexels-photo-1722198.jpeg?auto=compress&cs=tinysrgb&w=1600',
+    yearsOfExperience: '10+',
+    minimumRate: 100,
+    maximumRate: 180,
+    idealClientDescription:
+        'I work with adults, adolescents, and couples. I specialize in working with individuals who are struggling with anxiety, depression, and relationship issues. I also have experience working with individuals who are struggling with substance use and addiction. I am LGBTQIA+ affirming and welcome clients from all backgrounds.',
+    practiceNotes:
+        'I am goal oriented and believe that therapy should be a collaborative process. I work with clients to identify their goals and develop a plan to achieve them. I believe that therapy is a safe space to explore your thoughts and feelings and to work through difficult situations. I am a firm believer in the power of therapy and the ability of clients to make positive changes in their lives.',
+    gender: Gender.MAP.MALE,
+    credentials: [
+        {
+            state: 'Tennessee',
+            licenseNumber: '123456',
+            type: 'LMFT',
+            expirationDate: addYears(new Date(), 1).toISOString(),
+        },
+        {
+            state: 'New York',
+            licenseNumber: '123456',
+            type: 'LMFT',
+            expirationDate: addYears(new Date(), 1).toISOString(),
+        },
+    ],
+    acceptedInsurances: [
+        {
+            state: 'Tennessee',
+            insurances: [
+                InsuranceProvider.MAP.AETNA,
+                InsuranceProvider.MAP.AMERIHEALTH,
+                InsuranceProvider.MAP.BLUECROSS_BLUESHIELD,
+            ],
+        },
+        {
+            state: 'New York',
+            insurances: [InsuranceProvider.MAP.BLUECROSS_BLUESHIELD],
+        },
+    ],
+    specialties: [
+        AreaOfFocus.MAP.DEPRESSION,
+        AreaOfFocus.MAP.SELF_ESTEEM,
+        AreaOfFocus.MAP.STRESS,
+        AreaOfFocus.MAP.PARENTING,
+    ],
+    ethnicity: [
+        Ethnicity.MAP.BLACK_OR_AFRICAN_AMERICAN,
+        Ethnicity.MAP.EAST_ASIAN,
+    ],
+    communitiesServed: [
+        CommunitiesServed.MAP.IMMIGARNAT,
+        CommunitiesServed.MAP.SINGLE_PARENT,
+    ],
+    religions: [],
+    evidenceBasedPractices: [
+        EvidenceBasedApproach.ENTRIES[0],
+        EvidenceBasedApproach.ENTRIES[3],
+        EvidenceBasedApproach.ENTRIES[5],
+    ],
+    modalities: [Modality.MAP.INDIVIDUALS, Modality.MAP.COUPLES],
+    languagesSpoken: [Language.MAP.ENGLISH],
+    pronouns: Pronoun.MAP.HE_HIM,
+    ageGroups: [AgeGroup.MAP.ADULTS, AgeGroup.MAP.TEENS],
+    offersInPerson: true,
+    offersMedicationManagement: true,
+    offersPhoneConsultations: true,
+    offersVirtual: true,
+    designation: ProfileType.therapist,
+    newClientStatus: NewClientStatus.accepting,
+    practiceStartDate: new Date('2010-09-01T00:00:00.000Z'),
+};
+
+describe('executeProviderSearch', () => {
+    const executeProviderSearch = factory({
+        prisma: prismaMock,
+    });
+
+    describe('therapists', () => {
+        it('should return valid profiles', async () => {
+            prismaMock.providerProfile.findMany.mockResolvedValue([
+                mockProviderProfile,
+            ]);
+            const { profiles } = await executeProviderSearch({
+                state: 'New York',
+            });
+            await expect(profiles.length).toBe(1);
+        });
+        it('should filter out therapists with no credentials', async () => {
+            prismaMock.providerProfile.findMany.mockResolvedValue([
+                {
+                    ...mockProviderProfile,
+                    credentials: [],
+                },
+            ]);
+            const { profiles } = await executeProviderSearch({
+                state: 'New York',
+            });
+            await expect(profiles.length).toBe(0);
+        });
+        it('should filter out therapists with no credentials for the given state', async () => {
+            prismaMock.providerProfile.findMany.mockResolvedValue([
+                {
+                    ...mockProviderProfile,
+                    credentials: [mockProviderProfile.credentials[0]],
+                },
+            ]);
+            const { profiles } = await executeProviderSearch({
+                state: 'New York',
+            });
+            await expect(profiles.length).toBe(0);
+        });
+        it('should filter out therapists with expired credentials', async () => {
+            prismaMock.providerProfile.findMany.mockResolvedValue([
+                {
+                    ...mockProviderProfile,
+                    credentials: [
+                        {
+                            type: 'LMFT',
+                            licenseNumber: '123456',
+                            state: 'New York',
+                            expirationDate: addYears(
+                                new Date(),
+                                -1
+                            ).toISOString(),
+                        },
+                    ],
+                },
+            ]);
+            const { profiles } = await executeProviderSearch({
+                state: 'New York',
+            });
+            await expect(profiles.length).toBe(0);
+        });
+
+        it('should safely filter out therapists with malformed credentials', async () => {
+            prismaMock.providerProfile.findMany.mockResolvedValue([
+                {
+                    ...mockProviderProfile,
+                    credentials: [
+                        {
+                            state: 'New York',
+                            expirationDate: addYears(
+                                new Date(),
+                                -1
+                            ).toISOString(),
+                        },
+                    ],
+                },
+            ]);
+            const { profiles } = await executeProviderSearch({
+                state: 'New York',
+            });
+            await expect(profiles.length).toBe(0);
+        });
+    });
+
+    describe('coaches', () => {
+        it('should not filter coaches by credentials', async () => {
+            prismaMock.providerProfile.findMany.mockResolvedValue([
+                {
+                    ...mockProviderProfile,
+                    credentials: [],
+                    designation: ProfileType.coach,
+                },
+            ]);
+            const { profiles } = await executeProviderSearch({
+                state: 'New York',
+            });
+            expect(profiles.length).toBe(1);
+        });
+    });
+});

--- a/src/lib/modules/directory/service/execute-provider-search/executeProviderSearch.ts
+++ b/src/lib/modules/directory/service/execute-provider-search/executeProviderSearch.ts
@@ -1,0 +1,116 @@
+import { ProviderSearch } from '@/lib/modules/directory/features';
+import { DirectoryServiceParams } from '../params';
+import {
+    ListingStatus,
+    PlanStatus,
+    ProfileType,
+    ProviderProfile,
+} from '@prisma/client';
+import { ProviderCredential, State } from '@/lib/shared/types';
+import { DirectoryProfile } from '@/lib/shared/types/presentation';
+
+interface CreateConnectionFactoryParams extends DirectoryServiceParams {}
+
+export const factory = ({ prisma }: CreateConnectionFactoryParams) => {
+    return async function executeProviderSearch(
+        input: ProviderSearch.Input
+    ): Promise<ProviderSearch.Output> {
+        const profileResults = await prisma.providerProfile.findMany({
+            where: {
+                OR: [
+                    {
+                        designation: ProfileType.therapist,
+                        directoryListing: {
+                            status: ListingStatus.listed,
+                        },
+                        // Practice has active plan
+                        practiceProfile: {
+                            practice: {
+                                plans: {
+                                    some: {
+                                        endDate: {
+                                            gt: new Date(),
+                                        },
+                                        startDate: {
+                                            lte: new Date(),
+                                        },
+                                        status: {
+                                            in: [
+                                                PlanStatus.active,
+                                                PlanStatus.trialing,
+                                            ],
+                                        },
+                                    },
+                                },
+                            },
+                        },
+                        credentials: {
+                            isEmpty: false,
+                        },
+                    },
+                    {
+                        designation: ProfileType.coach,
+                        directoryListing: {
+                            status: ListingStatus.listed,
+                        },
+                        // Practice has active plan
+                        practiceProfile: {
+                            practice: {
+                                plans: {
+                                    some: {
+                                        endDate: {
+                                            gt: new Date(),
+                                        },
+                                        startDate: {
+                                            lte: new Date(),
+                                        },
+                                        status: {
+                                            in: [
+                                                PlanStatus.active,
+                                                PlanStatus.trialing,
+                                            ],
+                                        },
+                                    },
+                                },
+                            },
+                        },
+                    },
+                ],
+            },
+        });
+        // Because Prisma's Postgres connection doesn't support filtering on object key values inside JSON arrays,
+        // we have to filter the credential results outside of the query
+        // Prisma docs: https://www.prisma.io/docs/concepts/components/prisma-client/working-with-fields/working-with-json-fields#filtering-on-object-key-value-inside-array
+
+        const eligibleProfiles = profileResults.filter((profile) => {
+            if (profile.designation === ProfileType.therapist) {
+                const inStateCredentials = getInStateCredentials(
+                    input.state,
+                    profile.credentials
+                );
+                return inStateCredentials.length > 0;
+            }
+            return true;
+        });
+        return {
+            profiles: eligibleProfiles.map(DirectoryProfile.validate),
+        };
+    };
+};
+
+const getInStateCredentials = (
+    state: State.State,
+    credentials: ProviderProfile['credentials']
+) => {
+    return credentials.filter((credential) => {
+        const parsedCredential =
+            ProviderCredential.schema.safeParse(credential);
+
+        return (
+            parsedCredential.success &&
+            parsedCredential.data.state === state &&
+            new Date(parsedCredential.data.expirationDate).getTime() >
+                new Date().getTime()
+        );
+    });
+};

--- a/src/lib/modules/directory/service/execute-provider-search/index.ts
+++ b/src/lib/modules/directory/service/execute-provider-search/index.ts
@@ -1,0 +1,1 @@
+export * as ExecuteProviderSearch from './executeProviderSearch';

--- a/src/lib/modules/directory/service/index.ts
+++ b/src/lib/modules/directory/service/index.ts
@@ -4,12 +4,14 @@ import { ListConnectionRequestsByProviderId } from './list-connection-requests-b
 import { ListConnectionRequestsByPracticeOwnerId } from './list-connection-requests-by-practice-owner-id';
 import { DirectoryServiceParams } from './params';
 import { UpdateConnectionRequestStatus } from './update-connection-request-status';
+import { ExecuteProviderSearch } from './execute-provider-search';
 
 const params: DirectoryServiceParams = {
     prisma,
 };
 
 export const directoryService = {
+    executeProviderSearch: ExecuteProviderSearch.factory(params),
     createConnectionRequest: CreateConnectionRequest.factory(params),
     listConnectionRequestsByProviderId:
         ListConnectionRequestsByProviderId.factory(params),


### PR DESCRIPTION
# Description
As more practices onboard, we are now showing directory results to members that they cannot connect with because of state restrictions.  This work adds `executeDirectorySearch` method that takes a state and filters down results.
## Profile Filter Checks: 
### For Coach and Therapist Profiles: 
- must have directoryListing.status of `listed`
- Must be connected to a practice that has an active plan. 
  - "Active" is defined as a plan with `status` set to either `active` or `trialing`, with a `startDate` that is in the past, and an `endDate` that is in the future

### For Therapists specifically:
- Must also have at least one credential where `credential.state === input.state` and `credential.expirationDate` is in the future

# Closes issue(s)
NA
# How to test / repro
Observe directory behavior

# Screenshots

# Changes include

-   [ ] Bugfix (non-breaking change that solves an issue)
-   [ ] New feature (non-breaking change that adds functionality)
-   [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Checklist

-   [x] I have tested this code
-   [ ] I have updated the Readme

# Other comments
