### PR TITLE
fix: update unexpected stripe subscription types

### DIFF
--- a/src/lib/shared/vendors/stripe/types/discount.ts
+++ b/src/lib/shared/vendors/stripe/types/discount.ts
@@ -3,21 +3,23 @@ import * as z from 'zod';
 export const schema = z.object({
     customer: z.string(),
     discount: z.object({
-        coupon: z.object({
-            amount_off: z.number(),
-            created: z.number(),
-            currency: z.string(),
-            duration: z.string(),
-            duration_in_months: z.number(),
-            livemode: z.boolean(),
-            max_redemptions: z.number(),
-            metadata: z.object({}),
-            name: z.string(),
-            percent_off: z.number(),
-            redeem_by: z.number(),
-            times_redeemed: z.number(),
-            valid: z.boolean(),
-        }),
+        coupon: z
+            .object({
+                amount_off: z.number(),
+                created: z.number(),
+                currency: z.string(),
+                duration: z.string(),
+                duration_in_months: z.number(),
+                livemode: z.boolean(),
+                max_redemptions: z.number(),
+                metadata: z.object({}),
+                name: z.string(),
+                percent_off: z.number(),
+                redeem_by: z.number(),
+                times_redeemed: z.number(),
+                valid: z.boolean(),
+            })
+            .optional(),
         customer: z.string(),
         end: z.number(),
         id: z.string(),

--- a/src/lib/shared/vendors/stripe/types/subscription.ts
+++ b/src/lib/shared/vendors/stripe/types/subscription.ts
@@ -39,7 +39,7 @@ export const schema = z.object({
     current_period_start: z.number(),
     customer: z.string(),
     days_until_due: z.number().nullable(),
-    default_payment_method: z.string(),
+    default_payment_method: z.string().nullable(),
     default_source: z.string().nullable(),
     default_tax_rates: z.array(z.string()),
     discount: stripeDiscount.nullable(),


### PR DESCRIPTION
# Description
The stripe webhook listener for `customer.subscription.updated` failed for 2 events. 
The issue: 
![image](https://user-images.githubusercontent.com/25045075/222006938-eb136e2c-d9fc-4008-a3fa-d9c270f4f3f2.png)
![image](https://user-images.githubusercontent.com/25045075/222006960-734132e4-2e67-4268-88d0-1bd237fb601e.png)


This fix makes `subscription.discount.discount` optional and `subscription.default_payment_method` nullable

# Closes issue(s)

# How to test / repro

# Screenshots

# Changes include

-   [x] Bugfix (non-breaking change that solves an issue)
-   [ ] New feature (non-breaking change that adds functionality)
-   [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Checklist

-   [ ] I have tested this code
-   [ ] I have updated the Readme

# Other comments
