### PR TITLE
chore: v1 chat cleanup

### DIFF
--- a/src/lib/modules/directory/components/ProviderProfile/ProviderProfile.tsx
+++ b/src/lib/modules/directory/components/ProviderProfile/ProviderProfile.tsx
@@ -26,6 +26,7 @@ import {
     Diversity1Outlined,
     ChurchOutlined,
     PersonPinCircleOutlined,
+    QuestionAnswerOutlined,
 } from '@mui/icons-material';
 import {
     Box,
@@ -141,6 +142,7 @@ export function ProviderProfile({
     gender,
     offersPhoneConsultations,
     offersMedicationManagement,
+    offersChat,
     newClientStatus,
     practiceStartDate,
     specialties = [],
@@ -297,6 +299,15 @@ export function ProviderProfile({
                                         color="primary"
                                     />
                                 )}
+                                {offersChat && (
+                                    <SessionTypeChip
+                                        label="In-App Messaging"
+                                        size="small"
+                                        icon={<QuestionAnswerOutlined />}
+                                        variant="outlined"
+                                        color="primary"
+                                    />
+                                )}
                             </SessionTypeContainer>
                             <Box>
                                 {/* TODO: Handle Share */}
@@ -404,6 +415,15 @@ export function ProviderProfile({
                                     description={`${
                                         givenName || 'This provider'
                                     } offers a free 15 min phone consultation to get started`}
+                                />
+                            )}
+                            {offersChat && (
+                                <CalloutBanner
+                                    icon={<QuestionAnswerOutlined />}
+                                    title="Offers in-app messaging"
+                                    description={`${
+                                        givenName || 'This provider'
+                                    } can be reached by clients via in-app chat`}
                                 />
                             )}
                             {offersMedicationManagement && isTherapist && (

--- a/src/lib/modules/messaging/components/Chat/Chat.tsx
+++ b/src/lib/modules/messaging/components/Chat/Chat.tsx
@@ -181,6 +181,11 @@ const StyledChatContainer = styled(Box, {
         position: 'absolute',
         bottom: 0,
     },
+
+    '& textarea.rta__textarea::placeholder': {
+        fontSize: '14px !important',
+    },
+
     [theme.breakpoints.up('md')]: {
         flexDirection: 'row',
         ['& .str-chat-channel-list']: {

--- a/src/lib/modules/messaging/components/Chat/Chat.tsx
+++ b/src/lib/modules/messaging/components/Chat/Chat.tsx
@@ -178,14 +178,31 @@ const StyledChatContainer = styled(Box, {
         paddingBottom: 75,
     },
     ['& .str-chat__message-input']: {
+        width: '100%',
         position: 'absolute',
         bottom: 0,
+        [theme.breakpoints.down('md')]: {
+            paddingLeft: theme.spacing(2),
+            paddingRight: theme.spacing(2),
+        },
     },
-
-    '& textarea.rta__textarea::placeholder': {
-        fontSize: '14px !important',
+    '& .str-chat__send-button': {
+        backgroundColor: theme.palette.primary.main,
+        color: theme.palette.primary.contrastText,
+        borderRadius: theme.shape.borderRadius,
+        height: '57px',
+        width: '57px',
+        marginRight: theme.spacing(2),
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        '& svg path': {
+            fill: theme.palette.primary.contrastText,
+        },
+        [theme.breakpoints.up('md')]: {
+            display: 'none',
+        },
     },
-
     [theme.breakpoints.up('md')]: {
         flexDirection: 'row',
         ['& .str-chat-channel-list']: {

--- a/src/lib/modules/messaging/components/Chat/index.ts
+++ b/src/lib/modules/messaging/components/Chat/index.ts
@@ -1,1 +1,2 @@
 export * from './Chat';
+export * from './useRemoveHubspotChatWidget';

--- a/src/lib/modules/messaging/components/Chat/useRemoveHubspotChatWidget.ts
+++ b/src/lib/modules/messaging/components/Chat/useRemoveHubspotChatWidget.ts
@@ -1,0 +1,26 @@
+import { useEffect, useState } from 'react';
+
+const removeHubspotElement = () => {
+    const element = document?.getElementById(
+        'hubspot-messages-iframe-container'
+    );
+    if (element) {
+        element.remove();
+        return;
+    }
+    setTimeout(() => {
+        'retrying to remove hubspot element...';
+        removeHubspotElement();
+    }, 2000);
+};
+
+export const useRemoveHubspotChatWidget = () => {
+    const [attempts, setAttempts] = useState(0);
+
+    useEffect(() => {
+        setAttempts(attempts + 1);
+        if (attempts > 10) {
+            removeHubspotElement();
+        }
+    }, [attempts]);
+};

--- a/src/lib/modules/providers/components/Clients/ClientList/ClientList.tsx
+++ b/src/lib/modules/providers/components/Clients/ClientList/ClientList.tsx
@@ -17,20 +17,16 @@ interface ClientListProps {
     onTerminateConnectionRequest: HandleConnectionRequestAction;
     onReimbursmentRequest: HandleConnectionRequestAction;
     onViewMemberDetails: HandleConnectionRequestAction;
-    onOpenChat: (memberId: string) => void;
 }
 
 export const ClientList = ({
-    designation,
     connectionRequests,
     onAcceptConnectionRequest,
     onDeclineConnectionRequest,
     onTerminateConnectionRequest,
     onReimbursmentRequest,
-    onOpenChat,
     onViewMemberDetails,
 }: ClientListProps) => {
-    const isCoach = designation === ProfileType.coach;
     const isSmallScreen = useMediaQuery((theme: Theme) =>
         theme.breakpoints.down('md')
     );
@@ -75,11 +71,6 @@ export const ClientList = ({
                             onTerminateConnectionRequest(connectionRequest)
                         }
                         onView={() => onViewMemberDetails(connectionRequest)}
-                        onOpenChat={
-                            isCoach
-                                ? () => onOpenChat(connectionRequest.member.id)
-                                : undefined
-                        }
                         onReimbursmentRequest={() => {
                             onReimbursmentRequest(connectionRequest);
                         }}

--- a/src/lib/modules/providers/components/Clients/ClientList/ui/ActionButtons.tsx
+++ b/src/lib/modules/providers/components/Clients/ClientList/ui/ActionButtons.tsx
@@ -7,13 +7,11 @@ export const ActionButtons = ({
     onAccept,
     onDecline,
     onView,
-    onOpenChat,
 }: {
     connectionRequest: ConnectionRequest.Type;
     onAccept: () => void;
     onDecline: () => void;
     onView?: () => void;
-    onOpenChat?: () => void;
 }) => {
     const isPending =
         connectionRequest.connectionStatus === ConnectionStatus.pending;
@@ -41,28 +39,14 @@ export const ActionButtons = ({
                 </>
             )}
             {isAccepted && (
-                <>
-                    {!onOpenChat && (
-                        <Button
-                            size="small"
-                            color="info"
-                            type="outlined"
-                            onClick={onView}
-                        >
-                            View Member
-                        </Button>
-                    )}
-                    {onOpenChat && (
-                        <Button
-                            size="small"
-                            color="info"
-                            type="outlined"
-                            onClick={onOpenChat}
-                        >
-                            Chat
-                        </Button>
-                    )}
-                </>
+                <Button
+                    size="small"
+                    color="info"
+                    type="outlined"
+                    onClick={onView}
+                >
+                    View Member
+                </Button>
             )}
         </>
     );

--- a/src/lib/modules/providers/components/Clients/ClientList/ui/ClientListItem.tsx
+++ b/src/lib/modules/providers/components/Clients/ClientList/ui/ClientListItem.tsx
@@ -34,7 +34,6 @@ export const ClientListItem = ({
     onDecline,
     onTerminate,
     onView,
-    onOpenChat,
     onReimbursmentRequest,
 }: {
     connectionRequest: ConnectionRequest.Type;
@@ -43,7 +42,6 @@ export const ClientListItem = ({
     onDecline: () => void;
     onTerminate: () => void;
     onView?: () => void;
-    onOpenChat?: () => void;
     onReimbursmentRequest: () => void;
 }) => {
     const isPending =
@@ -65,24 +63,12 @@ export const ClientListItem = ({
                   },
               ]
             : []),
-        ...(!onOpenChat
-            ? [
-                  {
-                      icon: <PreviewRounded />,
-                      text: ' View Member Details',
-                      onClick: onView,
-                  },
-              ]
-            : []),
-        ...(onOpenChat
-            ? [
-                  {
-                      icon: <ChatBubbleOutlineRounded />,
-                      text: 'Chat',
-                      onClick: onOpenChat,
-                  },
-              ]
-            : []),
+
+        {
+            icon: <PreviewRounded />,
+            text: ' View Member Details',
+            onClick: onView,
+        },
     ];
     const actionList = [
         ...(isSmallScreen ? mobileActions : []),
@@ -160,7 +146,6 @@ export const ClientListItem = ({
                             onAccept={onAccept}
                             onDecline={onDecline}
                             onView={onView}
-                            onOpenChat={onOpenChat}
                         />
                     )}
                     {isPending && isSmallScreen && (

--- a/src/lib/modules/providers/components/ProfileEditor/ui/inputs/Practice/ToggleInputs.tsx
+++ b/src/lib/modules/providers/components/ProfileEditor/ui/inputs/Practice/ToggleInputs.tsx
@@ -1,6 +1,9 @@
 import { Control, Controller } from 'react-hook-form';
 import { Switch } from '@/lib/shared/components/ui';
 import { ProviderProfile } from '@/lib/shared/types';
+import { Tooltip, Box } from '@mui/material';
+import { styled } from '@mui/material/styles';
+import { InfoOutlined } from '@mui/icons-material';
 
 interface ToggleInputProps {
     control: Control<ProviderProfile.ProviderProfile>;
@@ -65,7 +68,14 @@ export const OffersChat = ({ control, disabled }: ToggleInputProps) => (
         render={({ field: { onChange, onBlur, value, name } }) => (
             <Switch
                 id="offersChat"
-                displayText="Do you want to offer chat?"
+                displayText={
+                    <Box display="flex" alignItems="center">
+                        Do you want to offer in-app messaging?{' '}
+                        <ChatTooltip title="In-app messaging allows you to communicate inside the Therify App with your clients">
+                            <InfoOutlined fontSize="small" />
+                        </ChatTooltip>
+                    </Box>
+                }
                 {...{
                     onChange,
                     onBlur,
@@ -78,6 +88,16 @@ export const OffersChat = ({ control, disabled }: ToggleInputProps) => (
         )}
     />
 );
+
+const ChatTooltip = styled(Tooltip)(({ theme }) => ({
+    marginLeft: 2,
+    fontSize: '0.8rem',
+    display: 'none',
+    [theme.breakpoints.up('md')]: {
+        display: 'inline-block',
+    },
+}));
+
 export const OffersMedicationManagement = ({
     control,
     disabled,

--- a/src/lib/modules/providers/components/ProfileEditor/ui/inputs/Practice/index.tsx
+++ b/src/lib/modules/providers/components/ProfileEditor/ui/inputs/Practice/index.tsx
@@ -1,6 +1,7 @@
 import {
     FormSectionTitle,
     FormSectionSubtitle,
+    Badge,
 } from '@/lib/shared/components/ui';
 import { ProviderProfile } from '@/lib/shared/types';
 import { Box } from '@mui/material';
@@ -21,6 +22,11 @@ import { ModalititesServedInput } from './Modalities';
 import { LanguagesSpokenInput } from './LanguagesSpoken';
 import { ReligionsInput } from './Religions';
 
+('TODO: Remove after 3/10/23');
+const CHAT_FEATURE_BADGE_EXPIRATION_TIMESTAMP = new Date(
+    '2023-03-10T00:00:00.000Z'
+).getTime();
+
 interface IdentitySectionProps {
     control: Control<ProviderProfile.ProviderProfile>;
     disabled?: boolean;
@@ -31,6 +37,8 @@ export const PracticeSection = ({
     disabled,
     isTherapist,
 }: IdentitySectionProps) => {
+    const showNewFeatureBadge =
+        CHAT_FEATURE_BADGE_EXPIRATION_TIMESTAMP > Date.now();
     return (
         <Box width="100%">
             <FormSectionTitle>Your Practice</FormSectionTitle>
@@ -59,7 +67,14 @@ export const PracticeSection = ({
             )}
             {!isTherapist && (
                 <Box marginBottom={4}>
-                    <FormSectionSubtitle>Chat</FormSectionSubtitle>
+                    <FormSectionSubtitle>
+                        In-App Messaging{' '}
+                        {showNewFeatureBadge && (
+                            <Badge color="success" size="small">
+                                New!
+                            </Badge>
+                        )}
+                    </FormSectionSubtitle>
                     <OffersChat control={control} disabled={disabled} />
                 </Box>
             )}

--- a/src/lib/modules/providers/service/page-props/get-clients-page-props/getProviderClientsPageProps.ts
+++ b/src/lib/modules/providers/service/page-props/get-clients-page-props/getProviderClientsPageProps.ts
@@ -16,12 +16,6 @@ export const factory = (params: ProvidersServiceParams) => {
     const getProviderClientsPageProps: GetServerSideProps<
         ProviderClientsPageProps
     > = async (context) => {
-        // TODO [feat:provider-clients-page]:  Remove this when ready for prod
-        if (process.env.NEXT_PUBLIC_VERCEL_ENV === 'production') {
-            return {
-                notFound: true,
-            };
-        }
         const session = await getSession(context.req, context.res);
         if (!session) {
             return {

--- a/src/lib/modules/providers/service/page-props/get-practice-clients-page-props/getPracticeClientsPageProps.ts
+++ b/src/lib/modules/providers/service/page-props/get-practice-clients-page-props/getPracticeClientsPageProps.ts
@@ -19,12 +19,6 @@ export const factory = (params: ProvidersServiceParams) => {
     const getPracticeClientsPageProps: GetServerSideProps<
         PracticeClientsPageProps
     > = async (context) => {
-        // TODO [feat:provider-clients-page]:  Remove this when ready for prod
-        if (process.env.NEXT_PUBLIC_VERCEL_ENV === 'production') {
-            return {
-                notFound: true,
-            };
-        }
         const session = await getSession(context.req, context.res);
         if (!session) {
             return {

--- a/src/lib/shared/components/features/pages/ProviderClientListPage/ProviderClientListPage.tsx
+++ b/src/lib/shared/components/features/pages/ProviderClientListPage/ProviderClientListPage.tsx
@@ -70,9 +70,6 @@ export function ProviderClientListPage({
                         connectionRequest,
                     })
                 }
-                onOpenChat={(memberId) =>
-                    console.log('TODO: Open chat with member', memberId)
-                }
                 onReimbursmentRequest={(connectionRequest) =>
                     window?.open(
                         formatReimbursementRequestUrl(

--- a/src/lib/shared/components/styles/Global.tsx
+++ b/src/lib/shared/components/styles/Global.tsx
@@ -22,6 +22,10 @@ export function Globals() {
                     font: inherit;
                 }
 
+                html {
+                    height: -webkit-fill-available;
+                }
+
                 html,
                 body {
                     padding: 0;
@@ -42,6 +46,7 @@ export function Globals() {
 
                 body {
                     min-height: 100vh;
+                    min-height: -webkit-fill-available;
                 }
 
                 input,
@@ -51,10 +56,6 @@ export function Globals() {
                     font-family: inherit;
                     font-size: inherit;
                     line-height: inherit;
-                }
-
-                body {
-                    height: 100vh;
                 }
             `}
         />

--- a/src/lib/shared/components/ui/Containers/ApplicationContainer/ApplicationContainer.tsx
+++ b/src/lib/shared/components/ui/Containers/ApplicationContainer/ApplicationContainer.tsx
@@ -3,6 +3,7 @@ import { styled } from '@mui/material/styles';
 
 export const ApplicationContainer = styled(Box)(({ theme }) => ({
     height: '100vh',
+    maxHeight: '-webkit-fill-available',
     width: '100vw',
     position: 'relative',
     margin: 0,

--- a/src/lib/sitemap/menus/coach-menu/menu.tsx
+++ b/src/lib/sitemap/menus/coach-menu/menu.tsx
@@ -7,8 +7,7 @@ import { ACCOUNT, BILLING_AND_SUBSCRIPTION, LOGOUT } from '../accountLinks';
 
 export const COACH_MAIN_MENU = [
     // DASHBOARD,
-    // TODO [feat:provider-clients-page]: Remove this when ready for prod
-    ...(process.env.NEXT_PUBLIC_VERCEL_ENV !== 'production' ? [CLIENTS] : []),
+    CLIENTS,
     PROFILE_EDITOR,
 ] as const;
 

--- a/src/lib/sitemap/menus/member-menu/links.ts
+++ b/src/lib/sitemap/menus/member-menu/links.ts
@@ -28,7 +28,7 @@ export const THERIFY_WEBSITE: NavigationLink = {
 
 export const CONTENT_LIBRARY: NavigationLink = {
     icon: NAVIGATION_ICON.LIBRARY,
-    displayName: 'Content Library',
+    displayName: 'Library',
     path: URL_PATHS.EXTERNAL.VIMEO.CHANNEL,
     // path: URL_PATHS.MEMBERS.CONTENT.LIBRARY,
 } as const;

--- a/src/lib/sitemap/menus/practice-admin-menu/menu.tsx
+++ b/src/lib/sitemap/menus/practice-admin-menu/menu.tsx
@@ -7,8 +7,7 @@ import { ACCOUNT, BILLING_AND_SUBSCRIPTION, LOGOUT } from '../accountLinks';
 
 export const PRACTICE_ADMIN_MAIN_MENU = [
     // DASHBOARD,
-    // TODO [feat:provider-clients-page]: Remove this when ready for prod
-    ...(process.env.NEXT_PUBLIC_VERCEL_ENV !== 'production' ? [CLIENTS] : []),
+    CLIENTS,
     PROFILES,
 ] as const;
 

--- a/src/lib/sitemap/menus/therapist-menu/menu.tsx
+++ b/src/lib/sitemap/menus/therapist-menu/menu.tsx
@@ -10,8 +10,7 @@ import {
 
 export const THERAPIST_MAIN_MENU = [
     // DASHBOARD,
-    // TODO [feat:provider-clients-page]: Remove this when ready for prod
-    ...(process.env.NEXT_PUBLIC_VERCEL_ENV !== 'production' ? [CLIENTS] : []),
+    CLIENTS,
     PROFILE_EDITOR,
 ] as const;
 

--- a/src/pages/members/chat.tsx
+++ b/src/pages/members/chat.tsx
@@ -1,5 +1,8 @@
 import { membersService } from '@/lib/modules/members/service';
-import { ChatComponent } from '@/lib/modules/messaging/components';
+import {
+    ChatComponent,
+    useRemoveHubspotChatWidget,
+} from '@/lib/modules/messaging/components';
 import { ChatPageProps } from '@/lib/modules/providers/service/page-props/get-chat-page-props/getChatPageProps';
 import { MemberNavigationPage } from '@/lib/shared/components/features/pages/MemberNavigationPage';
 import { RBAC } from '@/lib/shared/utils/rbac';
@@ -13,6 +16,7 @@ export const getServerSideProps = RBAC.requireMemberAuth(
 );
 
 export default function ChatPage({ user }: ChatPageProps) {
+    useRemoveHubspotChatWidget();
     if (!user) {
         return <div>Chat is not available</div>;
     }

--- a/src/pages/providers/coach/chat.tsx
+++ b/src/pages/providers/coach/chat.tsx
@@ -1,4 +1,7 @@
-import { ChatComponent } from '@/lib/modules/messaging/components';
+import {
+    ChatComponent,
+    useRemoveHubspotChatWidget,
+} from '@/lib/modules/messaging/components';
 import { ProvidersService } from '@/lib/modules/providers/service';
 import { ChatPageProps } from '@/lib/modules/providers/service/page-props/get-chat-page-props/getChatPageProps';
 import { ProviderNavigationPage } from '@/lib/shared/components/features/pages/ProviderNavigationPage';
@@ -13,6 +16,7 @@ export const getServerSideProps = RBAC.requireCoachAuth(
 );
 
 export default function ChatPage({ user }: ChatPageProps) {
+    useRemoveHubspotChatWidget();
     if (!user) {
         return <div>Chat is not available</div>;
     }

--- a/src/pages/providers/coach/profiles.tsx
+++ b/src/pages/providers/coach/profiles.tsx
@@ -15,13 +15,7 @@ import {
     Alert,
     IconButton,
 } from '@/lib/shared/components/ui';
-import { SideNavigationPage } from '@/lib/shared/components/features/pages';
-import {
-    URL_PATHS,
-    COACH_MAIN_MENU,
-    COACH_SECONDARY_MENU,
-    COACH_MOBILE_MENU,
-} from '@/lib/sitemap';
+import { URL_PATHS } from '@/lib/sitemap';
 import { EditRounded } from '@mui/icons-material';
 import { RBAC } from '@/lib/shared/utils';
 import { styled, useTheme } from '@mui/material/styles';
@@ -31,6 +25,7 @@ import { ProviderProfile } from '@/lib/shared/types';
 import { GetProviderProfileByUserId } from '@/lib/modules/providers/features/profiles';
 import { ProvidersService } from '@/lib/modules/providers/service';
 import { ProviderTherifyUserPageProps } from '@/lib/modules/providers/service/page-props/get-therify-user-props';
+import { ProviderNavigationPage } from '@/lib/shared/components/features/pages/ProviderNavigationPage';
 
 export const getServerSideProps = RBAC.requireCoachAuth(
     withPageAuthRequired({
@@ -72,13 +67,9 @@ export default function PracticeProfilesPage({
     const errorMessage = trpcError?.message || queryError;
 
     return (
-        <SideNavigationPage
+        <ProviderNavigationPage
             currentPath={URL_PATHS.PROVIDERS.COACH.PROFILES}
-            onNavigate={router.push}
             user={user}
-            primaryMenu={[...COACH_MAIN_MENU]}
-            secondaryMenu={[...COACH_SECONDARY_MENU]}
-            mobileMenu={[...COACH_MOBILE_MENU]}
         >
             <LoadingContainer isLoading={isLoading}>
                 <PageContentContainer
@@ -162,7 +153,7 @@ export default function PracticeProfilesPage({
                     </ProfileList>
                 </PageContentContainer>
             </LoadingContainer>
-        </SideNavigationPage>
+        </ProviderNavigationPage>
     );
 }
 

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -7,7 +7,6 @@
     font-weight: 700;
     font-display: swap;
 }
-
 * {
     box-sizing: border-box;
     --webkit-font-smoothing: antialiased;
@@ -15,6 +14,9 @@
     font: inherit;
 }
 
+html {
+  height: -webkit-fill-available;
+}
 html,
 body {
     padding: 0;
@@ -34,6 +36,7 @@ video {
 
 body {
     min-height: 100vh;
+    min-height: -webkit-fill-available;
 }
 
 input,
@@ -50,6 +53,3 @@ button {
     color: #000;
 }
 
-body {
-    height: 100vh;
-}


### PR DESCRIPTION
# Description
Ui clean up for Chat Launch
Adds
- Removes chat buttons on Clients page
- In-app messaging callouts on provider profile
- Change `Content Library` to `Library` in the Member menu
- Removes HubSpot widget when coach or member loads chat page
- Fixes the Webkit `100vh` overflow issue
- Fixes Chat menu disappearing on Coach Profiles page
- Adds New feature badge  by Messaging toggle in Profile Editor
- Removes environment flags protection

# Closes issue(s)
[Trello V1 chat finishing touches for launch](https://trello.com/c/LVp7cnkL)

# How to test / repro

# Screenshots
### Chat on Webkit Safari (iPhone 13)
<img src="https://user-images.githubusercontent.com/25045075/222599376-b488eb3b-af7e-4990-b964-c86f1b452d58.jpeg" width="300px" />

### Messaging Callouts 
![image](https://user-images.githubusercontent.com/25045075/222599521-9aec9f1d-38ff-47cf-baf4-185e70ca5b39.png)
![image](https://user-images.githubusercontent.com/25045075/222599544-0ea39800-bccd-4c65-81b1-70cedd89cec3.png)

### Tooltip in Chat toggle + New Feature Badge
![image](https://user-images.githubusercontent.com/25045075/222602165-c4d8e57a-9056-468e-afd2-1c6c6facffbc.png)


# Changes include

-   [ ] Bugfix (non-breaking change that solves an issue)
-   [ ] New feature (non-breaking change that adds functionality)
-   [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Checklist

-   [ ] I have tested this code
-   [ ] I have updated the Readme

# Other comments
