### PR TITLE
fix: infinite chat re-renders from HubSpot widget removal

### DIFF
--- a/src/lib/modules/messaging/components/Chat/useRemoveHubspotChatWidget.ts
+++ b/src/lib/modules/messaging/components/Chat/useRemoveHubspotChatWidget.ts
@@ -1,6 +1,9 @@
 import { useEffect, useState } from 'react';
 
+let attempts = 0;
+
 const removeHubspotElement = () => {
+    attempts += 1;
     const element = document?.getElementById(
         'hubspot-messages-iframe-container'
     );
@@ -8,19 +11,14 @@ const removeHubspotElement = () => {
         element.remove();
         return;
     }
-    setTimeout(() => {
-        'retrying to remove hubspot element...';
-        removeHubspotElement();
-    }, 2000);
+    if (attempts < 10) {
+        setTimeout(() => {
+            console.log('retrying to remove hubspot element...');
+            removeHubspotElement();
+        }, 2000);
+    }
 };
 
 export const useRemoveHubspotChatWidget = () => {
-    const [attempts, setAttempts] = useState(0);
-
-    useEffect(() => {
-        setAttempts(attempts + 1);
-        if (attempts > 10) {
-            removeHubspotElement();
-        }
-    }, [attempts]);
+    useEffect(removeHubspotElement, []);
 };


### PR DESCRIPTION
# Description
A bad use of useEffect was causing infinite rerenders and breaking the chat experience.

This cleans up the useEffect.
# Closes issue(s)

# How to test / repro
Got to the chat page and view the console. 

# Screenshots

# Changes include

-   [x] Bugfix (non-breaking change that solves an issue)
-   [ ] New feature (non-breaking change that adds functionality)
-   [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Checklist

-   [ ] I have tested this code
-   [ ] I have updated the Readme

# Other comments
