### PR TITLE
feat: add firebase presence

### DIFF
--- a/src/lib/modules/notifications/components/context/Provider.tsx
+++ b/src/lib/modules/notifications/components/context/Provider.tsx
@@ -2,6 +2,7 @@ import { ReactNode, useContext, useEffect, useState } from 'react';
 import { FirebaseClient, TherifyUser } from '@/lib/shared/context';
 import { Notification } from '@/lib/shared/types';
 import { handleNotifications } from './handle-notifications-change';
+import { useInAppPresence } from '../hooks';
 import { Context } from './Context';
 import {
     clearNotificationsFactory,
@@ -12,6 +13,8 @@ import {
 export const Provider = ({ children }: { children: ReactNode }) => {
     const { user } = useContext(TherifyUser.Context);
     const { firebase } = useContext(FirebaseClient.Context);
+    useInAppPresence({ userId: user?.userId, firebase });
+
     const [notifications, setNotifications] = useState<
         Notification.InApp.PersitedType[]
     >([]);

--- a/src/lib/modules/notifications/components/context/Provider.tsx
+++ b/src/lib/modules/notifications/components/context/Provider.tsx
@@ -11,17 +11,17 @@ import {
 } from './methods';
 
 export const Provider = ({ children }: { children: ReactNode }) => {
-    const { user } = useContext(TherifyUser.Context);
     const { firebase } = useContext(FirebaseClient.Context);
-    useInAppPresence({ userId: user?.userId, firebase });
+    const userId = firebase?.getSignedInUserId();
+    useInAppPresence({ userId, firebase });
 
     const [notifications, setNotifications] = useState<
         Notification.InApp.PersitedType[]
     >([]);
-    const notificationsPath = `in-app-notifications/${user?.userId}`;
+    const notificationsPath = `in-app-notifications/${userId}`;
     const isFirebaseAuthenticated = Boolean(firebase?.isAuthenticated());
     const [shouldListenToNotifications, setShouldListenToNotifications] =
-        useState(Boolean(firebase?.isAuthenticated() && user?.userId));
+        useState(Boolean(firebase?.isAuthenticated() && userId));
 
     const clearNotifications = clearNotificationsFactory({
         firebase,
@@ -42,10 +42,8 @@ export const Provider = ({ children }: { children: ReactNode }) => {
     });
 
     useEffect(() => {
-        setShouldListenToNotifications(
-            !!user?.userId && isFirebaseAuthenticated
-        );
-    }, [user?.userId, isFirebaseAuthenticated]);
+        setShouldListenToNotifications(!!userId && isFirebaseAuthenticated);
+    }, [userId, isFirebaseAuthenticated]);
 
     useEffect(() => {
         if (shouldListenToNotifications && !!firebase) {
@@ -60,12 +58,7 @@ export const Provider = ({ children }: { children: ReactNode }) => {
                 unsubscribe();
             };
         }
-    }, [
-        shouldListenToNotifications,
-        notificationsPath,
-        user?.userId,
-        firebase,
-    ]);
+    }, [shouldListenToNotifications, notificationsPath, userId, firebase]);
     return (
         <Context.Provider
             value={{

--- a/src/lib/modules/notifications/components/hooks/index.ts
+++ b/src/lib/modules/notifications/components/hooks/index.ts
@@ -1,1 +1,2 @@
 export { useInAppNotificationDrawer } from './use-in-app-notification-drawer';
+export { useInAppPresence } from './use-in-app-presence';

--- a/src/lib/modules/notifications/components/hooks/use-in-app-presence/index.ts
+++ b/src/lib/modules/notifications/components/hooks/use-in-app-presence/index.ts
@@ -1,0 +1,1 @@
+export * from './useInAppPresence';

--- a/src/lib/modules/notifications/components/hooks/use-in-app-presence/useInAppPresence.ts
+++ b/src/lib/modules/notifications/components/hooks/use-in-app-presence/useInAppPresence.ts
@@ -1,0 +1,67 @@
+import { useEffect, useRef, useState } from 'react';
+import { FirebaseVendor } from '@/lib/shared/vendors/firebase';
+
+interface InAppPresenceProps {
+    userId?: string;
+    firebase: FirebaseVendor | null;
+    inactivityTimeoutMs?: number;
+}
+
+const THIRTY_SECONDS = 30 * 1000;
+
+// Tracks user presence in the app and marks them `offline`.
+// Default inactivity occurs after 30 seconds
+export const useInAppPresence = ({
+    userId,
+    firebase,
+    inactivityTimeoutMs,
+}: InAppPresenceProps) => {
+    const windowBlurTimeout = useRef<number>();
+    const inactivityTimeout = useRef<number>();
+    const [localPresence, setLocalPresence] = useState<'online' | 'offline'>(
+        'offline'
+    );
+
+    useEffect(() => {
+        if (typeof window === 'undefined') return;
+        if (userId && firebase?.isAuthenticated()) {
+            const startInactivityTimeout = () =>
+                (inactivityTimeout.current = window.setTimeout(() => {
+                    if (localPresence === 'online') {
+                        firebase.setPresence(userId, 'offline');
+                        setLocalPresence('offline');
+                    }
+                }, inactivityTimeoutMs ?? THIRTY_SECONDS));
+
+            const resetInactivityTimeout = () => {
+                window.clearTimeout(inactivityTimeout?.current);
+                startInactivityTimeout();
+                if (localPresence === 'offline') {
+                    firebase.setPresence(userId, 'online');
+                    setLocalPresence('online');
+                }
+            };
+
+            const onWindowFocus = () => {
+                window.clearTimeout(windowBlurTimeout?.current);
+                if (localPresence === 'offline') {
+                    firebase.setPresence(userId, 'online');
+                    setLocalPresence('online');
+                }
+            };
+            window.addEventListener('mousemove', resetInactivityTimeout, false);
+            window.addEventListener('touchmove', resetInactivityTimeout, false);
+            window.addEventListener('focus', onWindowFocus);
+            startInactivityTimeout();
+
+            return () => {
+                window.clearTimeout(inactivityTimeout?.current);
+                window.removeEventListener('mousemove', resetInactivityTimeout);
+                window.removeEventListener('touchmove', resetInactivityTimeout);
+                window.removeEventListener('focus', onWindowFocus);
+            };
+        }
+    }, [firebase, localPresence, userId, inactivityTimeoutMs]);
+
+    return;
+};

--- a/src/lib/modules/notifications/components/hooks/use-in-app-presence/useInAppPresence.ts
+++ b/src/lib/modules/notifications/components/hooks/use-in-app-presence/useInAppPresence.ts
@@ -9,8 +9,8 @@ interface InAppPresenceProps {
 
 const THIRTY_SECONDS = 30 * 1000;
 
-// Tracks user presence in the app and marks them `offline`.
-// Default inactivity occurs after 30 seconds
+// Tracks user activity and marks them `offline` after specified time of activity.
+// Default inactivity timer expires after 30 seconds
 export const useInAppPresence = ({
     userId,
     firebase,

--- a/src/lib/modules/notifications/components/hooks/use-in-app-presence/useInAppPresence.ts
+++ b/src/lib/modules/notifications/components/hooks/use-in-app-presence/useInAppPresence.ts
@@ -1,6 +1,7 @@
 import { useEffect, useRef, useState } from 'react';
 import { useRouter } from 'next/router';
 import { FirebaseVendor } from '@/lib/shared/vendors/firebase';
+import { URL_PATHS } from '@/lib/sitemap';
 
 interface InAppPresenceProps {
     userId?: string;
@@ -27,6 +28,12 @@ export const useInAppPresence = ({
 
     useEffect(() => {
         if (typeof window === 'undefined') return;
+        if (pathname === URL_PATHS.AUTH.LOGOUT) {
+            // Signout will clean up presence.
+            // We dont want to make calls to firebase or we will get permission denied errors when the session ends from signout
+            window.clearTimeout(windowBlurTimeout?.current);
+            return;
+        }
         if (userId && firebase?.isAuthenticated()) {
             const startInactivityTimeout = () =>
                 (inactivityTimeout.current = window.setTimeout(() => {

--- a/src/lib/modules/notifications/components/hooks/use-in-app-presence/useInAppPresence.ts
+++ b/src/lib/modules/notifications/components/hooks/use-in-app-presence/useInAppPresence.ts
@@ -11,8 +11,12 @@ interface InAppPresenceProps {
 
 const THIRTY_SECONDS = 30 * 1000;
 
-// Tracks user activity and marks them `offline` after specified time of activity.
-// Default inactivity timer expires after 30 seconds
+/**
+ * Tracks user mouse, tap, and tab focus events to determine inactivity for presence
+ * @param userId the signed-in user's id
+ * @param firebase Firebase Vendor instance
+ * @param inactivityTimeoutMs the number of milliseconds of inactivity before the user is considered offline. Defualts to 30 seconds.
+ */
 export const useInAppPresence = ({
     userId,
     firebase,
@@ -28,9 +32,10 @@ export const useInAppPresence = ({
 
     useEffect(() => {
         if (typeof window === 'undefined') return;
-        if (pathname === URL_PATHS.AUTH.LOGOUT) {
+        if (pathname === URL_PATHS.AUTH.LOGOUT || pathname === '/') {
             // Signout will clean up presence.
-            // We dont want to make calls to firebase or we will get permission denied errors when the session ends from signout
+            // We dont want to make calls to firebase here
+            // or we will get permission denied errors when the session ends from signout
             window.clearTimeout(windowBlurTimeout?.current);
             return;
         }

--- a/src/lib/modules/notifications/service/get-user-presence/getUserPresenceFactory.ts
+++ b/src/lib/modules/notifications/service/get-user-presence/getUserPresenceFactory.ts
@@ -1,0 +1,18 @@
+import { FirebaseVendor } from '@/lib/shared/vendors/firebase';
+
+import { withAdminAuthentication } from '../in-app/utils/withAdminAuthentication';
+
+interface FactoryParams {
+    firebase: FirebaseVendor;
+}
+export const factory = (params: FactoryParams) => async (userId: string) => {
+    const firebase = await withAdminAuthentication(params.firebase);
+    if (firebase.isAuthenticated() === false) {
+        throw new Error('Notification service is not authenticated');
+    }
+    const presence = await firebase.getPresenceForUser(userId);
+    return {
+        isOnline: presence.status === 'online',
+        lastChanged: presence.last_changed ?? null,
+    };
+};

--- a/src/lib/modules/notifications/service/get-user-presence/getUserPresenceFactory.ts
+++ b/src/lib/modules/notifications/service/get-user-presence/getUserPresenceFactory.ts
@@ -13,6 +13,7 @@ export const factory = (params: FactoryParams) => async (userId: string) => {
     const presence = await firebase.getPresenceForUser(userId);
     return {
         isOnline: presence.status === 'online',
-        lastChanged: presence.last_changed ?? null,
+        updatedAt: presence.updatedAt ?? null,
+        path: presence.path,
     };
 };

--- a/src/lib/modules/notifications/service/get-user-presence/index.ts
+++ b/src/lib/modules/notifications/service/get-user-presence/index.ts
@@ -1,0 +1,1 @@
+export * as GetUserPresence from './getUserPresenceFactory';

--- a/src/lib/modules/notifications/service/in-app/create/createInAppNotification.ts
+++ b/src/lib/modules/notifications/service/in-app/create/createInAppNotification.ts
@@ -1,7 +1,7 @@
 import { CreateInAppNotification } from '@/lib/modules/notifications/features/in-app';
 import { InAppNotificationsFactoryParams } from '../factoryParams';
 import { getUserNotificationsPath } from '../utils';
-import { withAuthentication } from '../utils/withAuthentication';
+import { withAdminAuthentication } from '../utils/withAdminAuthentication';
 
 export const createInAppNotificationFactory =
     (params: InAppNotificationsFactoryParams) =>
@@ -9,7 +9,7 @@ export const createInAppNotificationFactory =
         targetUserId,
         notification,
     }: CreateInAppNotification.Input): Promise<CreateInAppNotification.Output> => {
-        const { firebase } = await withAuthentication(params);
+        const firebase = await withAdminAuthentication(params.firebase);
         if (firebase.isAuthenticated() === false) {
             throw new Error('Notification service is not authenticated');
         }

--- a/src/lib/modules/notifications/service/in-app/utils/withAdminAuthentication.ts
+++ b/src/lib/modules/notifications/service/in-app/utils/withAdminAuthentication.ts
@@ -1,17 +1,15 @@
+import { FirebaseVendor } from '@/lib/shared/vendors/firebase';
 import { firebaseAdminVendor } from '@/lib/shared/vendors/firebase-admin';
-import { InAppNotificationsFactoryParams } from '../factoryParams';
 import { IN_APP_NOTIFICATIONS_SERVICE_IDENTIFIER } from './constants';
 
-export const withAuthentication = async (
-    params: InAppNotificationsFactoryParams
-) => {
-    if (params.firebase.isAuthenticated() === false) {
+export const withAdminAuthentication = async (firebase: FirebaseVendor) => {
+    if (firebase.isAuthenticated() === false) {
         await firebaseAdminVendor
             .createCustomToken({
                 userId: IN_APP_NOTIFICATIONS_SERVICE_IDENTIFIER,
             })
             .then((token) => {
-                return params.firebase.authenticateWithCustomToken(token);
+                return firebase.authenticateWithCustomToken(token);
             })
             .catch((error) => {
                 console.error(error);
@@ -20,5 +18,5 @@ export const withAuthentication = async (
                 );
             });
     }
-    return params;
+    return firebase;
 };

--- a/src/lib/modules/notifications/service/index.ts
+++ b/src/lib/modules/notifications/service/index.ts
@@ -1,5 +1,6 @@
 import { prisma as orm } from '@/lib/prisma';
 import { getFirebaseVendor } from '@/lib/shared/vendors/firebase';
+import { GetUserPresence } from './get-user-presence';
 import { inAppNotificationFactory } from './in-app';
 import { IN_APP_NOTIFICATIONS_SERVICE_IDENTIFIER } from './in-app/utils/constants';
 
@@ -9,6 +10,7 @@ const firebase = getFirebaseVendor(IN_APP_NOTIFICATIONS_SERVICE_IDENTIFIER);
 
 export const notificationsService = {
     inApp: inAppNotificationFactory({ firebase, orm }),
+    getUserPresence: GetUserPresence.factory({ firebase }),
 };
 
 export type NotificationsService = typeof notificationsService;

--- a/src/lib/shared/context/firebase/Provider.tsx
+++ b/src/lib/shared/context/firebase/Provider.tsx
@@ -4,16 +4,15 @@ import { Context, firebase } from './Context';
 
 export const Provider = ({ children }: { children: ReactNode }) => {
     const { user } = useContext(TherifyUser.Context);
+    const isAuthenticated = firebase?.isAuthenticated();
 
     useEffect(() => {
         if (user?.firebaseToken && firebase?.isAuthenticated() === false) {
-            // TODO: There is a case where user can be defined but firebaseToken is undefined
-            // This will cause the user to never authenticate with firebase
             firebase.authenticateWithCustomToken(user.firebaseToken);
         } else if (!user && firebase?.isAuthenticated()) {
             firebase.signOut();
         }
-    }, [user]);
+    }, [user, isAuthenticated]);
 
     return (
         <Context.Provider

--- a/src/lib/shared/context/firebase/Provider.tsx
+++ b/src/lib/shared/context/firebase/Provider.tsx
@@ -7,6 +7,8 @@ export const Provider = ({ children }: { children: ReactNode }) => {
 
     useEffect(() => {
         if (user?.firebaseToken && firebase?.isAuthenticated() === false) {
+            // TODO: There is a case where user can be defined but firebaseToken is undefined
+            // This will cause the user to never authenticate with firebase
             firebase.authenticateWithCustomToken(user.firebaseToken);
         } else if (!user && firebase?.isAuthenticated()) {
             firebase.signOut();

--- a/src/lib/shared/vendors/firebase/getFirebaseVendor.ts
+++ b/src/lib/shared/vendors/firebase/getFirebaseVendor.ts
@@ -11,6 +11,7 @@ import {
     signOutFactory,
     readPresenceFactory,
     establishPresence,
+    setPresenceFactory,
 } from './methods';
 
 export const getFirebaseVendor = (instanceName: string) => {
@@ -44,6 +45,7 @@ export const getFirebaseVendor = (instanceName: string) => {
         addListener: addListenerFactory({ database }),
         updateData: updateDataFactory({ database }),
         getPresenceForUser: readPresenceFactory({ database }),
+        setPresence: setPresenceFactory({ database }),
         authenticateWithCustomToken: async (token: string) => {
             const userCredential = await authenticateWithCustomToken(token);
             unsubscribePresenceListener = await establishPresence(

--- a/src/lib/shared/vendors/firebase/methods/index.ts
+++ b/src/lib/shared/vendors/firebase/methods/index.ts
@@ -5,3 +5,4 @@ export * from './set-data';
 export * from './update-data';
 export * from './authenticate-with-custom-token';
 export * from './sign-out';
+export * from './presence';

--- a/src/lib/shared/vendors/firebase/methods/presence/constants.ts
+++ b/src/lib/shared/vendors/firebase/methods/presence/constants.ts
@@ -1,0 +1,1 @@
+export const USER_PRESENCE_PATH = '/status' as const;

--- a/src/lib/shared/vendors/firebase/methods/presence/establish-presence/establishPresence.ts
+++ b/src/lib/shared/vendors/firebase/methods/presence/establish-presence/establishPresence.ts
@@ -5,11 +5,11 @@ export const establishPresence = (uid: string, database: Database) => {
     const userStatusDatabaseRef = ref(database, `${USER_PRESENCE_PATH}/${uid}`);
 
     const isOfflineForDatabase = {
-        state: 'offline',
+        status: 'offline',
     };
 
     const isOnlineForDatabase = {
-        state: 'online',
+        status: 'online',
     };
 
     return onValue(ref(database, '.info/connected'), function (snapshot) {

--- a/src/lib/shared/vendors/firebase/methods/presence/establish-presence/establishPresence.ts
+++ b/src/lib/shared/vendors/firebase/methods/presence/establish-presence/establishPresence.ts
@@ -4,14 +4,6 @@ import { USER_PRESENCE_PATH } from '../constants';
 export const establishPresence = (uid: string, database: Database) => {
     const userStatusDatabaseRef = ref(database, `${USER_PRESENCE_PATH}/${uid}`);
 
-    const isOfflineForDatabase = {
-        status: 'offline',
-    };
-
-    const isOnlineForDatabase = {
-        status: 'online',
-    };
-
     return onValue(ref(database, '.info/connected'), function (snapshot) {
         // If we're not currently connected, don't do anything.
         if (snapshot.val() == false) {
@@ -24,8 +16,8 @@ export const establishPresence = (uid: string, database: Database) => {
         // losing internet, or any other means.
         onDisconnect(userStatusDatabaseRef)
             .set({
-                ...isOfflineForDatabase,
-                last_changed: new Date().toISOString(),
+                status: 'offline',
+                updatedAt: new Date().toISOString(),
             })
             .then(function () {
                 // The promise returned from .onDisconnect().set() will
@@ -36,8 +28,8 @@ export const establishPresence = (uid: string, database: Database) => {
                 // We can now safely set ourselves as 'online' knowing that the
                 // server will mark us as offline once we lose connection.
                 set(userStatusDatabaseRef, {
-                    ...isOnlineForDatabase,
-                    last_changed: new Date().toISOString(),
+                    status: 'online',
+                    updatedAt: new Date().toISOString(),
                 });
             });
     });

--- a/src/lib/shared/vendors/firebase/methods/presence/establish-presence/establishPresence.ts
+++ b/src/lib/shared/vendors/firebase/methods/presence/establish-presence/establishPresence.ts
@@ -1,0 +1,44 @@
+import { Database, ref, onValue, onDisconnect, set } from 'firebase/database';
+import { USER_PRESENCE_PATH } from '../constants';
+
+export const establishPresence = (uid: string, database: Database) => {
+    const userStatusDatabaseRef = ref(database, `${USER_PRESENCE_PATH}/${uid}`);
+
+    const isOfflineForDatabase = {
+        state: 'offline',
+    };
+
+    const isOnlineForDatabase = {
+        state: 'online',
+    };
+
+    return onValue(ref(database, '.info/connected'), function (snapshot) {
+        // If we're not currently connected, don't do anything.
+        if (snapshot.val() == false) {
+            return;
+        }
+
+        // If we are currently connected, then use the 'onDisconnect()'
+        // method to add a set which will only trigger once this
+        // client has disconnected by closing the app,
+        // losing internet, or any other means.
+        onDisconnect(userStatusDatabaseRef)
+            .set({
+                ...isOfflineForDatabase,
+                last_changed: new Date().toISOString(),
+            })
+            .then(function () {
+                // The promise returned from .onDisconnect().set() will
+                // resolve as soon as the server acknowledges the onDisconnect()
+                // request, NOT once we've actually disconnected:
+                // https://firebase.google.com/docs/reference/js/firebase.database.OnDisconnect
+
+                // We can now safely set ourselves as 'online' knowing that the
+                // server will mark us as offline once we lose connection.
+                set(userStatusDatabaseRef, {
+                    ...isOnlineForDatabase,
+                    last_changed: new Date().toISOString(),
+                });
+            });
+    });
+};

--- a/src/lib/shared/vendors/firebase/methods/presence/establish-presence/index.ts
+++ b/src/lib/shared/vendors/firebase/methods/presence/establish-presence/index.ts
@@ -1,0 +1,1 @@
+export * from './establishPresence';

--- a/src/lib/shared/vendors/firebase/methods/presence/index.ts
+++ b/src/lib/shared/vendors/firebase/methods/presence/index.ts
@@ -1,0 +1,2 @@
+export * from './establish-presence';
+export * from './read-presence';

--- a/src/lib/shared/vendors/firebase/methods/presence/index.ts
+++ b/src/lib/shared/vendors/firebase/methods/presence/index.ts
@@ -1,2 +1,3 @@
 export * from './establish-presence';
 export * from './read-presence';
+export * from './set-presence';

--- a/src/lib/shared/vendors/firebase/methods/presence/read-presence/index.ts
+++ b/src/lib/shared/vendors/firebase/methods/presence/read-presence/index.ts
@@ -1,0 +1,1 @@
+export * from './readPresence';

--- a/src/lib/shared/vendors/firebase/methods/presence/read-presence/readPresence.ts
+++ b/src/lib/shared/vendors/firebase/methods/presence/read-presence/readPresence.ts
@@ -3,17 +3,27 @@ import { readDataFactory } from '../../read-data';
 import { USER_PRESENCE_PATH } from '../constants';
 type UserPresence = {
     status: 'online' | 'offline';
-    last_changed: string | null;
+    // updatedAt: null only occurs on presence that has never been set
+    updatedAt: string | null;
+    path: string | null;
 };
+/**
+ * Reads a user's presence
+ * @param userId the signed-in user's id
+ * @param status online or offline
+ * @param path the url path the user is currently on
+ * @returns `success: true` or throws
+ */
 export const readPresenceFactory =
     (params: FirebaseFactoryParams) =>
     async (userId: string): Promise<UserPresence> => {
         const readData = readDataFactory(params);
         const presence = (await readData(
             `${USER_PRESENCE_PATH}/${userId}`
-        )) as { status: 'online' | 'offline'; last_changed: string };
+        )) as UserPresence;
         return {
             status: presence?.status === 'online' ? 'online' : 'offline',
-            last_changed: presence?.last_changed ?? null,
+            updatedAt: presence?.updatedAt ?? null,
+            path: presence.path ?? null,
         };
     };

--- a/src/lib/shared/vendors/firebase/methods/presence/read-presence/readPresence.ts
+++ b/src/lib/shared/vendors/firebase/methods/presence/read-presence/readPresence.ts
@@ -1,0 +1,9 @@
+import { FirebaseFactoryParams } from '../../../factoryParams';
+import { readDataFactory } from '../../read-data';
+import { USER_PRESENCE_PATH } from '../constants';
+
+export const readPresenceFactory =
+    (params: FirebaseFactoryParams) => async (userId: string) => {
+        const readData = readDataFactory(params);
+        return await readData(`${USER_PRESENCE_PATH}/${userId}`);
+    };

--- a/src/lib/shared/vendors/firebase/methods/presence/read-presence/readPresence.ts
+++ b/src/lib/shared/vendors/firebase/methods/presence/read-presence/readPresence.ts
@@ -1,9 +1,19 @@
 import { FirebaseFactoryParams } from '../../../factoryParams';
 import { readDataFactory } from '../../read-data';
 import { USER_PRESENCE_PATH } from '../constants';
-
+type UserPresence = {
+    status: 'online' | 'offline';
+    last_changed: string | null;
+};
 export const readPresenceFactory =
-    (params: FirebaseFactoryParams) => async (userId: string) => {
+    (params: FirebaseFactoryParams) =>
+    async (userId: string): Promise<UserPresence> => {
         const readData = readDataFactory(params);
-        return await readData(`${USER_PRESENCE_PATH}/${userId}`);
+        const presence = (await readData(
+            `${USER_PRESENCE_PATH}/${userId}`
+        )) as { status: 'online' | 'offline'; last_changed: string };
+        return {
+            status: presence?.status === 'online' ? 'online' : 'offline',
+            last_changed: presence?.last_changed ?? null,
+        };
     };

--- a/src/lib/shared/vendors/firebase/methods/presence/set-presence/index.ts
+++ b/src/lib/shared/vendors/firebase/methods/presence/set-presence/index.ts
@@ -1,0 +1,1 @@
+export * from './setPresence';

--- a/src/lib/shared/vendors/firebase/methods/presence/set-presence/setPresence.ts
+++ b/src/lib/shared/vendors/firebase/methods/presence/set-presence/setPresence.ts
@@ -19,7 +19,7 @@ export const setPresenceFactory =
         await set(ref(database, `${USER_PRESENCE_PATH}/${userId}`), {
             status,
             updatedAt: new Date().toISOString(),
-            path,
+            ...(path ? { path } : {}),
         });
         return { success: true };
     };

--- a/src/lib/shared/vendors/firebase/methods/presence/set-presence/setPresence.ts
+++ b/src/lib/shared/vendors/firebase/methods/presence/set-presence/setPresence.ts
@@ -2,15 +2,24 @@ import { ref, set } from 'firebase/database';
 import { FirebaseFactoryParams } from '../../../factoryParams';
 import { USER_PRESENCE_PATH } from '../constants';
 
+/**
+ * Sets a user's presence as online or offline
+ * @param userId the signed-in user's id
+ * @param status online or offline
+ * @param path the url path the user is currently on
+ * @returns `success: true` or throws
+ */
 export const setPresenceFactory =
     ({ database }: FirebaseFactoryParams) =>
     async (
         userId: string,
-        status: 'online' | 'offline'
-    ): Promise<{ success: boolean }> => {
+        status: 'online' | 'offline',
+        path?: string
+    ): Promise<{ success: true }> => {
         await set(ref(database, `${USER_PRESENCE_PATH}/${userId}`), {
             status,
-            last_changed: new Date().toISOString(),
+            updatedAt: new Date().toISOString(),
+            path,
         });
         return { success: true };
     };

--- a/src/lib/shared/vendors/firebase/methods/presence/set-presence/setPresence.ts
+++ b/src/lib/shared/vendors/firebase/methods/presence/set-presence/setPresence.ts
@@ -1,0 +1,16 @@
+import { ref, set } from 'firebase/database';
+import { FirebaseFactoryParams } from '../../../factoryParams';
+import { USER_PRESENCE_PATH } from '../constants';
+
+export const setPresenceFactory =
+    ({ database }: FirebaseFactoryParams) =>
+    async (
+        userId: string,
+        status: 'online' | 'offline'
+    ): Promise<{ success: boolean }> => {
+        await set(ref(database, `${USER_PRESENCE_PATH}/${userId}`), {
+            status,
+            last_changed: new Date().toISOString(),
+        });
+        return { success: true };
+    };

--- a/src/lib/shared/vendors/firebase/methods/sign-out/signOut.ts
+++ b/src/lib/shared/vendors/firebase/methods/sign-out/signOut.ts
@@ -5,6 +5,11 @@ import { signOut, Auth } from 'firebase/auth';
  */
 export const signOutFactory =
     ({ auth }: { auth: Auth }) =>
-    async () => {
+    async (preSignoutActions: Array<(() => void) | null | undefined>) => {
+        try {
+            await Promise.all(preSignoutActions.map((action) => action?.()));
+        } catch (error) {
+            console.error('Pre signout actions failed', error);
+        }
         return await signOut(auth);
     };

--- a/src/lib/sitemap/urls/api/index.ts
+++ b/src/lib/sitemap/urls/api/index.ts
@@ -2,4 +2,7 @@ import { ACCOUNTS_PATHS } from './accounts';
 
 export const API_PATHS = {
     ACCOUNTS: ACCOUNTS_PATHS,
+    AUTH: {
+        LOGOUT: '/api/auth/logout',
+    },
 } as const;

--- a/src/lib/sitemap/urls/authentication/index.ts
+++ b/src/lib/sitemap/urls/authentication/index.ts
@@ -1,4 +1,4 @@
 export const AUTHENTICATION_PATHS = {
     LOGIN: '/api/auth/login',
-    LOGOUT: '/api/auth/logout',
+    LOGOUT: '/logout',
 } as const;

--- a/src/pages/logout.tsx
+++ b/src/pages/logout.tsx
@@ -1,0 +1,38 @@
+import { CenteredContainer, TherifyIcon } from '@/lib/shared/components/ui';
+import { FirebaseClient } from '@/lib/shared/context';
+import { URL_PATHS } from '@/lib/sitemap';
+import { useTheme } from '@mui/material/styles';
+import { motion } from 'framer-motion';
+import { useRouter } from 'next/router';
+import { destroyCookie } from 'nookies';
+import { useContext, useEffect } from 'react';
+
+export default function Logout() {
+    const router = useRouter();
+    const theme = useTheme();
+    const { firebase } = useContext(FirebaseClient.Context);
+    useEffect(() => {
+        destroyCookie(null, 'userRoles');
+        firebase?.signOut();
+        router.push(URL_PATHS.API.AUTH.LOGOUT);
+    }, [firebase, router]);
+
+    return (
+        <CenteredContainer
+            fillSpace
+            style={{ background: theme.palette.background.default }}
+        >
+            <motion.div
+                animate={{ rotate: [0, 360, 360], scale: [1, 1.3, 1] }}
+                transition={{
+                    duration: 1,
+                    ease: 'easeInOut',
+                    repeat: Infinity,
+                    repeatDelay: 0.5,
+                }}
+            >
+                <TherifyIcon width="50px" />
+            </motion.div>
+        </CenteredContainer>
+    );
+}


### PR DESCRIPTION
# Description
Extends firebaseVendor to support tracking user presence in Firebase.
- Adds `readPresenceFactory`,`establishPresence`, and `setPresenceFactory` methods to Firebase Vendor
- Adds `useInAppPresence` hook
- Adds `getUserPresence` method to `Notifications Service`

Note: Refactors user Logout and Firebase sign-in/signout to more reliably keep firebase auth sessions in line with Auth0 auth sessions.
- Adds`Logout` page to clean up clientside authentication (sign out of firebase, set presence to `offline`, and clear cookies) before redirecting to Auth0's `api/auth/logout` route.
- Changes Sitemap's `URL_PATHS.AUTH.LOGOUT` path to be `/logout` so all existing logout navigation will go to new logout page.

# Closes issue(s)
[Trello: Firebase Presence](https://trello.com/c/TLwKjeHf)

# How to test / repro
- Go to Firebase Realtime Database Console
- Login to app.
- Find your userId and see it update as you end and resume activity
- 
# Screenshots
![image](https://user-images.githubusercontent.com/25045075/223231973-91e417f1-376d-497e-bcf1-a8a44f665b86.png)

# Changes include

-   [ ] Bugfix (non-breaking change that solves an issue)
-   [x] New feature (non-breaking change that adds functionality)
-   [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Checklist

-   [ ] I have tested this code
-   [ ] I have updated the Readme

# Other comments
