### PR TITLE
feat: handle inactive and expired plans

### DIFF
--- a/jest.config.ts
+++ b/jest.config.ts
@@ -6,19 +6,24 @@ import { compilerOptions } from './tsconfig.json';
 const createJestConfig = nextJest({
     dir: './',
 });
+const esModules = ['firebase', '@firebase'].join('|');
 
 const CONFIG: Config = {
     moduleDirectories: ['node_modules', '<rootDir>/src'],
     testEnvironment: 'jest-environment-jsdom',
     setupFilesAfterEnv: ['<rootDir>/jest.setup.ts'],
-    moduleNameMapper: pathsToModuleNameMapper(compilerOptions.paths, {
-        prefix: '<rootDir>/src',
-    }),
+    moduleNameMapper: {
+        ...pathsToModuleNameMapper(compilerOptions.paths, {
+            prefix: '<rootDir>/src',
+        }),
+        firebase: '<rootDir>/src/lib/shared/utils/test-utils/firebaseMock.ts',
+    },
     testPathIgnorePatterns: [
         '<rootDir>/.next/',
         '<rootDir>/node_modules/',
         '<rootDir>/e2e/',
     ],
+    transformIgnorePatterns: [`/node_modules/(?!${esModules})`],
 };
 
 export default createJestConfig(CONFIG);

--- a/src/lib/modules/notifications/components/hooks/use-in-app-notification-drawer/useInAppNotificationDrawer.tsx
+++ b/src/lib/modules/notifications/components/hooks/use-in-app-notification-drawer/useInAppNotificationDrawer.tsx
@@ -3,7 +3,6 @@ import { useRouter } from 'next/router';
 import { InAppNotificationsContext } from '../../context';
 import { getNotificationCountForPath } from './methods';
 import { handleActionFactory } from './methods/handle-action/handleAction';
-import { FirebaseClient } from '@/lib/shared/context';
 import { NavigationLink } from '@/lib/sitemap';
 
 export const useInAppNotificationDrawer = () => {

--- a/src/lib/modules/providers/service/get-provider-therify-user/getProviderTherifyUser.ts
+++ b/src/lib/modules/providers/service/get-provider-therify-user/getProviderTherifyUser.ts
@@ -70,7 +70,6 @@ export const factory =
         });
 
         if (!user) return { user: null };
-        console.log('Building provider user', user);
         const {
             providerProfile,
             emailAddress,

--- a/src/lib/modules/providers/service/page-props/get-billing-page-props/getBillingPageProps.ts
+++ b/src/lib/modules/providers/service/page-props/get-billing-page-props/getBillingPageProps.ts
@@ -33,14 +33,6 @@ export const factory = (params: ProvidersServiceParams) => {
                 },
             };
         }
-        if (!user.isPracticeAdmin) {
-            return {
-                redirect: {
-                    destination: URL_PATHS.ROOT,
-                    permanent: false,
-                },
-            };
-        }
 
         const stripeCustomerPortalUrl =
             process.env.STRIPE_CUSTOMER_PORTAL_URL ?? null;

--- a/src/lib/shared/components/features/account/MemberExpiredPlanPage/MemberExpiredPlanPage.spec.tsx
+++ b/src/lib/shared/components/features/account/MemberExpiredPlanPage/MemberExpiredPlanPage.spec.tsx
@@ -1,0 +1,106 @@
+import { renderWithTheme } from '@/lib/shared/components/fixtures/renderWithTheme';
+import { Mocks } from '@/lib/shared/types';
+import { useInAppNotificationDrawer } from '@/lib/modules/notifications/components/hooks';
+import { MemberExpiredPlanPage } from './MemberExpiredPlanPage';
+import { format } from 'date-fns';
+
+jest.mock('@/lib/modules/notifications/components/hooks', () => {
+    return {
+        useInAppNotificationDrawer: jest.fn(),
+    };
+});
+
+jest.mock('next/router', () => {
+    return {
+        useRouter: () => ({ pathname: '/test', push: jest.fn() }),
+    };
+});
+
+describe('MemberExpiredPlanPage', () => {
+    beforeAll(() => {
+        (useInAppNotificationDrawer as jest.Mock).mockReturnValue({
+            notifications: [],
+            clearNotifications: jest.fn(),
+            clearActionlessNotifications: jest.fn(),
+            drawer: {
+                isOpen: false,
+                close: jest.fn(),
+                open: jest.fn(),
+            },
+            unreadCount: 0,
+            handleAction: jest.fn(),
+            getNotificationsMapForMenu: () => ({}),
+            getNotificationCountForPath: jest.fn(),
+        });
+    });
+
+    const inactiveMessage =
+        'Please contact the account administrator within your organization for further information about access to our services.';
+    const expiredMessage =
+        'Your sponsoring organization’s contract with Therify has expired. Please contact the account administrator within your organization for further information on future access to our services.';
+
+    it('renders', () => {
+        expect(
+            renderWithTheme(
+                <MemberExpiredPlanPage
+                    user={Mocks.getTherifyUser({
+                        type: 'member',
+                    })}
+                />
+            )
+        ).toBeDefined();
+    });
+
+    it('should render active message when not expired', () => {
+        const user = Mocks.getTherifyUser({
+            type: 'member',
+            plan: 'active',
+        });
+        const { getByText } = renderWithTheme(
+            <MemberExpiredPlanPage user={user} />
+        );
+        expect(
+            getByText(
+                `Your current plan access ends on ${format(
+                    new Date(user.plan!.endDate),
+                    'MMMM do, yyyy'
+                )}.`
+            )
+        ).toBeVisible();
+    });
+
+    it('should render expired message when expired', () => {
+        const user = Mocks.getTherifyUser({
+            type: 'member',
+            plan: 'expired',
+        });
+        const { getByText } = renderWithTheme(
+            <MemberExpiredPlanPage user={user} />
+        );
+        expect(getByText(expiredMessage)).toBeVisible();
+    });
+
+    it('should render inactive message when plan not active', () => {
+        const user = Mocks.getTherifyUser({
+            type: 'member',
+            plan: 'inactive',
+        });
+        const { getByText } = renderWithTheme(
+            <MemberExpiredPlanPage user={user} />
+        );
+        expect(getByText(inactiveMessage)).toBeVisible();
+        expect(getByText('Your plan status is not active.')).toBeVisible();
+    });
+
+    it('should not render invalid messages when plan is active', () => {
+        const user = Mocks.getTherifyUser({
+            type: 'member',
+            plan: 'active',
+        });
+        const { queryByText } = renderWithTheme(
+            <MemberExpiredPlanPage user={user} />
+        );
+        expect(queryByText(inactiveMessage)).toBeNull();
+        expect(queryByText(expiredMessage)).toBeNull();
+    });
+});

--- a/src/lib/shared/components/features/account/MemberExpiredPlanPage/MemberExpiredPlanPage.tsx
+++ b/src/lib/shared/components/features/account/MemberExpiredPlanPage/MemberExpiredPlanPage.tsx
@@ -49,7 +49,7 @@ export const MemberExpiredPlanPage = ({ user }: MemberTherifyUserPageProps) => {
 
     return (
         <MemberNavigationPage
-            currentPath={URL_PATHS.MEMBERS.ACCOUNT.EXPIRED_PLAN}
+            currentPath={URL_PATHS.MEMBERS.ACCOUNT.INVALID_PLAN}
             user={user}
         >
             <CenteredContainer

--- a/src/lib/shared/components/features/account/MemberExpiredPlanPage/MemberExpiredPlanPage.tsx
+++ b/src/lib/shared/components/features/account/MemberExpiredPlanPage/MemberExpiredPlanPage.tsx
@@ -1,0 +1,115 @@
+import { Box } from '@mui/material';
+import { styled } from '@mui/material/styles';
+import { isAfter, format } from 'date-fns';
+import { useTheme } from '@mui/material/styles';
+import { WarningRounded } from '@mui/icons-material';
+import { useRouter } from 'next/router';
+import {
+    Paragraph,
+    H3,
+    Alert,
+    CenteredContainer,
+    Button,
+} from '@/lib/shared/components/ui';
+import { MemberTherifyUserPageProps } from '@/lib/modules/members/service/get-therify-user-props';
+import { MemberNavigationPage } from '@/lib/shared/components/features/pages';
+import { URL_PATHS } from '@/lib/sitemap';
+import { PlanStatus } from '@prisma/client';
+
+export const MemberExpiredPlanPage = ({ user }: MemberTherifyUserPageProps) => {
+    const theme = useTheme();
+    const router = useRouter();
+    const isPlanExpired =
+        !!user?.plan?.endDate &&
+        isAfter(new Date(), new Date(user.plan.endDate));
+    const isPlanActive =
+        !!user &&
+        (user.plan?.status === PlanStatus.active ||
+            user.plan?.status === PlanStatus.trialing);
+
+    if (!isPlanExpired && isPlanActive) {
+        return (
+            <CenteredContainer
+                fillSpace
+                style={{ background: theme.palette.background.default }}
+            >
+                <H3>Plan is still active</H3>
+                {user?.plan?.endDate && (
+                    <Paragraph>
+                        Your current plan access ends on{' '}
+                        {format(new Date(user.plan.endDate), 'MMMM do, yyyy')}.
+                    </Paragraph>
+                )}
+                <Button onClick={() => router.push(URL_PATHS.ROOT)}>
+                    Go Home
+                </Button>
+            </CenteredContainer>
+        );
+    }
+
+    return (
+        <MemberNavigationPage
+            currentPath={URL_PATHS.MEMBERS.ACCOUNT.EXPIRED_PLAN}
+            user={user}
+        >
+            <CenteredContainer
+                fillSpace
+                style={{ background: theme.palette.background.default }}
+            >
+                <ErrorContainer>
+                    <H3>
+                        Unfortunately, you no longer have access to Therify.
+                    </H3>
+                    {isPlanExpired && (
+                        <Paragraph>
+                            Your sponsoring organization’s contract with Therify
+                            has expired. Please contact the account
+                            administrator within your organization for further
+                            information on future access to our services.
+                        </Paragraph>
+                    )}
+                    {isPlanExpired && user.plan?.endDate && (
+                        <Alert
+                            icon={
+                                <CenteredContainer marginRight={2}>
+                                    <WarningRounded />
+                                </CenteredContainer>
+                            }
+                            title={`Your plan expired on ${format(
+                                new Date(user.plan.endDate),
+                                'MMMM do, yyyy'
+                            )}.`}
+                            type="error"
+                        />
+                    )}
+                    {!isPlanExpired && !isPlanActive && (
+                        <Paragraph>
+                            Please contact the account administrator within your
+                            organization for further information about access to
+                            our services.
+                        </Paragraph>
+                    )}
+                    {!isPlanExpired && !isPlanActive && (
+                        <Alert
+                            icon={
+                                <CenteredContainer marginRight={2}>
+                                    <WarningRounded />
+                                </CenteredContainer>
+                            }
+                            title="Your plan status is not active."
+                            type="error"
+                        />
+                    )}
+                </ErrorContainer>
+            </CenteredContainer>
+        </MemberNavigationPage>
+    );
+};
+
+const ErrorContainer = styled(Box)(({ theme }) => ({
+    background: theme.palette.background.paper,
+    borderRadius: theme.shape.borderRadius,
+    padding: theme.spacing(10),
+    border: `1px solide ${theme.palette.error.main}`,
+    maxWidth: '800px',
+}));

--- a/src/lib/shared/components/features/account/MemberExpiredPlanPage/index.ts
+++ b/src/lib/shared/components/features/account/MemberExpiredPlanPage/index.ts
@@ -1,0 +1,1 @@
+export * from './MemberExpiredPlanPage';

--- a/src/lib/shared/components/features/pages/SideNavigationPage/SideNavigationPage.tsx
+++ b/src/lib/shared/components/features/pages/SideNavigationPage/SideNavigationPage.tsx
@@ -4,7 +4,8 @@ import { styled, useTheme } from '@mui/material/styles';
 import { Button, BUTTON_TYPE } from '@/lib/shared/components/ui';
 import { ActionNavListItem } from '@/lib/shared/components/ui/Navigation/NavigationMenu';
 import { NavigationLink, URL_PATHS } from '@/lib/sitemap';
-import { TherifyUser } from '@/lib/shared/hooks';
+import { usePlanMonitoring } from '@/lib/shared/hooks';
+import { TherifyUser } from '@/lib/shared/types';
 import {
     SideNavigationLayout,
     NavigationDrawer,
@@ -21,12 +22,14 @@ export interface SideNavigationPageProps {
     mobileMenu: NavigationLink[];
     currentPath: string;
     onNavigate: (path: string) => void;
-    user?: TherifyUser;
+    user?: TherifyUser.TherifyUser;
     actionLink?: NavigationLink;
     isLoadingUser?: boolean;
     children?: React.ReactNode;
 }
-
+/**
+ * @deprecated Use role-based navigation page navigation components instead except for in role-based navigation page components themselves
+ */
 export const SideNavigationPage = ({
     primaryMenu,
     secondaryMenu,
@@ -38,6 +41,7 @@ export const SideNavigationPage = ({
     isLoadingUser = false,
     children,
 }: SideNavigationPageProps) => {
+    usePlanMonitoring(user);
     const [isMobileMenuOpen, setIsMobileMenuOpen] = useState(false);
     const theme = useTheme();
     const {

--- a/src/lib/shared/components/features/pages/SideNavigationPage/SideNavigationPage.tsx
+++ b/src/lib/shared/components/features/pages/SideNavigationPage/SideNavigationPage.tsx
@@ -41,7 +41,7 @@ export const SideNavigationPage = ({
     isLoadingUser = false,
     children,
 }: SideNavigationPageProps) => {
-    usePlanMonitoring(user);
+    const { hasAccess } = usePlanMonitoring(user);
     const [isMobileMenuOpen, setIsMobileMenuOpen] = useState(false);
     const theme = useTheme();
     const {
@@ -71,10 +71,12 @@ export const SideNavigationPage = ({
             navigationSlot={
                 <SideNavigationBar
                     currentPath={currentPath}
-                    navigationMenu={primaryMenu}
+                    navigationMenu={hasAccess ? primaryMenu : []}
                     onNavigate={onNavigate}
                     actionLink={actionLink}
-                    notificationMap={getNotificationsMapForMenu(primaryMenu)}
+                    notificationMap={getNotificationsMapForMenu(
+                        hasAccess ? primaryMenu : []
+                    )}
                 />
             }
         >
@@ -84,8 +86,10 @@ export const SideNavigationPage = ({
                 currentPath={currentPath}
                 isOpen={isMobileMenuOpen}
                 onClose={() => setIsMobileMenuOpen(false)}
-                navigationMenu={mobileMenu}
-                notificationsMap={getNotificationsMapForMenu(mobileMenu)}
+                navigationMenu={hasAccess ? mobileMenu : secondaryMenu}
+                notificationsMap={getNotificationsMapForMenu(
+                    hasAccess ? mobileMenu : secondaryMenu
+                )}
                 onNavigate={(path) => {
                     onNavigate(path);
                     setIsMobileMenuOpen(false);

--- a/src/lib/shared/components/features/pages/TopNavigationPage/TopNavigationPage.tsx
+++ b/src/lib/shared/components/features/pages/TopNavigationPage/TopNavigationPage.tsx
@@ -39,7 +39,7 @@ export const TopNavigationPage = ({
     isLoadingUser,
     children,
 }: TopNavigationPageProps) => {
-    usePlanMonitoring(user);
+    const { hasAccess } = usePlanMonitoring(user);
     const [isMobileMenuOpen, setIsMobileMenuOpen] = useState(false);
     const theme = useTheme();
     const {
@@ -57,7 +57,7 @@ export const TopNavigationPage = ({
                 user && (
                     <TopNavigationBar
                         currentPath={currentPath}
-                        primaryMenu={primaryMenu}
+                        primaryMenu={hasAccess ? primaryMenu : []}
                         secondaryMenu={secondaryMenu}
                         onNavigate={onNavigate}
                         onShowNotifications={notificationDrawer.open}
@@ -78,8 +78,10 @@ export const TopNavigationPage = ({
                     currentPath={currentPath}
                     isOpen={isMobileMenuOpen}
                     onClose={() => setIsMobileMenuOpen(false)}
-                    navigationMenu={mobileMenu}
-                    notificationsMap={getNotificationsMapForMenu(mobileMenu)}
+                    navigationMenu={hasAccess ? mobileMenu : secondaryMenu}
+                    notificationsMap={getNotificationsMapForMenu(
+                        hasAccess ? mobileMenu : secondaryMenu
+                    )}
                     onNavigate={(path) => {
                         onNavigate(path);
                         setIsMobileMenuOpen(false);

--- a/src/lib/shared/components/features/pages/TopNavigationPage/TopNavigationPage.tsx
+++ b/src/lib/shared/components/features/pages/TopNavigationPage/TopNavigationPage.tsx
@@ -4,6 +4,7 @@ import { LogoutRounded as LogoutIcon } from '@mui/icons-material';
 import { styled, useTheme } from '@mui/material/styles';
 import { NavigationLink, URL_PATHS } from '@/lib/sitemap';
 import { TherifyUser } from '@/lib/shared/types';
+import { usePlanMonitoring } from '@/lib/shared/hooks';
 import {
     Button,
     BUTTON_TYPE,
@@ -25,6 +26,9 @@ export interface TopNavigationPageProps {
     isLoadingUser: boolean;
     children?: React.ReactNode;
 }
+/**
+ * @deprecated Use role-based navigation page navigation components instead except for in role-based navigation page components themselves
+ */
 export const TopNavigationPage = ({
     primaryMenu,
     secondaryMenu,
@@ -35,6 +39,7 @@ export const TopNavigationPage = ({
     isLoadingUser,
     children,
 }: TopNavigationPageProps) => {
+    usePlanMonitoring(user);
     const [isMobileMenuOpen, setIsMobileMenuOpen] = useState(false);
     const theme = useTheme();
     const {

--- a/src/lib/shared/components/features/pages/index.ts
+++ b/src/lib/shared/components/features/pages/index.ts
@@ -1,2 +1,5 @@
 export { SideNavigationPage } from './SideNavigationPage';
 export { TopNavigationPage } from './TopNavigationPage';
+export { ProviderNavigationPage } from './ProviderNavigationPage';
+export { MemberNavigationPage } from './MemberNavigationPage';
+export { PracticeAdminNavigationPage } from './PracticeAdminNavigationPage';

--- a/src/lib/shared/components/features/pages/providers/billing-page-view/BillingPageView.spec.tsx
+++ b/src/lib/shared/components/features/pages/providers/billing-page-view/BillingPageView.spec.tsx
@@ -1,0 +1,225 @@
+import { renderWithTheme } from '@/lib/shared/components/fixtures/renderWithTheme';
+import { Mocks } from '@/lib/shared/types';
+import { useInAppNotificationDrawer } from '@/lib/modules/notifications/components/hooks';
+import { ProviderBillingPageView } from './BillingPageView';
+import { TEST_IDS } from './ui';
+import { format } from 'date-fns';
+jest.mock('@/lib/modules/notifications/components/hooks', () => {
+    return {
+        useInAppNotificationDrawer: jest.fn(),
+    };
+});
+jest.mock('next/router', () => {
+    return {
+        useRouter: () => ({ pathname: '/test', push: jest.fn() }),
+    };
+});
+
+describe('BillingPage', () => {
+    const currentPath = '/billing';
+    beforeEach(() => {
+        (useInAppNotificationDrawer as jest.Mock).mockReturnValue({
+            notifications: [],
+            clearNotifications: jest.fn(),
+            clearActionlessNotifications: jest.fn(),
+            drawer: {
+                isOpen: false,
+                close: jest.fn(),
+                open: jest.fn(),
+            },
+            unreadCount: 0,
+            handleAction: jest.fn(),
+            getNotificationsMapForMenu: () => ({}),
+            getNotificationCountForPath: jest.fn(),
+        });
+    });
+
+    it('renders', () => {
+        expect(
+            renderWithTheme(
+                <ProviderBillingPageView
+                    currentPath={currentPath}
+                    user={Mocks.getTherifyUser({
+                        type: 'therapist',
+                    })}
+                    stripeCustomerPortalUrl={null}
+                />
+            )
+        ).toBeDefined();
+    });
+
+    const inactivePlanAlertTitle = 'Your plan is not active.';
+    describe('Practice Owner', () => {
+        const stripeButtonText = 'Launch Stripe Customer Portal';
+        const missingStripeUrlAlertText =
+            'Stripe customer portal URL is not configured. Please reach out to Therify support.';
+        const invalidPlanAlertMessage =
+            'Please update your billing information with Stripe to continue using Therify.';
+        it('should render practice owner billing page', () => {
+            const { queryByTestId } = renderWithTheme(
+                <ProviderBillingPageView
+                    currentPath={currentPath}
+                    user={Mocks.getTherifyUser({
+                        type: 'practice-owner',
+                    })}
+                    stripeCustomerPortalUrl={null}
+                />
+            );
+            expect(
+                queryByTestId(TEST_IDS.PRACTICE_ADMIN_BILLING_VIEW)
+            ).toBeInTheDocument();
+            expect(queryByTestId(TEST_IDS.PROVIDER_BILLING_VIEW)).toBeNull();
+        });
+
+        it('should render stripe button', () => {
+            const { getByText } = renderWithTheme(
+                <ProviderBillingPageView
+                    currentPath={currentPath}
+                    user={Mocks.getTherifyUser({
+                        type: 'practice-owner',
+                    })}
+                    stripeCustomerPortalUrl={'therify.co'}
+                />
+            );
+            expect(getByText(stripeButtonText)).toBeVisible();
+        });
+        it('should render stripe alert when checkout url is missing', () => {
+            const { getByText } = renderWithTheme(
+                <ProviderBillingPageView
+                    currentPath={currentPath}
+                    user={Mocks.getTherifyUser({
+                        type: 'practice-owner',
+                    })}
+                    stripeCustomerPortalUrl={null}
+                />
+            );
+            expect(getByText(missingStripeUrlAlertText)).toBeVisible();
+        });
+
+        it('should show expired plan alert', () => {
+            const mockUser = Mocks.getTherifyUser({
+                type: 'practice-owner',
+                plan: 'expired',
+            });
+            const expiredPlanAlertTitle = `Your plan expired on ${format(
+                new Date(mockUser.plan!.endDate),
+                'MMMM do, yyyy'
+            )}.`;
+            const { getByText } = renderWithTheme(
+                <ProviderBillingPageView
+                    currentPath={currentPath}
+                    user={mockUser}
+                    stripeCustomerPortalUrl={null}
+                />
+            );
+            expect(getByText(expiredPlanAlertTitle)).toBeVisible();
+            expect(getByText(invalidPlanAlertMessage)).toBeVisible();
+        });
+        it('should show inactive plan alert', () => {
+            const { getByText } = renderWithTheme(
+                <ProviderBillingPageView
+                    currentPath={currentPath}
+                    user={Mocks.getTherifyUser({
+                        type: 'practice-owner',
+                        plan: 'inactive',
+                    })}
+                    stripeCustomerPortalUrl={null}
+                />
+            );
+            expect(getByText(inactivePlanAlertTitle)).toBeVisible();
+            expect(getByText(invalidPlanAlertMessage)).toBeVisible();
+        });
+        it('should not show alerts when plan is valid', () => {
+            const { queryByText } = renderWithTheme(
+                <ProviderBillingPageView
+                    currentPath={currentPath}
+                    user={Mocks.getTherifyUser({
+                        type: 'practice-owner',
+                        plan: 'active',
+                    })}
+                    stripeCustomerPortalUrl={'stripe.com'}
+                />
+            );
+            [
+                inactivePlanAlertTitle,
+                missingStripeUrlAlertText,
+                invalidPlanAlertMessage,
+            ].forEach((text) => {
+                expect(queryByText(text)).toBeNull();
+            });
+        });
+    });
+
+    describe('Provider', () => {
+        const invalidPlanAlertMessage =
+            'Please reach out to your practice administrator to update your billing information.';
+        it('should render provider billing page', () => {
+            const { queryByTestId } = renderWithTheme(
+                <ProviderBillingPageView
+                    currentPath={currentPath}
+                    user={Mocks.getTherifyUser({
+                        type: 'therapist',
+                    })}
+                    stripeCustomerPortalUrl={null}
+                />
+            );
+            expect(
+                queryByTestId(TEST_IDS.PRACTICE_ADMIN_BILLING_VIEW)
+            ).toBeNull();
+            expect(
+                queryByTestId(TEST_IDS.PROVIDER_BILLING_VIEW)
+            ).toBeInTheDocument();
+        });
+
+        it('should show expired plan alert', () => {
+            const mockUser = Mocks.getTherifyUser({
+                type: 'therapist',
+                plan: 'expired',
+            });
+            const expiredPlanAlertTitle = `Your plan expired on ${format(
+                new Date(mockUser.plan!.endDate),
+                'MMMM do, yyyy'
+            )}.`;
+            const { getByText } = renderWithTheme(
+                <ProviderBillingPageView
+                    currentPath={currentPath}
+                    user={mockUser}
+                    stripeCustomerPortalUrl={null}
+                />
+            );
+            expect(getByText(expiredPlanAlertTitle)).toBeVisible();
+            expect(getByText(invalidPlanAlertMessage)).toBeVisible();
+        });
+        it('should show inactive plan alert', () => {
+            const { getByText } = renderWithTheme(
+                <ProviderBillingPageView
+                    currentPath={currentPath}
+                    user={Mocks.getTherifyUser({
+                        type: 'therapist',
+                        plan: 'inactive',
+                    })}
+                    stripeCustomerPortalUrl={null}
+                />
+            );
+            expect(getByText(inactivePlanAlertTitle)).toBeVisible();
+            expect(getByText(invalidPlanAlertMessage)).toBeVisible();
+        });
+        it('should not show alerts when plan is valid', () => {
+            const { queryByText } = renderWithTheme(
+                <ProviderBillingPageView
+                    currentPath={currentPath}
+                    user={Mocks.getTherifyUser({
+                        type: 'therapist',
+                        plan: 'active',
+                    })}
+                    stripeCustomerPortalUrl={'stripe.com'}
+                />
+            );
+            [inactivePlanAlertTitle, invalidPlanAlertMessage].forEach(
+                (text) => {
+                    expect(queryByText(text)).toBeNull();
+                }
+            );
+        });
+    });
+});

--- a/src/lib/shared/components/features/pages/providers/billing-page-view/BillingPageView.tsx
+++ b/src/lib/shared/components/features/pages/providers/billing-page-view/BillingPageView.tsx
@@ -1,0 +1,44 @@
+import { isAfter } from 'date-fns';
+import { TherifyUser } from '@/lib/shared/types';
+import { PlanStatus } from '@prisma/client';
+import { PracticeAdminBillingView, ProviderBillingView } from './ui';
+
+interface ProviderBillingPageViewProps {
+    user: TherifyUser.TherifyUser;
+    stripeCustomerPortalUrl: string | null;
+    currentPath: string;
+}
+
+export const ProviderBillingPageView = ({
+    user,
+    stripeCustomerPortalUrl,
+    currentPath,
+}: ProviderBillingPageViewProps) => {
+    const isPlanExpired =
+        !!user?.plan?.endDate &&
+        isAfter(new Date(), new Date(user.plan.endDate));
+    const isPlanActive =
+        user &&
+        (user?.plan?.status === PlanStatus.active ||
+            user?.plan?.status === PlanStatus.trialing);
+    return (
+        <>
+            {user?.isPracticeAdmin ? (
+                <PracticeAdminBillingView
+                    currentPath={currentPath}
+                    stripeCustomerPortalUrl={stripeCustomerPortalUrl}
+                    isPlanExpired={isPlanExpired}
+                    isPlanActive={isPlanActive}
+                    user={user}
+                />
+            ) : (
+                <ProviderBillingView
+                    currentPath={currentPath}
+                    user={user}
+                    isPlanExpired={isPlanExpired}
+                    isPlanActive={isPlanActive}
+                />
+            )}
+        </>
+    );
+};

--- a/src/lib/shared/components/features/pages/providers/billing-page-view/ui/PlanAlert.tsx
+++ b/src/lib/shared/components/features/pages/providers/billing-page-view/ui/PlanAlert.tsx
@@ -1,0 +1,32 @@
+import { Alert, CenteredContainer } from '@/lib/shared/components/ui';
+import { WarningRounded } from '@mui/icons-material';
+import { format } from 'date-fns';
+
+export const PlanAlert = ({
+    endDate,
+    message,
+    showExpiredMessage,
+}: {
+    endDate?: string;
+    showExpiredMessage: boolean;
+    message: string;
+}) => {
+    const expiredTitle = `Your plan expired${
+        endDate ? ` on ${format(new Date(endDate), 'MMMM do, yyyy')}` : ''
+    }.`;
+    const title = showExpiredMessage
+        ? expiredTitle
+        : 'Your plan is not active.';
+    return (
+        <Alert
+            icon={
+                <CenteredContainer marginRight={2}>
+                    <WarningRounded />
+                </CenteredContainer>
+            }
+            title={title}
+            type="error"
+            message={message}
+        />
+    );
+};

--- a/src/lib/shared/components/features/pages/providers/billing-page-view/ui/PracticeAdminBillingView.tsx
+++ b/src/lib/shared/components/features/pages/providers/billing-page-view/ui/PracticeAdminBillingView.tsx
@@ -1,0 +1,86 @@
+import { Box, Link } from '@mui/material';
+import { useTheme } from '@mui/material/styles';
+import {
+    ArrowForwardRounded as ArrowIcon,
+    WarningRounded,
+} from '@mui/icons-material';
+import { TherifyUser } from '@/lib/shared/types';
+import {
+    Paragraph,
+    H3,
+    Button,
+    Alert,
+    CenteredContainer,
+} from '@/lib/shared/components/ui';
+import { PracticeAdminNavigationPage } from '@/lib/shared/components/features/pages';
+import { PlanAlert } from './PlanAlert';
+import { TEST_IDS } from './testIds';
+
+export const PracticeAdminBillingView = ({
+    stripeCustomerPortalUrl,
+    isPlanExpired,
+    isPlanActive,
+    currentPath,
+    user,
+}: {
+    isPlanExpired: boolean;
+    isPlanActive: boolean;
+    user: TherifyUser.TherifyUser;
+    stripeCustomerPortalUrl: string | null;
+    currentPath: string;
+}) => {
+    const theme = useTheme();
+
+    return (
+        <PracticeAdminNavigationPage currentPath={currentPath} user={user}>
+            <Box data-testid={TEST_IDS.PRACTICE_ADMIN_BILLING_VIEW} padding={4}>
+                {(isPlanExpired || !isPlanActive) && user && (
+                    <Box marginBottom={4}>
+                        <PlanAlert
+                            showExpiredMessage={isPlanExpired}
+                            endDate={user.plan?.endDate}
+                            message="Please update your billing information with Stripe to continue using Therify."
+                        />
+                    </Box>
+                )}
+                <H3>Billing and Subscription</H3>
+                <Paragraph>
+                    We partner with{' '}
+                    <Link
+                        href="https://stripe.com/"
+                        target="_blank"
+                        style={{ color: theme.palette.text.primary }}
+                    >
+                        Stripe
+                    </Link>{' '}
+                    for simplified billing. You can edit subscription and
+                    payment settings in Stripe&apos;s customer portal.
+                </Paragraph>
+
+                {stripeCustomerPortalUrl ? (
+                    <Link
+                        href={stripeCustomerPortalUrl}
+                        target="_blank"
+                        style={{ textDecoration: 'none' }}
+                    >
+                        <Button endIcon={<ArrowIcon />}>
+                            Launch Stripe Customer Portal
+                        </Button>
+                    </Link>
+                ) : (
+                    <Alert
+                        icon={
+                            <CenteredContainer>
+                                <WarningRounded />
+                            </CenteredContainer>
+                        }
+                        title="Stripe Billing Issue"
+                        type="error"
+                        message="Stripe customer portal URL is not configured. Please reach
+                    out to Therify support."
+                    />
+                )}
+            </Box>
+        </PracticeAdminNavigationPage>
+    );
+};

--- a/src/lib/shared/components/features/pages/providers/billing-page-view/ui/ProviderBillingView.tsx
+++ b/src/lib/shared/components/features/pages/providers/billing-page-view/ui/ProviderBillingView.tsx
@@ -1,0 +1,39 @@
+import { Box } from '@mui/material';
+import { TherifyUser } from '@/lib/shared/types';
+import { Paragraph, H3 } from '@/lib/shared/components/ui';
+import { ProviderNavigationPage } from '@/lib/shared/components/features/pages';
+import { PlanAlert } from './PlanAlert';
+import { TEST_IDS } from './testIds';
+
+export const ProviderBillingView = ({
+    user,
+    isPlanExpired,
+    isPlanActive,
+    currentPath,
+}: {
+    user: TherifyUser.TherifyUser;
+    isPlanExpired: boolean;
+    isPlanActive: boolean;
+    currentPath: string;
+}) => {
+    return (
+        <ProviderNavigationPage currentPath={currentPath} user={user}>
+            <Box data-testid={TEST_IDS.PROVIDER_BILLING_VIEW} padding={4}>
+                {(isPlanExpired || !isPlanActive) && user && (
+                    <Box marginBottom={4}>
+                        <PlanAlert
+                            showExpiredMessage={isPlanExpired}
+                            endDate={user.plan?.endDate}
+                            message="Please reach out to your practice administrator to update your billing information."
+                        />
+                    </Box>
+                )}
+                <H3>Billing and Subscription</H3>
+                <Paragraph>
+                    Your billing is handled by your practice administrator.
+                    Please contact them for any billing questions.
+                </Paragraph>
+            </Box>
+        </ProviderNavigationPage>
+    );
+};

--- a/src/lib/shared/components/features/pages/providers/billing-page-view/ui/index.ts
+++ b/src/lib/shared/components/features/pages/providers/billing-page-view/ui/index.ts
@@ -1,0 +1,3 @@
+export * from './PracticeAdminBillingView';
+export * from './ProviderBillingView';
+export * from './testIds';

--- a/src/lib/shared/components/features/pages/providers/billing-page-view/ui/testIds.ts
+++ b/src/lib/shared/components/features/pages/providers/billing-page-view/ui/testIds.ts
@@ -1,0 +1,4 @@
+export const TEST_IDS = {
+    PROVIDER_BILLING_VIEW: 'provider-billing-view',
+    PRACTICE_ADMIN_BILLING_VIEW: 'practice-admin-billing-view',
+} as const;

--- a/src/lib/shared/components/ui/Alert/index.tsx
+++ b/src/lib/shared/components/ui/Alert/index.tsx
@@ -10,7 +10,7 @@ export const ALERT_TYPE = {
     INFO: 'info',
 } as const;
 
-export type AlertType = typeof ALERT_TYPE[keyof typeof ALERT_TYPE];
+export type AlertType = (typeof ALERT_TYPE)[keyof typeof ALERT_TYPE];
 
 interface AlertAction {
     displayText: string;
@@ -41,7 +41,13 @@ export const Alert = ({
             icon={icon}
             severity={alertType}
             onClose={onClose}
-            sx={{ fontSize: '1rem', ...sx }}
+            sx={{
+                fontSize: '1rem',
+                '& .MuiAlert-message': {
+                    ...(!message && { display: 'flex', alignItems: 'center' }),
+                },
+                ...sx,
+            }}
         >
             <>
                 <AlertTitle

--- a/src/lib/shared/hooks/index.ts
+++ b/src/lib/shared/hooks/index.ts
@@ -1,2 +1,3 @@
 export * from './use-therify-user';
 export * from './use-on-screen';
+export * from './use-plan-monitoring';

--- a/src/lib/shared/hooks/use-plan-monitoring/index.ts
+++ b/src/lib/shared/hooks/use-plan-monitoring/index.ts
@@ -1,0 +1,1 @@
+export * from './usePlanMonitoring';

--- a/src/lib/shared/hooks/use-plan-monitoring/usePlanMonitoring.spec.tsx
+++ b/src/lib/shared/hooks/use-plan-monitoring/usePlanMonitoring.spec.tsx
@@ -94,7 +94,7 @@ describe('usePlanMonitoring', () => {
             };
             render(<TestJSX />);
             expect(routerMock.push).toHaveBeenCalledWith(
-                URL_PATHS.MEMBERS.ACCOUNT.EXPIRED_PLAN
+                URL_PATHS.MEMBERS.ACCOUNT.INVALID_PLAN
             );
         });
         it('should route to billing when provider plan is expired', () => {
@@ -137,7 +137,7 @@ describe('usePlanMonitoring', () => {
                 );
                 return <div />;
             };
-            routerMock.pathname = URL_PATHS.MEMBERS.ACCOUNT.EXPIRED_PLAN;
+            routerMock.pathname = URL_PATHS.MEMBERS.ACCOUNT.INVALID_PLAN;
             render(<TestJSX />);
             expect(routerMock.push).not.toHaveBeenCalled();
         });
@@ -171,7 +171,7 @@ describe('usePlanMonitoring', () => {
             };
             render(<TestJSX />);
             expect(routerMock.push).toHaveBeenCalledWith(
-                URL_PATHS.MEMBERS.ACCOUNT.EXPIRED_PLAN
+                URL_PATHS.MEMBERS.ACCOUNT.INVALID_PLAN
             );
         });
         it('should route to billing when provider plan is not active', () => {
@@ -214,7 +214,7 @@ describe('usePlanMonitoring', () => {
                 );
                 return <div />;
             };
-            routerMock.pathname = URL_PATHS.MEMBERS.ACCOUNT.EXPIRED_PLAN;
+            routerMock.pathname = URL_PATHS.MEMBERS.ACCOUNT.INVALID_PLAN;
             render(<TestJSX />);
             expect(routerMock.push).not.toHaveBeenCalled();
         });

--- a/src/lib/shared/hooks/use-plan-monitoring/usePlanMonitoring.spec.tsx
+++ b/src/lib/shared/hooks/use-plan-monitoring/usePlanMonitoring.spec.tsx
@@ -1,0 +1,314 @@
+import { usePlanMonitoring } from './usePlanMonitoring';
+import { Mocks } from '../../types';
+import { render } from '@testing-library/react';
+import { URL_PATHS } from '@/lib/sitemap';
+const routerMock = { pathname: '/test', push: jest.fn() };
+jest.mock('next/router', () => {
+    return {
+        useRouter: () => routerMock,
+    };
+});
+
+describe('usePlanMonitoring', () => {
+    beforeEach(() => {
+        routerMock.push.mockReset();
+        routerMock.pathname = '/test';
+    });
+
+    describe('hasAccess', () => {
+        it('should return hasAccess as true if plan is active', () => {
+            let result = false;
+            const TestJSX = () => {
+                const { hasAccess } = usePlanMonitoring(Mocks.getTherifyUser());
+                result = hasAccess;
+                return <div />;
+            };
+            render(<TestJSX />);
+            expect(result).toBe(true);
+        });
+
+        it('should return hasAccess as false if plan is inactive', () => {
+            let result = true;
+            const TestJSX = () => {
+                const { hasAccess } = usePlanMonitoring(
+                    Mocks.getTherifyUser({
+                        plan: 'inactive',
+                    })
+                );
+                result = hasAccess;
+                return <div />;
+            };
+            render(<TestJSX />);
+            expect(result).toBe(false);
+        });
+
+        it('should return hasAccess as false if plan is expired', () => {
+            let result = true;
+            const TestJSX = () => {
+                const { hasAccess } = usePlanMonitoring(
+                    Mocks.getTherifyUser({
+                        plan: 'expired',
+                    })
+                );
+                result = hasAccess;
+                return <div />;
+            };
+            render(<TestJSX />);
+            expect(result).toBe(false);
+        });
+
+        it('should return hasAccess as false if plan hasnt started', () => {
+            let result = true;
+            const TestJSX = () => {
+                const { hasAccess } = usePlanMonitoring(
+                    Mocks.getTherifyUser({
+                        plan: 'future',
+                    })
+                );
+                result = hasAccess;
+                return <div />;
+            };
+            render(<TestJSX />);
+            expect(result).toBe(false);
+        });
+    });
+    it('should not re-direct if plan is active', () => {
+        const TestJSX = () => {
+            usePlanMonitoring(Mocks.getTherifyUser());
+            return <div />;
+        };
+        render(<TestJSX />);
+        expect(routerMock.push).not.toHaveBeenCalled();
+    });
+
+    describe('plan is expired', () => {
+        it('should route to inactive plan page when plan is expired', () => {
+            const TestJSX = () => {
+                usePlanMonitoring(
+                    Mocks.getTherifyUser({
+                        type: 'member',
+                        plan: 'expired',
+                    })
+                );
+                return <div />;
+            };
+            render(<TestJSX />);
+            expect(routerMock.push).toHaveBeenCalledWith(
+                URL_PATHS.MEMBERS.ACCOUNT.EXPIRED_PLAN
+            );
+        });
+        it('should route to billing when provider plan is expired', () => {
+            const TestJSX = () => {
+                usePlanMonitoring(
+                    Mocks.getTherifyUser({
+                        type: 'therapist',
+                        plan: 'expired',
+                    })
+                );
+                return <div />;
+            };
+            render(<TestJSX />);
+            expect(routerMock.push).toHaveBeenCalledWith(
+                URL_PATHS.PROVIDERS.ACCOUNT.BILLING_AND_SUBSCRIPTION
+            );
+        });
+        it('should route to billing when practice owner plan is expired', () => {
+            const TestJSX = () => {
+                usePlanMonitoring(
+                    Mocks.getTherifyUser({
+                        type: 'practice-owner',
+                        plan: 'expired',
+                    })
+                );
+                return <div />;
+            };
+            render(<TestJSX />);
+            expect(routerMock.push).toHaveBeenCalledWith(
+                URL_PATHS.PROVIDERS.ACCOUNT.BILLING_AND_SUBSCRIPTION
+            );
+        });
+        it('should not route to inactive plan page when already on member page with expired plan', () => {
+            const TestJSX = () => {
+                usePlanMonitoring(
+                    Mocks.getTherifyUser({
+                        type: 'member',
+                        plan: 'expired',
+                    })
+                );
+                return <div />;
+            };
+            routerMock.pathname = URL_PATHS.MEMBERS.ACCOUNT.EXPIRED_PLAN;
+            render(<TestJSX />);
+            expect(routerMock.push).not.toHaveBeenCalled();
+        });
+        it('should not route to billing when already on billing page with expired plan', () => {
+            const TestJSX = () => {
+                usePlanMonitoring(
+                    Mocks.getTherifyUser({
+                        type: 'therapist',
+                        plan: 'expired',
+                    })
+                );
+                return <div />;
+            };
+            routerMock.pathname =
+                URL_PATHS.PROVIDERS.ACCOUNT.BILLING_AND_SUBSCRIPTION;
+            render(<TestJSX />);
+            expect(routerMock.push).not.toHaveBeenCalled();
+        });
+    });
+
+    describe('plan is not active', () => {
+        it('should route to inactive plan page when plan is not active', () => {
+            const TestJSX = () => {
+                usePlanMonitoring(
+                    Mocks.getTherifyUser({
+                        type: 'member',
+                        plan: 'inactive',
+                    })
+                );
+                return <div />;
+            };
+            render(<TestJSX />);
+            expect(routerMock.push).toHaveBeenCalledWith(
+                URL_PATHS.MEMBERS.ACCOUNT.EXPIRED_PLAN
+            );
+        });
+        it('should route to billing when provider plan is not active', () => {
+            const TestJSX = () => {
+                usePlanMonitoring(
+                    Mocks.getTherifyUser({
+                        type: 'therapist',
+                        plan: 'inactive',
+                    })
+                );
+                return <div />;
+            };
+            render(<TestJSX />);
+            expect(routerMock.push).toHaveBeenCalledWith(
+                URL_PATHS.PROVIDERS.ACCOUNT.BILLING_AND_SUBSCRIPTION
+            );
+        });
+        it('should route to billing when practice owner plan is not active', () => {
+            const TestJSX = () => {
+                usePlanMonitoring(
+                    Mocks.getTherifyUser({
+                        type: 'practice-owner',
+                        plan: 'inactive',
+                    })
+                );
+                return <div />;
+            };
+            render(<TestJSX />);
+            expect(routerMock.push).toHaveBeenCalledWith(
+                URL_PATHS.PROVIDERS.ACCOUNT.BILLING_AND_SUBSCRIPTION
+            );
+        });
+        it('should not route to inactive plan page when already on member page with non-active plan', () => {
+            const TestJSX = () => {
+                usePlanMonitoring(
+                    Mocks.getTherifyUser({
+                        type: 'member',
+                        plan: 'inactive',
+                    })
+                );
+                return <div />;
+            };
+            routerMock.pathname = URL_PATHS.MEMBERS.ACCOUNT.EXPIRED_PLAN;
+            render(<TestJSX />);
+            expect(routerMock.push).not.toHaveBeenCalled();
+        });
+        it('should not route to billing when already on billing page with non-active plan', () => {
+            const TestJSX = () => {
+                usePlanMonitoring(
+                    Mocks.getTherifyUser({
+                        type: 'therapist',
+                        plan: 'inactive',
+                    })
+                );
+                return <div />;
+            };
+            routerMock.pathname =
+                URL_PATHS.PROVIDERS.ACCOUNT.BILLING_AND_SUBSCRIPTION;
+            render(<TestJSX />);
+            expect(routerMock.push).not.toHaveBeenCalled();
+        });
+    });
+
+    describe('plan access has not started', () => {
+        it('should route member to countdown page when plan has not started', () => {
+            const TestJSX = () => {
+                usePlanMonitoring(
+                    Mocks.getTherifyUser({
+                        type: 'member',
+                        plan: 'future',
+                    })
+                );
+                return <div />;
+            };
+            render(<TestJSX />);
+            expect(routerMock.push).toHaveBeenCalledWith(
+                URL_PATHS.ACCESS_COUNTDOWN
+            );
+        });
+        it('should route coach to countdown page when plan has not started', () => {
+            const TestJSX = () => {
+                usePlanMonitoring(
+                    Mocks.getTherifyUser({
+                        type: 'coach',
+                        plan: 'future',
+                    })
+                );
+                return <div />;
+            };
+            render(<TestJSX />);
+            expect(routerMock.push).toHaveBeenCalledWith(
+                URL_PATHS.ACCESS_COUNTDOWN
+            );
+        });
+        it('should route therapist to countdown page when plan has not started', () => {
+            const TestJSX = () => {
+                usePlanMonitoring(
+                    Mocks.getTherifyUser({
+                        type: 'therapist',
+                        plan: 'future',
+                    })
+                );
+                return <div />;
+            };
+            render(<TestJSX />);
+            expect(routerMock.push).toHaveBeenCalledWith(
+                URL_PATHS.ACCESS_COUNTDOWN
+            );
+        });
+        it('should route practice owner to countdown page when plan has not started', () => {
+            const TestJSX = () => {
+                usePlanMonitoring(
+                    Mocks.getTherifyUser({
+                        type: 'practice-owner',
+                        plan: 'future',
+                    })
+                );
+                return <div />;
+            };
+            render(<TestJSX />);
+            expect(routerMock.push).toHaveBeenCalledWith(
+                URL_PATHS.ACCESS_COUNTDOWN
+            );
+        });
+        it('should not route to countdown when already on countdown page', () => {
+            const TestJSX = () => {
+                usePlanMonitoring(
+                    Mocks.getTherifyUser({
+                        type: 'therapist',
+                        plan: 'future',
+                    })
+                );
+                return <div />;
+            };
+            routerMock.pathname = URL_PATHS.ACCESS_COUNTDOWN;
+            render(<TestJSX />);
+            expect(routerMock.push).not.toHaveBeenCalled();
+        });
+    });
+});

--- a/src/lib/shared/hooks/use-plan-monitoring/usePlanMonitoring.ts
+++ b/src/lib/shared/hooks/use-plan-monitoring/usePlanMonitoring.ts
@@ -7,7 +7,7 @@ import { useEffect } from 'react';
 
 const EXPIRED_PLAN_ROUTES = [
     URL_PATHS.PROVIDERS.ACCOUNT.BILLING_AND_SUBSCRIPTION,
-    URL_PATHS.MEMBERS.ACCOUNT.PLAN_EXPIRED,
+    URL_PATHS.MEMBERS.ACCOUNT.EXPIRED_PLAN,
 ];
 
 export const usePlanMonitoring = (
@@ -29,7 +29,7 @@ export const usePlanMonitoring = (
             router.push(URL_PATHS.LAUNCH_COUNTDOWN);
         } else if (isPlanExpired) {
             const expiredPath = user.roles.includes(Role.member)
-                ? URL_PATHS.MEMBERS.ACCOUNT.PLAN_EXPIRED
+                ? URL_PATHS.MEMBERS.ACCOUNT.EXPIRED_PLAN
                 : URL_PATHS.PROVIDERS.ACCOUNT.BILLING_AND_SUBSCRIPTION;
             router.push(expiredPath);
         }

--- a/src/lib/shared/hooks/use-plan-monitoring/usePlanMonitoring.ts
+++ b/src/lib/shared/hooks/use-plan-monitoring/usePlanMonitoring.ts
@@ -14,14 +14,13 @@ export const usePlanMonitoring = (
     user: TherifyUser.TherifyUser | null | undefined
 ) => {
     const router = useRouter();
-    console.log({ user });
     const isPlanExpired =
         !!user?.plan?.endDate &&
         isAfter(new Date(), new Date(user.plan.endDate));
     const hasPlanStarted =
         !!user?.plan?.startDate &&
         isAfter(new Date(), new Date(user.plan.startDate));
-    console.log({ isPlanExpired, hasPlanStarted });
+
     useEffect(() => {
         if (EXPIRED_PLAN_ROUTES.includes(router.pathname) || !user?.roles)
             return;

--- a/src/lib/shared/hooks/use-plan-monitoring/usePlanMonitoring.ts
+++ b/src/lib/shared/hooks/use-plan-monitoring/usePlanMonitoring.ts
@@ -1,6 +1,6 @@
 import { TherifyUser } from '@/lib/shared/types';
 import { URL_PATHS } from '@/lib/sitemap';
-import { Role } from '@prisma/client';
+import { PlanStatus, Role } from '@prisma/client';
 import { isAfter } from 'date-fns';
 import { useRouter } from 'next/router';
 import { useEffect } from 'react';
@@ -21,6 +21,10 @@ export const usePlanMonitoring = (
     const hasPlanStarted =
         !!user?.plan?.startDate &&
         isAfter(new Date(), new Date(user.plan.startDate));
+    const isPlanActive =
+        user &&
+        (user?.plan?.status === PlanStatus.active ||
+            user?.plan?.status === PlanStatus.trialing);
 
     useEffect(() => {
         if (IGNORED_PLAN_ROUTES.includes(router.pathname) || !user?.roles)
@@ -28,11 +32,14 @@ export const usePlanMonitoring = (
 
         if (!hasPlanStarted) {
             router.push(URL_PATHS.ACCESS_COUNTDOWN);
-        } else if (isPlanExpired) {
+        } else if (isPlanExpired || !isPlanActive) {
             const expiredPath = user.roles.includes(Role.member)
                 ? URL_PATHS.MEMBERS.ACCOUNT.EXPIRED_PLAN
                 : URL_PATHS.PROVIDERS.ACCOUNT.BILLING_AND_SUBSCRIPTION;
             router.push(expiredPath);
         }
-    }, [hasPlanStarted, isPlanExpired, router, user?.roles]);
+    }, [hasPlanStarted, isPlanExpired, isPlanActive, router, user?.roles]);
+    return {
+        hasAccess: hasPlanStarted && isPlanActive && !isPlanExpired,
+    };
 };

--- a/src/lib/shared/hooks/use-plan-monitoring/usePlanMonitoring.ts
+++ b/src/lib/shared/hooks/use-plan-monitoring/usePlanMonitoring.ts
@@ -5,9 +5,9 @@ import { isAfter } from 'date-fns';
 import { useRouter } from 'next/router';
 import { useEffect } from 'react';
 
-const EXPIRED_PLAN_ROUTES = [
+const INVALID_PLAN_ROUTES = [
     URL_PATHS.PROVIDERS.ACCOUNT.BILLING_AND_SUBSCRIPTION,
-    URL_PATHS.MEMBERS.ACCOUNT.EXPIRED_PLAN,
+    URL_PATHS.MEMBERS.ACCOUNT.INVALID_PLAN,
 ];
 
 export const usePlanMonitoring = (
@@ -32,15 +32,15 @@ export const usePlanMonitoring = (
             router.push(URL_PATHS.ACCESS_COUNTDOWN);
         } else if (
             (isPlanExpired || !isPlanActive) &&
-            !EXPIRED_PLAN_ROUTES.includes(router.pathname)
+            !INVALID_PLAN_ROUTES.includes(router.pathname)
         ) {
-            const expiredPath = user.roles.includes(Role.member)
-                ? URL_PATHS.MEMBERS.ACCOUNT.EXPIRED_PLAN
+            const invalidPath = user.roles.includes(Role.member)
+                ? URL_PATHS.MEMBERS.ACCOUNT.INVALID_PLAN
                 : URL_PATHS.PROVIDERS.ACCOUNT.BILLING_AND_SUBSCRIPTION;
-            router.push(expiredPath);
+            router.push(invalidPath);
         }
     }, [hasPlanStarted, isPlanExpired, isPlanActive, router, user?.roles]);
     return {
-        hasAccess: hasPlanStarted && isPlanActive && !isPlanExpired,
+        hasAccess: Boolean(hasPlanStarted && isPlanActive && !isPlanExpired),
     };
 };

--- a/src/lib/shared/hooks/use-plan-monitoring/usePlanMonitoring.ts
+++ b/src/lib/shared/hooks/use-plan-monitoring/usePlanMonitoring.ts
@@ -5,9 +5,10 @@ import { isAfter } from 'date-fns';
 import { useRouter } from 'next/router';
 import { useEffect } from 'react';
 
-const EXPIRED_PLAN_ROUTES = [
+const IGNORED_PLAN_ROUTES = [
     URL_PATHS.PROVIDERS.ACCOUNT.BILLING_AND_SUBSCRIPTION,
     URL_PATHS.MEMBERS.ACCOUNT.EXPIRED_PLAN,
+    URL_PATHS.ACCESS_COUNTDOWN,
 ];
 
 export const usePlanMonitoring = (
@@ -22,11 +23,11 @@ export const usePlanMonitoring = (
         isAfter(new Date(), new Date(user.plan.startDate));
 
     useEffect(() => {
-        if (EXPIRED_PLAN_ROUTES.includes(router.pathname) || !user?.roles)
+        if (IGNORED_PLAN_ROUTES.includes(router.pathname) || !user?.roles)
             return;
 
         if (!hasPlanStarted) {
-            router.push(URL_PATHS.LAUNCH_COUNTDOWN);
+            router.push(URL_PATHS.ACCESS_COUNTDOWN);
         } else if (isPlanExpired) {
             const expiredPath = user.roles.includes(Role.member)
                 ? URL_PATHS.MEMBERS.ACCOUNT.EXPIRED_PLAN

--- a/src/lib/shared/hooks/use-plan-monitoring/usePlanMonitoring.ts
+++ b/src/lib/shared/hooks/use-plan-monitoring/usePlanMonitoring.ts
@@ -5,10 +5,9 @@ import { isAfter } from 'date-fns';
 import { useRouter } from 'next/router';
 import { useEffect } from 'react';
 
-const IGNORED_PLAN_ROUTES = [
+const EXPIRED_PLAN_ROUTES = [
     URL_PATHS.PROVIDERS.ACCOUNT.BILLING_AND_SUBSCRIPTION,
     URL_PATHS.MEMBERS.ACCOUNT.EXPIRED_PLAN,
-    URL_PATHS.ACCESS_COUNTDOWN,
 ];
 
 export const usePlanMonitoring = (
@@ -27,12 +26,14 @@ export const usePlanMonitoring = (
             user?.plan?.status === PlanStatus.trialing);
 
     useEffect(() => {
-        if (IGNORED_PLAN_ROUTES.includes(router.pathname) || !user?.roles)
-            return;
+        if (!user?.roles) return;
 
-        if (!hasPlanStarted) {
+        if (!hasPlanStarted && router.pathname !== URL_PATHS.ACCESS_COUNTDOWN) {
             router.push(URL_PATHS.ACCESS_COUNTDOWN);
-        } else if (isPlanExpired || !isPlanActive) {
+        } else if (
+            (isPlanExpired || !isPlanActive) &&
+            !EXPIRED_PLAN_ROUTES.includes(router.pathname)
+        ) {
             const expiredPath = user.roles.includes(Role.member)
                 ? URL_PATHS.MEMBERS.ACCOUNT.EXPIRED_PLAN
                 : URL_PATHS.PROVIDERS.ACCOUNT.BILLING_AND_SUBSCRIPTION;

--- a/src/lib/shared/hooks/use-plan-monitoring/usePlanMonitoring.ts
+++ b/src/lib/shared/hooks/use-plan-monitoring/usePlanMonitoring.ts
@@ -1,0 +1,38 @@
+import { TherifyUser } from '@/lib/shared/types';
+import { URL_PATHS } from '@/lib/sitemap';
+import { Role } from '@prisma/client';
+import { isAfter } from 'date-fns';
+import { useRouter } from 'next/router';
+import { useEffect } from 'react';
+
+const EXPIRED_PLAN_ROUTES = [
+    URL_PATHS.PROVIDERS.ACCOUNT.BILLING_AND_SUBSCRIPTION,
+    URL_PATHS.MEMBERS.ACCOUNT.PLAN_EXPIRED,
+];
+
+export const usePlanMonitoring = (
+    user: TherifyUser.TherifyUser | null | undefined
+) => {
+    const router = useRouter();
+    console.log({ user });
+    const isPlanExpired =
+        !!user?.plan?.endDate &&
+        isAfter(new Date(), new Date(user.plan.endDate));
+    const hasPlanStarted =
+        !!user?.plan?.startDate &&
+        isAfter(new Date(), new Date(user.plan.startDate));
+    console.log({ isPlanExpired, hasPlanStarted });
+    useEffect(() => {
+        if (EXPIRED_PLAN_ROUTES.includes(router.pathname) || !user?.roles)
+            return;
+
+        if (!hasPlanStarted) {
+            router.push(URL_PATHS.LAUNCH_COUNTDOWN);
+        } else if (isPlanExpired) {
+            const expiredPath = user.roles.includes(Role.member)
+                ? URL_PATHS.MEMBERS.ACCOUNT.PLAN_EXPIRED
+                : URL_PATHS.PROVIDERS.ACCOUNT.BILLING_AND_SUBSCRIPTION;
+            router.push(expiredPath);
+        }
+    }, [hasPlanStarted, isPlanExpired, router, user?.roles]);
+};

--- a/src/lib/shared/types/__mocks__/index.ts
+++ b/src/lib/shared/types/__mocks__/index.ts
@@ -1,0 +1,1 @@
+export * from './therifyUser';

--- a/src/lib/shared/types/__mocks__/therifyUser.tsx
+++ b/src/lib/shared/types/__mocks__/therifyUser.tsx
@@ -1,4 +1,4 @@
-import { Role } from '@prisma/client';
+import { PlanStatus, Role } from '@prisma/client';
 import { TherifyUser } from '../therify-user';
 import { faker } from '@faker-js/faker';
 import { add, sub } from 'date-fns';
@@ -32,21 +32,28 @@ export const getTherifyUser = (options?: {
 });
 
 const mockExpiredPlan: Exclude<TherifyUser.TherifyUser['plan'], null> = {
-    status: 'active',
+    status: PlanStatus.active,
     startDate: sub(new Date(), { months: 2 }).toISOString(),
     endDate: sub(new Date(), { days: 1 }).toISOString(),
     renews: false,
     seats: 1,
 };
 const mockActivePlan: Exclude<TherifyUser.TherifyUser['plan'], null> = {
-    status: 'active',
+    status: PlanStatus.active,
+    startDate: sub(new Date(), { months: 1 }).toISOString(),
+    endDate: add(new Date(), { months: 1 }).toISOString(),
+    renews: false,
+    seats: 1,
+};
+const mockInctivePlan: Exclude<TherifyUser.TherifyUser['plan'], null> = {
+    status: PlanStatus.canceled,
     startDate: sub(new Date(), { months: 1 }).toISOString(),
     endDate: add(new Date(), { months: 1 }).toISOString(),
     renews: false,
     seats: 1,
 };
 const mockFuturePlan: Exclude<TherifyUser.TherifyUser['plan'], null> = {
-    status: 'active',
+    status: PlanStatus.active,
     startDate: add(new Date(), { months: 1 }).toISOString(),
     endDate: add(new Date(), { months: 2 }).toISOString(),
     renews: false,
@@ -58,6 +65,8 @@ function getPlan(plan?: MockPlanType): TherifyUser.TherifyUser['plan'] {
         case undefined:
         case 'active':
             return mockActivePlan;
+        case 'inactive':
+            return mockInctivePlan;
         case 'expired':
             return mockExpiredPlan;
         case 'future':

--- a/src/lib/shared/types/__mocks__/therifyUser.tsx
+++ b/src/lib/shared/types/__mocks__/therifyUser.tsx
@@ -1,0 +1,86 @@
+import { Role } from '@prisma/client';
+import { TherifyUser } from '../therify-user';
+import { faker } from '@faker-js/faker';
+import { add, sub } from 'date-fns';
+
+type MockPlanType = 'active' | 'inactive' | 'expired' | 'future' | null;
+type MockUserType = 'member' | 'therapist' | 'coach' | 'practice-owner';
+/**
+ * Generates a Therify user object with mock data. Defaults to a member with an active plan.
+ * @param options
+ * @returns TherifyUser
+ */
+export const getTherifyUser = (options?: {
+    type?: MockUserType;
+    isPracticeAdmin?: boolean;
+    hasChatEnabled?: boolean;
+    plan?: MockPlanType;
+}): TherifyUser.TherifyUser => ({
+    emailAddress: faker.internet.email(),
+    givenName: faker.name.firstName(),
+    surname: faker.name.lastName(),
+    createdAt: sub(new Date(), { months: 1 }).toISOString(),
+    chatAccessToken: 'mock-chat-token',
+    userId: 'auth0|' + faker.random.alphaNumeric(24),
+    avatarUrl: undefined,
+    firebaseToken: undefined,
+    memberChannels: [],
+    providerChannels: [],
+    plan: getPlan(options?.plan),
+    hasChatEnabled: false,
+    ...getUserType(options?.type),
+});
+
+const mockExpiredPlan: Exclude<TherifyUser.TherifyUser['plan'], null> = {
+    status: 'active',
+    startDate: sub(new Date(), { months: 2 }).toISOString(),
+    endDate: sub(new Date(), { days: 1 }).toISOString(),
+    renews: false,
+    seats: 1,
+};
+const mockActivePlan: Exclude<TherifyUser.TherifyUser['plan'], null> = {
+    status: 'active',
+    startDate: sub(new Date(), { months: 1 }).toISOString(),
+    endDate: add(new Date(), { months: 1 }).toISOString(),
+    renews: false,
+    seats: 1,
+};
+const mockFuturePlan: Exclude<TherifyUser.TherifyUser['plan'], null> = {
+    status: 'active',
+    startDate: add(new Date(), { months: 1 }).toISOString(),
+    endDate: add(new Date(), { months: 2 }).toISOString(),
+    renews: false,
+    seats: 1,
+};
+
+function getPlan(plan?: MockPlanType): TherifyUser.TherifyUser['plan'] {
+    switch (plan) {
+        case undefined:
+        case 'active':
+            return mockActivePlan;
+        case 'expired':
+            return mockExpiredPlan;
+        case 'future':
+            return mockFuturePlan;
+        default:
+            return null;
+    }
+}
+
+function getUserType(type?: MockUserType) {
+    switch (type) {
+        case 'therapist':
+            return { roles: [Role.provider_therapist], isPracticeAdmin: false };
+        case 'coach':
+            return { roles: [Role.provider_coach], isPracticeAdmin: false };
+        case 'practice-owner':
+            return { roles: [Role.provider_therapist], isPracticeAdmin: true };
+        case 'member':
+        default:
+            return {
+                roles: [Role.member],
+                isPracticeAdmin: false,
+                accountId: faker.datatype.uuid(),
+            };
+    }
+}

--- a/src/lib/shared/types/index.ts
+++ b/src/lib/shared/types/index.ts
@@ -25,3 +25,5 @@ export * from './provider-supervisor';
 export * from './accepted-insurance';
 export * from './provider-availability';
 export * from './connection-request';
+
+export * as Mocks from './__mocks__';

--- a/src/lib/shared/utils/test-utils/firebaseMock.ts
+++ b/src/lib/shared/utils/test-utils/firebaseMock.ts
@@ -1,0 +1,17 @@
+export const firebase = () => {
+    const app = {
+        initializeApp: (options: unknown, name?: string) => {},
+    };
+    const auth = {
+        getAuth: (app: unknown) => {},
+        onAuthStateChanged: (callback: unknown) => {},
+    };
+    const database = {
+        getDatabase: (app: unknown) => {},
+    };
+    return {
+        auth,
+        database,
+        app,
+    };
+};

--- a/src/lib/sitemap/menus/practice-admin-menu/menu.tsx
+++ b/src/lib/sitemap/menus/practice-admin-menu/menu.tsx
@@ -19,5 +19,5 @@ export const PRACTICE_ADMIN_SECONDARY_MENU = [
 
 export const PRACTICE_ADMIN_MOBILE_MENU = [
     ...PRACTICE_ADMIN_MAIN_MENU,
-    // ACCOUNT,
+    { ...ACCOUNT, path: BILLING_AND_SUBSCRIPTION.path },
 ] as const;

--- a/src/lib/sitemap/urlPaths.ts
+++ b/src/lib/sitemap/urlPaths.ts
@@ -14,4 +14,5 @@ export const URL_PATHS = {
     EXTERNAL: EXTERNAL_URLS,
     404: '/404',
     ROOT: '/',
+    LAUNCH_COUNTDOWN: '/launch-countdown',
 } as const;

--- a/src/lib/sitemap/urlPaths.ts
+++ b/src/lib/sitemap/urlPaths.ts
@@ -14,5 +14,5 @@ export const URL_PATHS = {
     EXTERNAL: EXTERNAL_URLS,
     404: '/404',
     ROOT: '/',
-    LAUNCH_COUNTDOWN: '/launch-countdown',
+    ACCESS_COUNTDOWN: '/access-countdown',
 } as const;

--- a/src/lib/sitemap/urls/members/index.ts
+++ b/src/lib/sitemap/urls/members/index.ts
@@ -9,6 +9,6 @@ export const MEMBER_PATHS = {
     CHAT: '/members/chat',
     CONTENT: CONTENT_PATHS,
     ACCOUNT: {
-        EXPIRED_PLAN: '/members/account/expired-plan',
+        INVALID_PLAN: '/members/account/invalid-plan',
     },
 } as const;

--- a/src/lib/sitemap/urls/members/index.ts
+++ b/src/lib/sitemap/urls/members/index.ts
@@ -8,4 +8,7 @@ export const MEMBER_PATHS = {
     DIRECTORY: '/members/directory',
     CHAT: '/members/chat',
     CONTENT: CONTENT_PATHS,
+    ACCOUNT: {
+        PLAN_EXPIRED: '/members/account/expired',
+    },
 } as const;

--- a/src/lib/sitemap/urls/members/index.ts
+++ b/src/lib/sitemap/urls/members/index.ts
@@ -9,6 +9,6 @@ export const MEMBER_PATHS = {
     CHAT: '/members/chat',
     CONTENT: CONTENT_PATHS,
     ACCOUNT: {
-        PLAN_EXPIRED: '/members/account/expired',
+        EXPIRED_PLAN: '/members/account/expired-plan',
     },
 } as const;

--- a/src/lib/sitemap/urls/providers/account/index.ts
+++ b/src/lib/sitemap/urls/providers/account/index.ts
@@ -1,4 +1,4 @@
-export const ACCOUNT_LINKS = {
+export const ACCOUNT_PATHS = {
     BILLING_AND_SUBSCRIPTION: '/providers/account/billing',
     ACCOUNT_EDITOR: '/providers/account/me',
 };

--- a/src/lib/sitemap/urls/providers/index.ts
+++ b/src/lib/sitemap/urls/providers/index.ts
@@ -1,4 +1,4 @@
-import { ACCOUNT_LINKS } from './account';
+import { ACCOUNT_PATHS } from './account';
 import { COACH_PATHS } from './coaches';
 import { ONBOARDING_PATHS } from './onboarding';
 import { PRACTICE_PATHS } from './practice';
@@ -8,6 +8,6 @@ export const PROVIDERS_PATHS = {
     COACH: COACH_PATHS,
     THERAPIST: THERAPIST_PATHS,
     ONBOARDING: ONBOARDING_PATHS,
-    ACCOUNT: ACCOUNT_LINKS,
+    ACCOUNT: ACCOUNT_PATHS,
     PRACTICE: PRACTICE_PATHS,
 } as const;

--- a/src/pages/access-countdown.tsx
+++ b/src/pages/access-countdown.tsx
@@ -1,0 +1,180 @@
+import { useEffect, useRef, useState } from 'react';
+import { motion } from 'framer-motion';
+import { Box } from '@mui/material';
+import { styled } from '@mui/material/styles';
+import { format } from 'date-fns';
+import { useTheme } from '@mui/material/styles';
+import { useRouter } from 'next/router';
+import {
+    Paragraph,
+    H1,
+    Caption,
+    CenteredContainer,
+    AbstractShape1,
+    TherifyIcon,
+} from '@/lib/shared/components/ui';
+import { withPageAuthRequired } from '@auth0/nextjs-auth0';
+import { membersService } from '@/lib/modules/members/service';
+import { RBAC } from '@/lib/shared/utils';
+import { MemberTherifyUserPageProps } from '@/lib/modules/members/service/get-therify-user-props';
+import { MemberNavigationPage } from '@/lib/shared/components/features/pages';
+import { URL_PATHS } from '@/lib/sitemap';
+
+export const getServerSideProps = RBAC.requireMemberAuth(
+    withPageAuthRequired({
+        getServerSideProps: membersService.getTherifyUserPageProps,
+    })
+);
+export default function AccessCountdownPage({
+    user,
+}: MemberTherifyUserPageProps) {
+    const theme = useTheme();
+    const router = useRouter();
+    const [countdown, setCountdown] = useState('');
+    const countdownRef = useRef<number>();
+    const isCountDownComplete = countdown === '00:00:00';
+
+    useEffect(() => {
+        if (user?.plan?.startDate) {
+            const getTimeRemaining = () => {
+                if (!user?.plan?.startDate) return;
+                const startDate = new Date(user.plan.startDate);
+                const now = new Date();
+                const diff = startDate.getTime() - now.getTime();
+                return {
+                    days: Math.floor(diff / (1000 * 60 * 60 * 24)),
+                    hours: Math.floor((diff / (1000 * 60 * 60)) % 24),
+                    minutes: Math.floor((diff / 1000 / 60) % 60),
+                    seconds: Math.floor((diff / 1000) % 60),
+                };
+            };
+            countdownRef.current = window.setInterval(() => {
+                const { days, hours, minutes, seconds } =
+                    getTimeRemaining() ?? {};
+
+                setCountdown(
+                    [
+                        ...(days === undefined || days > 0
+                            ? [withLeadingZero(days)]
+                            : []),
+                        withLeadingZero(hours),
+                        withLeadingZero(minutes),
+                        withLeadingZero(seconds),
+                    ].join(':')
+                );
+                if (
+                    [days, hours, minutes, seconds].every(
+                        (time) => time !== undefined && time <= 0
+                    )
+                ) {
+                    window.clearInterval(countdownRef.current);
+                    router.push(URL_PATHS.ROOT);
+                }
+            }, 1000);
+        }
+        return () => {
+            if (countdownRef.current) {
+                window.clearInterval(countdownRef.current);
+            }
+        };
+    }, [router, user?.plan?.startDate]);
+
+    return (
+        <MemberNavigationPage
+            currentPath={URL_PATHS.MEMBERS.ACCOUNT.EXPIRED_PLAN}
+            user={user}
+        >
+            <CenteredContainer
+                fillSpace
+                style={{ background: theme.palette.background.default }}
+            >
+                <Container>
+                    <CenteredContainer zIndex={2}>
+                        <motion.div
+                            animate={
+                                isCountDownComplete
+                                    ? {
+                                          rotate: [0, 360, 360],
+                                          scale: [1, 1.3, 1],
+                                      }
+                                    : undefined
+                            }
+                            transition={{
+                                duration: 1,
+                                ease: 'easeInOut',
+                                repeat: Infinity,
+                                repeatDelay: 0.5,
+                            }}
+                            style={{ marginBottom: theme.spacing(4) }}
+                        >
+                            <TherifyIcon width="50px" />
+                        </motion.div>
+                        {isCountDownComplete && (
+                            <Title>Welcome to Therify</Title>
+                        )}
+                        {!isCountDownComplete && (
+                            <Title>Your access to Therify starts soon!</Title>
+                        )}
+                        {user?.plan?.startDate && (
+                            <>
+                                <Paragraph>
+                                    Your plan with Therify starts on{' '}
+                                    {format(
+                                        new Date(user.plan.startDate),
+                                        'MMMM do, yyyy'
+                                    )}{' '}
+                                    at{' '}
+                                    {format(
+                                        new Date(user.plan.startDate),
+                                        'h:mm a'
+                                    )}
+                                    .
+                                </Paragraph>
+                                <CountDown>{countdown}</CountDown>
+                            </>
+                        )}
+                        <Caption secondary>
+                            Please contact your account administrator within
+                            your organization for further information about
+                            accessing our services.
+                        </Caption>
+                    </CenteredContainer>
+                    <Shape />
+                </Container>
+            </CenteredContainer>
+        </MemberNavigationPage>
+    );
+}
+const Title = styled(H1)(({ theme }) => ({
+    ...theme.typography.h2,
+}));
+
+const Container = styled(Box)(({ theme }) => ({
+    background: theme.palette.background.paper,
+    borderRadius: theme.shape.borderRadius,
+    padding: theme.spacing(10),
+    maxWidth: '800px',
+    textAlign: 'center',
+    position: 'relative',
+    overflow: 'hidden',
+}));
+
+const Shape = styled(AbstractShape1)(({ theme }) => ({
+    position: 'absolute',
+    width: '250px',
+    top: -100,
+    right: -100,
+    transform: 'rotate(-90deg)',
+    zIndex: 1,
+}));
+
+const CountDown = styled(Paragraph)(({ theme }) => ({
+    fontSize: theme.typography.h1.fontSize,
+    fontWeight: 'bold',
+    margin: theme.spacing(6, 0),
+}));
+
+const withLeadingZero = (num?: number) => {
+    if (num === undefined || num < 0) return '00';
+    return num.toString().padStart(2, '0');
+};

--- a/src/pages/access-countdown.tsx
+++ b/src/pages/access-countdown.tsx
@@ -48,9 +48,11 @@ export const getServerSideProps: GetServerSideProps = async (context) => {
     }
 
     return {
-        props: {
-            user,
-        },
+        props: JSON.parse(
+            JSON.stringify({
+                user,
+            })
+        ),
     };
 };
 export default function AccessCountdownPage({

--- a/src/pages/members/account/expired-plan.tsx
+++ b/src/pages/members/account/expired-plan.tsx
@@ -17,6 +17,7 @@ import { RBAC } from '@/lib/shared/utils';
 import { MemberTherifyUserPageProps } from '@/lib/modules/members/service/get-therify-user-props';
 import { MemberNavigationPage } from '@/lib/shared/components/features/pages';
 import { URL_PATHS } from '@/lib/sitemap';
+import { PlanStatus } from '@prisma/client';
 
 export const getServerSideProps = RBAC.requireMemberAuth(
     withPageAuthRequired({
@@ -29,7 +30,12 @@ export default function ExpiredPlanPage({ user }: MemberTherifyUserPageProps) {
     const isPlanExpired =
         !!user?.plan?.endDate &&
         isAfter(new Date(), new Date(user.plan.endDate));
-    if (!isPlanExpired)
+    const isPlanActive =
+        !!user &&
+        (user.plan?.status === PlanStatus.active ||
+            user.plan?.status === PlanStatus.trialing);
+
+    if (!isPlanExpired && isPlanActive)
         return (
             <CenteredContainer
                 fillSpace
@@ -47,6 +53,7 @@ export default function ExpiredPlanPage({ user }: MemberTherifyUserPageProps) {
                 </Button>
             </CenteredContainer>
         );
+
     return (
         <MemberNavigationPage
             currentPath={URL_PATHS.MEMBERS.ACCOUNT.EXPIRED_PLAN}
@@ -60,12 +67,14 @@ export default function ExpiredPlanPage({ user }: MemberTherifyUserPageProps) {
                     <H3>
                         Unfortunately, you no longer have access to Therify.
                     </H3>
-                    <Paragraph>
-                        Your sponsoring organization’s contract with Therify has
-                        expired. Please contact the account administrator within
-                        your organization for further information on future
-                        access to our services.
-                    </Paragraph>
+                    {isPlanExpired && (
+                        <Paragraph>
+                            Your sponsoring organization’s contract with Therify
+                            has expired. Please contact the account
+                            administrator within your organization for further
+                            information on future access to our services.
+                        </Paragraph>
+                    )}
                     {isPlanExpired && user.plan?.endDate && (
                         <Alert
                             icon={
@@ -77,6 +86,24 @@ export default function ExpiredPlanPage({ user }: MemberTherifyUserPageProps) {
                                 new Date(user.plan.endDate),
                                 'MMMM do, yyyy'
                             )}.`}
+                            type="error"
+                        />
+                    )}
+                    {!isPlanExpired && !isPlanActive && (
+                        <Paragraph>
+                            Please contact the account administrator within your
+                            organization for further information about access to
+                            our services.
+                        </Paragraph>
+                    )}
+                    {!isPlanExpired && !isPlanActive && (
+                        <Alert
+                            icon={
+                                <CenteredContainer marginRight={2}>
+                                    <WarningRounded />
+                                </CenteredContainer>
+                            }
+                            title={`Your plan status is not active.`}
                             type="error"
                         />
                     )}

--- a/src/pages/members/account/expired-plan.tsx
+++ b/src/pages/members/account/expired-plan.tsx
@@ -1,0 +1,95 @@
+import { Box } from '@mui/material';
+import { styled } from '@mui/material/styles';
+import { isAfter, format } from 'date-fns';
+import { useTheme } from '@mui/material/styles';
+import { WarningRounded } from '@mui/icons-material';
+import { useRouter } from 'next/router';
+import {
+    Paragraph,
+    H3,
+    Alert,
+    CenteredContainer,
+    Button,
+} from '@/lib/shared/components/ui';
+import { withPageAuthRequired } from '@auth0/nextjs-auth0';
+import { membersService } from '@/lib/modules/members/service';
+import { RBAC } from '@/lib/shared/utils';
+import { MemberTherifyUserPageProps } from '@/lib/modules/members/service/get-therify-user-props';
+import { MemberNavigationPage } from '@/lib/shared/components/features/pages';
+import { URL_PATHS } from '@/lib/sitemap';
+
+export const getServerSideProps = RBAC.requireMemberAuth(
+    withPageAuthRequired({
+        getServerSideProps: membersService.getTherifyUserPageProps,
+    })
+);
+export default function ExpiredPlanPage({ user }: MemberTherifyUserPageProps) {
+    const theme = useTheme();
+    const router = useRouter();
+    const isPlanExpired =
+        !!user?.plan?.endDate &&
+        isAfter(new Date(), new Date(user.plan.endDate));
+    if (!isPlanExpired)
+        return (
+            <CenteredContainer
+                fillSpace
+                style={{ background: theme.palette.background.default }}
+            >
+                <H3>Plan is still active</H3>
+                {user?.plan?.endDate && (
+                    <Paragraph>
+                        Your current plan access ends on{' '}
+                        {format(new Date(user.plan.endDate), 'MMMM do, yyyy')}.
+                    </Paragraph>
+                )}
+                <Button onClick={() => router.push(URL_PATHS.ROOT)}>
+                    Go Home
+                </Button>
+            </CenteredContainer>
+        );
+    return (
+        <MemberNavigationPage
+            currentPath={URL_PATHS.MEMBERS.ACCOUNT.EXPIRED_PLAN}
+            user={user}
+        >
+            <CenteredContainer
+                fillSpace
+                style={{ background: theme.palette.background.default }}
+            >
+                <ErrorContainer>
+                    <H3>
+                        Unfortunately, you no longer have access to Therify.
+                    </H3>
+                    <Paragraph>
+                        Your sponsoring organization’s contract with Therify has
+                        expired. Please contact the account administrator within
+                        your organization for further information on future
+                        access to our services.
+                    </Paragraph>
+                    {isPlanExpired && user.plan?.endDate && (
+                        <Alert
+                            icon={
+                                <CenteredContainer marginRight={2}>
+                                    <WarningRounded />
+                                </CenteredContainer>
+                            }
+                            title={`Your plan expired on ${format(
+                                new Date(user.plan.endDate),
+                                'MMMM do, yyyy'
+                            )}.`}
+                            type="error"
+                        />
+                    )}
+                </ErrorContainer>
+            </CenteredContainer>
+        </MemberNavigationPage>
+    );
+}
+
+const ErrorContainer = styled(Box)(({ theme }) => ({
+    background: theme.palette.background.paper,
+    borderRadius: theme.shape.borderRadius,
+    padding: theme.spacing(10),
+    border: `1px solide ${theme.palette.error.main}`,
+    maxWidth: '800px',
+}));

--- a/src/pages/members/account/invalid-plan.tsx
+++ b/src/pages/members/account/invalid-plan.tsx
@@ -24,7 +24,7 @@ export const getServerSideProps = RBAC.requireMemberAuth(
         getServerSideProps: membersService.getTherifyUserPageProps,
     })
 );
-export default function ExpiredPlanPage({ user }: MemberTherifyUserPageProps) {
+export default function InvalidPlanPage({ user }: MemberTherifyUserPageProps) {
     const theme = useTheme();
     const router = useRouter();
     const isPlanExpired =
@@ -56,7 +56,7 @@ export default function ExpiredPlanPage({ user }: MemberTherifyUserPageProps) {
 
     return (
         <MemberNavigationPage
-            currentPath={URL_PATHS.MEMBERS.ACCOUNT.EXPIRED_PLAN}
+            currentPath={URL_PATHS.MEMBERS.ACCOUNT.INVALID_PLAN}
             user={user}
         >
             <CenteredContainer

--- a/src/pages/providers/account/billing.tsx
+++ b/src/pages/providers/account/billing.tsx
@@ -1,29 +1,9 @@
-import { Box, Link } from '@mui/material';
-import { isAfter, format } from 'date-fns';
-import { useTheme } from '@mui/material/styles';
-import {
-    ArrowForwardRounded as ArrowIcon,
-    WarningRounded,
-} from '@mui/icons-material';
-import {
-    Paragraph,
-    H3,
-    Button,
-    Alert,
-    CenteredContainer,
-} from '@/lib/shared/components/ui';
 import { withPageAuthRequired } from '@auth0/nextjs-auth0';
-
 import { RBAC } from '@/lib/shared/utils';
-import { TherifyUser } from '@/lib/shared/types';
 import { ProvidersService } from '@/lib/modules/providers/service';
 import { ProviderBillingPageProps } from '@/lib/modules/providers/service/page-props/get-billing-page-props';
-import {
-    ProviderNavigationPage,
-    PracticeAdminNavigationPage,
-} from '@/lib/shared/components/features/pages';
 import { URL_PATHS } from '@/lib/sitemap';
-import { PlanStatus } from '@prisma/client';
+import { ProviderBillingPageView } from '@/lib/shared/components/features/pages/providers/billing-page-view/BillingPageView';
 
 export const getServerSideProps = RBAC.requireProviderAuth(
     withPageAuthRequired({
@@ -34,162 +14,11 @@ export default function BillingPage({
     stripeCustomerPortalUrl,
     user,
 }: ProviderBillingPageProps) {
-    const isPlanExpired =
-        !!user?.plan?.endDate &&
-        isAfter(new Date(), new Date(user.plan.endDate));
-    const isPlanActive =
-        user &&
-        (user?.plan?.status === PlanStatus.active ||
-            user?.plan?.status === PlanStatus.trialing);
     return (
-        <>
-            {user?.isPracticeAdmin ? (
-                <PracticeAdminBillingView
-                    stripeCustomerPortalUrl={stripeCustomerPortalUrl}
-                    isPlanExpired={isPlanExpired}
-                    isPlanActive={isPlanActive}
-                    user={user}
-                />
-            ) : (
-                <ProviderBillingView
-                    user={user}
-                    isPlanExpired={isPlanExpired}
-                    isPlanActive={isPlanActive}
-                />
-            )}
-        </>
-    );
-}
-
-const PracticeAdminBillingView = ({
-    stripeCustomerPortalUrl,
-    isPlanExpired,
-    isPlanActive,
-    user,
-}: {
-    isPlanExpired: boolean;
-    isPlanActive: boolean;
-    user: TherifyUser.TherifyUser;
-    stripeCustomerPortalUrl: string | null;
-}) => {
-    const theme = useTheme();
-
-    return (
-        <PracticeAdminNavigationPage
-            currentPath={URL_PATHS.PROVIDERS.ACCOUNT.BILLING_AND_SUBSCRIPTION}
+        <ProviderBillingPageView
             user={user}
-        >
-            <Box padding={4}>
-                {(isPlanExpired || !isPlanActive) && user && (
-                    <Box marginBottom={4}>
-                        <PlanAlert
-                            showExpiredMessage={isPlanExpired}
-                            endDate={user.plan?.endDate}
-                            message="Please update your billing information with Stripe to continue using Therify."
-                        />
-                    </Box>
-                )}
-                <H3>Billing and Subscription</H3>
-                <Paragraph>
-                    We partner with{' '}
-                    <Link
-                        href="https://stripe.com/"
-                        target="_blank"
-                        style={{ color: theme.palette.text.primary }}
-                    >
-                        Stripe
-                    </Link>{' '}
-                    for simplified billing. You can edit subscription and
-                    payment settings in Stripe&apos;s customer portal.
-                </Paragraph>
-
-                {stripeCustomerPortalUrl ? (
-                    <Link
-                        href={stripeCustomerPortalUrl}
-                        target="_blank"
-                        style={{ textDecoration: 'none' }}
-                    >
-                        <Button endIcon={<ArrowIcon />}>
-                            Launch Stripe Customer Portal
-                        </Button>
-                    </Link>
-                ) : (
-                    <Alert
-                        icon={
-                            <CenteredContainer>
-                                <WarningRounded />
-                            </CenteredContainer>
-                        }
-                        title="Stripe Billing Issue"
-                        type="error"
-                        message="Stripe customer portal URL is not configured. Please reach
-                    out to Therify support."
-                    />
-                )}
-            </Box>
-        </PracticeAdminNavigationPage>
-    );
-};
-
-const ProviderBillingView = ({
-    user,
-    isPlanExpired,
-    isPlanActive,
-}: {
-    user: TherifyUser.TherifyUser;
-    isPlanExpired: boolean;
-    isPlanActive: boolean;
-}) => {
-    return (
-        <ProviderNavigationPage
+            stripeCustomerPortalUrl={stripeCustomerPortalUrl}
             currentPath={URL_PATHS.PROVIDERS.ACCOUNT.BILLING_AND_SUBSCRIPTION}
-            user={user}
-        >
-            <Box padding={4}>
-                {(isPlanExpired || !isPlanActive) && user && (
-                    <Box marginBottom={4}>
-                        <PlanAlert
-                            showExpiredMessage={isPlanExpired}
-                            endDate={user.plan?.endDate}
-                            message="Please reach out to your practice administrator to update your billing information."
-                        />
-                    </Box>
-                )}
-                <H3>Billing and Subscription</H3>
-                <Paragraph>
-                    Your billing is handled by your practice administrator.
-                    Please contact them for any billing questions.
-                </Paragraph>
-            </Box>
-        </ProviderNavigationPage>
-    );
-};
-
-const PlanAlert = ({
-    endDate,
-    message,
-    showExpiredMessage,
-}: {
-    endDate?: string;
-    showExpiredMessage: boolean;
-    message: string;
-}) => {
-    const expiredTitle = `Your plan expired${
-        endDate ? ` on ${format(new Date(endDate), 'MMMM do, yyyy')}` : ''
-    }.`;
-    const title = showExpiredMessage
-        ? expiredTitle
-        : 'Your plan is not active.';
-    return (
-        <Alert
-            icon={
-                <CenteredContainer marginRight={2}>
-                    <WarningRounded />
-                </CenteredContainer>
-            }
-            title={title}
-            type="error"
-            message={message}
         />
     );
-};
+}


### PR DESCRIPTION
# Description
Adds a hook to all navigation page components that watches user plans and checks:
- status is active or trialing
- Start date is in the past
- End date is in the future
If any of those checks fail, the user will be redirected to the appropriate page.
Members go to `/members/account/expired-plan`
Providers go to `/providers/account/billing`
 If start date is in the future, all users go to `/access-countdown`

# Closes issue(s)
[Check plan expiration when provisioning access to app](https://trello.com/c/b1fpdEvK)

# How to test / repro
sign in as practice owner.
Go to stripe customer portal and cancel plan
see access get revoked

# Screenshots
### Plan status not active
<img width="1787" alt="image" src="https://user-images.githubusercontent.com/25045075/223915788-015d2ef6-e5e9-4e4f-9a9b-c4560364a597.png">

### Plan expired
<img width="1391" alt="image" src="https://user-images.githubusercontent.com/25045075/223919201-90d3e642-513f-4aaf-bb34-6b89b8c00783.png">

### Member plan expires/not active
<img width="1394" alt="image" src="https://user-images.githubusercontent.com/25045075/223919350-d18d6d02-bb30-47b2-87bd-3b05352a33b0.png">

### Plan not active yet
<img width="997" alt="image" src="https://user-images.githubusercontent.com/25045075/223918980-b11cf41b-af47-456e-b71f-7a467db0913c.png">


# Changes include

-   [ ] Bugfix (non-breaking change that solves an issue)
-   [x] New feature (non-breaking change that adds functionality)
-   [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Checklist

-   [x] I have tested this code
-   [ ] I have updated the Readme

# Other comments
