### PR TITLE
feat: add annual subscriptions

### DIFF
--- a/src/lib/modules/accounts/service/service/handle-practice-onboarding/transaction/createStripeCheckoutSession.ts
+++ b/src/lib/modules/accounts/service/service/handle-practice-onboarding/transaction/createStripeCheckoutSession.ts
@@ -1,13 +1,25 @@
 import { HandlePracticeOnboarding } from '@/lib/modules/onboarding/features';
+import { getProductByEnvironment, PRODUCTS } from '@/lib/shared/types';
+import { NodeEnvironment } from '@/lib/shared/types/nodeEnvironment';
 import { URL_PATHS } from '@/lib/sitemap';
 
 import { HandlePracticeOnboardingTransaction } from './definition';
 
+const PRODUCT = getProductByEnvironment(
+    PRODUCTS.GROUP_PRACTICE_PLAN,
+    process.env.NEXT_PUBLIC_VERCEL_ENV as NodeEnvironment
+);
+
 export const factory = ({
     seatCount,
-    priceId,
+    billingCycle,
 }: HandlePracticeOnboarding.Input): HandlePracticeOnboardingTransaction['createStripeCheckoutSession'] => ({
     async commit({ stripe }, { getUserDetails: { stripeCustomerId } }) {
+        const priceId =
+            billingCycle === 'year'
+                ? PRODUCT.PRICES.ANNUAL
+                : PRODUCT.PRICES.DEFAULT;
+
         const { url: checkoutSessionUrl, id: checkoutSessionId } =
             await stripe.createCheckoutSession({
                 priceId,

--- a/src/lib/modules/onboarding/components/PracticeDetailsForm/PracticeDetailsForm.tsx
+++ b/src/lib/modules/onboarding/components/PracticeDetailsForm/PracticeDetailsForm.tsx
@@ -17,6 +17,7 @@ import {
     PhoneNumberInput,
     PracticeEmailInput,
     SeatCountInput,
+    BillingCycleButtons,
 } from './components/inputs';
 import { SafePracticeDetails } from './hooks';
 
@@ -25,7 +26,8 @@ export interface PracticeDetailsFormProps {
     control: Control<HandlePracticeOnboarding.Input>;
     minimumSeats?: number;
     maximumSeats?: number;
-    baseSeatPrice: number;
+    seatPrice: number;
+    billingCycle: HandlePracticeOnboarding.Input['billingCycle'];
     seatCount: number;
     disabled?: boolean;
     onInputBlur: () => void;
@@ -36,8 +38,9 @@ export const PracticeDetailsForm = ({
     control,
     minimumSeats = 1,
     maximumSeats = 15,
-    baseSeatPrice,
+    seatPrice,
     seatCount,
+    billingCycle,
     disabled,
     onInputBlur,
 }: PracticeDetailsFormProps) => {
@@ -94,6 +97,14 @@ export const PracticeDetailsForm = ({
                     disabled={disabled}
                 />
                 <SectionTitle>
+                    How would you like to pay for your Therify subscription?
+                </SectionTitle>
+                <BillingCycleButtons
+                    control={control}
+                    defaultValue={defaultValues?.billingCycle}
+                    disabled={disabled}
+                />
+                <SectionTitle>
                     How many profiles do you want to list with Therify?
                 </SectionTitle>
                 <Subhead textAlign="center">{seatCount}</Subhead>
@@ -110,7 +121,15 @@ export const PracticeDetailsForm = ({
                     <Paragraph>{maximumSeats}</Paragraph>
                 </Box>
                 <Paragraph>Your plan:</Paragraph>
-                <H3>${seatCount * baseSeatPrice} / month</H3>
+                <H3>
+                    ${seatCount * seatPrice} / {billingCycle}
+                </H3>
+                {billingCycle === 'year' && (
+                    <Caption secondary>
+                        $31 per profile per month, paid annually. (20% off the
+                        monthly rate)
+                    </Caption>
+                )}
                 {seatCount === maximumSeats && (
                     <Paragraph>
                         Need more than {maximumSeats} seats?{' '}

--- a/src/lib/modules/onboarding/components/PracticeDetailsForm/components/inputs/BillingCycleButtons.tsx
+++ b/src/lib/modules/onboarding/components/PracticeDetailsForm/components/inputs/BillingCycleButtons.tsx
@@ -11,7 +11,7 @@ interface BillingCycleButtonsProps {
 
 const BILLING_CYCLE_OPTIONS = {
     MONTHLY: 'month',
-    ANNUAL: 'year',
+    ANNUALLY: 'year',
 } as const;
 
 export const BillingCycleButtons = ({
@@ -43,7 +43,7 @@ export const BillingCycleButtons = ({
                     <ToggleButton value={BILLING_CYCLE_OPTIONS.MONTHLY}>
                         Monthly
                     </ToggleButton>
-                    <ToggleButton value={BILLING_CYCLE_OPTIONS.ANNUAL}>
+                    <ToggleButton value={BILLING_CYCLE_OPTIONS.ANNUALLY}>
                         Annually
                     </ToggleButton>
                 </ButtonGroup>

--- a/src/lib/modules/onboarding/components/PracticeDetailsForm/components/inputs/BillingCycleButtons.tsx
+++ b/src/lib/modules/onboarding/components/PracticeDetailsForm/components/inputs/BillingCycleButtons.tsx
@@ -44,7 +44,7 @@ export const BillingCycleButtons = ({
                         Monthly
                     </ToggleButton>
                     <ToggleButton value={BILLING_CYCLE_OPTIONS.ANNUAL}>
-                        Annual
+                        Annually
                     </ToggleButton>
                 </ButtonGroup>
             )}

--- a/src/lib/modules/onboarding/components/PracticeDetailsForm/components/inputs/BillingCycleButtons.tsx
+++ b/src/lib/modules/onboarding/components/PracticeDetailsForm/components/inputs/BillingCycleButtons.tsx
@@ -1,0 +1,66 @@
+import { HandlePracticeOnboarding } from '@/lib/modules/onboarding/features';
+import { ToggleButton, ToggleButtonGroup } from '@mui/material';
+import { styled } from '@mui/material/styles';
+import { Control, Controller } from 'react-hook-form';
+
+interface BillingCycleButtonsProps {
+    control: Control<HandlePracticeOnboarding.Input>;
+    defaultValue?: HandlePracticeOnboarding.Input['billingCycle'];
+    disabled?: boolean;
+}
+
+const BILLING_CYCLE_OPTIONS = {
+    MONTHLY: 'month',
+    ANNUAL: 'year',
+} as const;
+
+export const BillingCycleButtons = ({
+    defaultValue,
+    control,
+    disabled,
+}: BillingCycleButtonsProps) => {
+    return (
+        <Controller
+            control={control}
+            name="billingCycle"
+            defaultValue={defaultValue ?? 'month'}
+            rules={{
+                required: true,
+            }}
+            render={({ field: { onChange, onBlur, value, name } }) => (
+                <ButtonGroup
+                    color="primary"
+                    value={value}
+                    exclusive
+                    onChange={onChange}
+                    aria-label="Subscription Cycle"
+                    disabled={disabled}
+                    {...{
+                        name,
+                        onBlur,
+                    }}
+                >
+                    <ToggleButton value={BILLING_CYCLE_OPTIONS.MONTHLY}>
+                        Monthly
+                    </ToggleButton>
+                    <ToggleButton value={BILLING_CYCLE_OPTIONS.ANNUAL}>
+                        Annual
+                    </ToggleButton>
+                </ButtonGroup>
+            )}
+        />
+    );
+};
+
+const ButtonGroup = styled(ToggleButtonGroup)(({ theme }) => ({
+    width: '100%',
+    display: 'flex',
+    '& > button': {
+        flex: 1,
+        '&.Mui-selected, &.Mui-selected:hover': {
+            backgroundColor: theme.palette.primary.main,
+            color: theme.palette.primary.contrastText,
+            border: `1px solid ${theme.palette.primary.main}`,
+        },
+    },
+}));

--- a/src/lib/modules/onboarding/components/PracticeDetailsForm/components/inputs/index.ts
+++ b/src/lib/modules/onboarding/components/PracticeDetailsForm/components/inputs/index.ts
@@ -4,3 +4,4 @@ export * from './Website';
 export * from './Phone';
 export * from './PracticeEmail';
 export * from './SeatCount';
+export * from './BillingCycleButtons';

--- a/src/lib/modules/onboarding/components/PracticeDetailsForm/hooks/usePracticeOnboardingStorage.ts
+++ b/src/lib/modules/onboarding/components/PracticeDetailsForm/hooks/usePracticeOnboardingStorage.ts
@@ -13,6 +13,7 @@ export type SafePracticeDetails = Pick<
     | 'email'
     | 'website'
     | 'seatCount'
+    | 'billingCycle'
 >;
 
 export const usePracticeOnboardingStorage = () => {
@@ -31,6 +32,7 @@ export const usePracticeOnboardingStorage = () => {
             email: details.email,
             website: details.website,
             seatCount: details.seatCount,
+            billingCycle: details.billingCycle,
         };
         const cleanedDetails = Object.entries(safeDetails).reduce<
             Partial<SafePracticeDetails>

--- a/src/lib/modules/onboarding/features/handle-practice-onboarding/input.ts
+++ b/src/lib/modules/onboarding/features/handle-practice-onboarding/input.ts
@@ -15,7 +15,7 @@ export const schema = PracticeSchema.pick({
     .extend({
         practiceId: z.string().optional(),
         seatCount: z.number().min(1),
-        priceId: z.string(),
+        billingCycle: z.enum(['month', 'year']),
         userId: z.string(),
     })
     .refine((data) => data.seatCount > 0, {

--- a/src/lib/modules/webhooks/services/stripe/event-handlers/invoices/paid/handlers/handleGroupPracticePayment.ts
+++ b/src/lib/modules/webhooks/services/stripe/event-handlers/invoices/paid/handlers/handleGroupPracticePayment.ts
@@ -21,7 +21,6 @@ export const handleGroupPracticePayment = async ({
     priceId,
     seats,
 }: HandleGroupPracticePaymentInput) => {
-    console.log('handleGroupPracticePayment...');
     return await accounts.billing.handleGroupPracticePlanPayment({
         startDate,
         endDate,

--- a/src/lib/shared/types/products/products.ts
+++ b/src/lib/shared/types/products/products.ts
@@ -7,12 +7,13 @@ export const PRODUCTS = {
     GROUP_PRACTICE_PLAN: 'group_practice_plan',
 } as const;
 
-export type Product = typeof PRODUCTS[keyof typeof PRODUCTS];
+export type Product = (typeof PRODUCTS)[keyof typeof PRODUCTS];
 
 type ProductIds = {
     PRODUCT_ID: string;
     PRICES: {
         DEFAULT: string;
+        ANNUAL: string;
         [id: string]: string;
     };
 };
@@ -22,6 +23,7 @@ export const DEVELOPMENT_PRODUCT_IDS: Record<Product, ProductIds> = {
         PRODUCT_ID: 'prod_N94KTDPkgySWMC',
         PRICES: {
             DEFAULT: 'price_1MOmC0Allox7wzg5rapKGwqU',
+            ANNUAL: 'price_1MlGl1Allox7wzg5qhovHhDp',
         },
     },
 } as const;
@@ -31,6 +33,7 @@ export const PRODUCTION_PRODUCT_IDS: Record<Product, ProductIds> = {
         PRODUCT_ID: 'prod_N68tLSFmC9RrdQ',
         PRICES: {
             DEFAULT: 'price_1MbwAQAllox7wzg5jmrDiIdA',
+            ANNUAL: 'price_1MlHjSAllox7wzg5HKWnEHKS',
         },
     },
 } as const;

--- a/src/pages/providers/onboarding/billing/index.tsx
+++ b/src/pages/providers/onboarding/billing/index.tsx
@@ -17,19 +17,13 @@ import { useForm } from 'react-hook-form';
 import { ArrowForwardRounded as NextIcon } from '@mui/icons-material';
 import { useUser } from '@auth0/nextjs-auth0/client';
 import { withPageAuthRequired } from '@auth0/nextjs-auth0';
-import { getProductByEnvironment, PRODUCTS } from '@/lib/shared/types';
 import { TRPCClientError } from '@trpc/client';
 import Link from 'next/link';
 import { URL_PATHS } from '@/lib/sitemap';
 import { RBAC } from '@/lib/shared/utils';
-import { NodeEnvironment } from '@/lib/shared/types/nodeEnvironment';
 
 const REGISTRATION_STEPS = ['Registration', 'Payment', 'Onboarding'] as const;
 
-const PRODUCT = getProductByEnvironment(
-    PRODUCTS.GROUP_PRACTICE_PLAN,
-    process.env.NEXT_PUBLIC_VERCEL_ENV as NodeEnvironment
-);
 export const getServerSideProps = RBAC.requireProviderAuth(
     withPageAuthRequired()
 );
@@ -44,9 +38,9 @@ export default function PracticeOnboardingPage() {
         mode: 'onChange',
         defaultValues: {
             ...getStoredPracticeDetails(),
-            priceId: PRODUCT.PRICES.DEFAULT,
         },
     });
+    const billingCycle = practiceDetailsForm.watch('billingCycle');
 
     const { isLoading: isLoadingPractice, data: practiceData } = trpc.useQuery(
         [
@@ -151,13 +145,14 @@ export default function PracticeOnboardingPage() {
                             defaultValues={undefined}
                             control={practiceDetailsForm.control}
                             seatCount={practiceDetailsForm.watch('seatCount')}
-                            baseSeatPrice={39}
+                            seatPrice={billingCycle === 'year' ? 372 : 39}
                             maximumSeats={35}
                             onInputBlur={() =>
                                 storePracticeDetails(
                                     practiceDetailsForm.getValues()
                                 )
                             }
+                            billingCycle={billingCycle}
                             disabled={
                                 isLoadingUser ||
                                 isLoadingPractice ||


### PR DESCRIPTION
# Description
This allows practice owners to sign up for annual plans.
- Adds Stripe price id
- Updates practice onboarding form
- Updates `handlePracticeOnboarding` to take a `billingCycle` param and apply the correct Stripe priceId to the checkout session.

# Closes issue(s)
[Stripe: Add annual subscription](https://trello.com/c/VmwEoZMZ)

# How to test / repro
Sign up as a new practice

# Screenshots
![image](https://user-images.githubusercontent.com/25045075/224825956-0e8eee04-dded-4e21-87d1-d32f43895490.png)

# Changes include

-   [ ] Bugfix (non-breaking change that solves an issue)
-   [x] New feature (non-breaking change that adds functionality)
-   [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Checklist

-   [x] I have tested this code
-   [ ] I have updated the Readme

# Other comments
Manually tested webhook integration with Stipes test environment and local Stripe CLI wehook listeners