### PR TITLE
chore: add plan info to practice billing view

### DIFF
--- a/src/lib/shared/components/features/pages/providers/billing-page-view/ui/PracticeAdminBillingView.tsx
+++ b/src/lib/shared/components/features/pages/providers/billing-page-view/ui/PracticeAdminBillingView.tsx
@@ -1,16 +1,23 @@
+import { format } from 'date-fns';
+import { PlanStatus } from '@prisma/client';
 import { Box, Link } from '@mui/material';
 import { useTheme } from '@mui/material/styles';
 import {
     ArrowForwardRounded as ArrowIcon,
+    CheckCircle,
+    CancelRounded,
     WarningRounded,
 } from '@mui/icons-material';
 import { TherifyUser } from '@/lib/shared/types';
 import {
     Paragraph,
     H3,
+    H4,
     Button,
     Alert,
     CenteredContainer,
+    Badge,
+    Divider,
 } from '@/lib/shared/components/ui';
 import { PracticeAdminNavigationPage } from '@/lib/shared/components/features/pages';
 import { PlanAlert } from './PlanAlert';
@@ -80,7 +87,68 @@ export const PracticeAdminBillingView = ({
                     out to Therify support."
                     />
                 )}
+
+                {user.plan && (
+                    <>
+                        <Divider />
+                        <Box marginTop={8}>
+                            <H4>Your Current Plan</H4>
+                            <Box marginBottom={2}>
+                                <Badge
+                                    icon={
+                                        isPlanActive ? (
+                                            <CheckCircle />
+                                        ) : (
+                                            <CancelRounded />
+                                        )
+                                    }
+                                    color={isPlanActive ? 'success' : 'error'}
+                                >
+                                    {getPlanStatusText(user.plan.status)}
+                                </Badge>
+                            </Box>
+                            <Paragraph>
+                                Period start:{' '}
+                                {format(
+                                    new Date(user.plan.startDate),
+                                    'MMMM do, yyyy'
+                                )}
+                            </Paragraph>
+                            <Paragraph>
+                                Period end:{' '}
+                                {format(
+                                    new Date(user.plan.endDate),
+                                    'MMMM do, yyyy'
+                                )}
+                            </Paragraph>
+                            <Paragraph>
+                                Renews: {user.plan.renews ? 'Yes' : 'No'}
+                            </Paragraph>
+                        </Box>
+                    </>
+                )}
             </Box>
         </PracticeAdminNavigationPage>
     );
+};
+
+const getPlanStatusText = (status: string) => {
+    switch (status) {
+        case PlanStatus.active:
+            return 'Active';
+        case PlanStatus.trialing:
+            return 'Trialing';
+        case PlanStatus.past_due:
+            return 'Past Due';
+        case PlanStatus.canceled:
+            return 'Canceled';
+        case PlanStatus.unpaid:
+            return 'Unpaid';
+        case PlanStatus.incomplete:
+            return 'Incomplete';
+        case PlanStatus.incomplete_expired:
+            return 'Incomplete - Expired';
+        default:
+            return 'Unknown';
+    }
 };


### PR DESCRIPTION
# Description
Adds plans details for practice owner billing page

# Closes issue(s)

# How to test / repro

# Screenshots
<img width="1127" alt="image" src="https://user-images.githubusercontent.com/25045075/224872314-9703ecca-cefa-42a8-84d2-b4848080d5ef.png">

# Changes include

-   [ ] Bugfix (non-breaking change that solves an issue)
-   [ ] New feature (non-breaking change that adds functionality)
-   [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Checklist

-   [ ] I have tested this code
-   [ ] I have updated the Readme

# Other comments
