### PR TITLE
chore: add profile designation and price editing rules

### DIFF
--- a/src/lib/modules/providers/components/ProfileEditor/ProfileEditor.tsx
+++ b/src/lib/modules/providers/components/ProfileEditor/ProfileEditor.tsx
@@ -27,6 +27,8 @@ import { CloudinaryUploadResult } from '../../../media/components/hooks/userClou
 interface ProfileEditorProps {
     providerProfile?: Partial<ProviderProfile.ProviderProfile>;
     practice: ProviderPractice.Type;
+    canEditSessionPrice?: boolean;
+    allowProfileDesignationChange?: boolean;
     isSavingProfile: boolean;
     onBack?: () => void;
     onSubmit: (profile: ProviderProfile.ProviderProfile) => Promise<void>;
@@ -36,6 +38,8 @@ export function ProfileEditor({
     providerProfile,
     practice,
     isSavingProfile,
+    canEditSessionPrice,
+    allowProfileDesignationChange,
     onBack,
     onSubmit,
 }: ProfileEditorProps) {
@@ -180,6 +184,10 @@ export function ProfileEditor({
                         <SlotWrapper>
                             <ProfileEditorForm
                                 control={providerProfileForm.control}
+                                canEditSessionPrice={canEditSessionPrice}
+                                allowProfileDesignationChange={
+                                    allowProfileDesignationChange
+                                }
                                 onDeleteImage={onDeleteImage}
                                 onImageUploadSuccess={onImageUploadSuccess}
                                 onImageUploadError={onImageUploadError}

--- a/src/lib/modules/providers/components/ProfileEditor/ui/ProfileEditorForm.tsx
+++ b/src/lib/modules/providers/components/ProfileEditor/ui/ProfileEditorForm.tsx
@@ -32,6 +32,8 @@ interface EditorFormProps {
     control: Control<ProviderProfile.ProviderProfile>;
     isSubmitDisabled: boolean;
     isSubmittingForm: boolean;
+    canEditSessionPrice?: boolean;
+    allowProfileDesignationChange?: boolean;
     licensedStates?: Region.StateAndCountry[];
     onImageUploadSuccess: (
         error: Error | null,
@@ -72,6 +74,8 @@ export const ProfileEditorForm = ({
     hideFloatingButton,
     watchedProfileValues,
     setSupervisor,
+    canEditSessionPrice,
+    allowProfileDesignationChange,
 }: EditorFormProps) => {
     const isNewProfile = !watchedProfileValues.id;
     const theme = useTheme();
@@ -152,13 +156,17 @@ export const ProfileEditorForm = ({
                     </FloatingButtons>
                 )}
                 <Divider sx={{ mb: 4 }} />
-                <FormSectionTitle style={{ marginTop: 0 }}>
-                    Profile Type
-                </FormSectionTitle>
-                <DesignationInput
-                    control={control}
-                    disabled={isSubmittingForm}
-                />
+                {allowProfileDesignationChange && (
+                    <>
+                        <FormSectionTitle style={{ marginTop: 0 }}>
+                            Profile Type
+                        </FormSectionTitle>
+                        <DesignationInput
+                            control={control}
+                            disabled={isSubmittingForm}
+                        />
+                    </>
+                )}
                 <FormSectionTitle style={{ margin: 0 }}>
                     New Clients
                 </FormSectionTitle>
@@ -188,12 +196,16 @@ export const ProfileEditorForm = ({
                     disabled={isSubmittingForm}
                     setSupervisor={setSupervisor}
                 />
-                <PricingInputs
-                    control={control}
-                    offersSlidingScale={watchedProfileValues.offersSlidingScale}
-                    minimumRate={watchedProfileValues.minimumRate}
-                    disabled={isSubmittingForm}
-                />
+                {canEditSessionPrice && (
+                    <PricingInputs
+                        control={control}
+                        offersSlidingScale={
+                            watchedProfileValues.offersSlidingScale
+                        }
+                        minimumRate={watchedProfileValues.minimumRate}
+                        disabled={isSubmittingForm}
+                    />
+                )}
                 <PracticeSection
                     control={control}
                     isTherapist={isTherapist}

--- a/src/pages/providers/practice/profiles/create.tsx
+++ b/src/pages/providers/practice/profiles/create.tsx
@@ -69,6 +69,8 @@ export default function PracticeProfileCreatePage({
             mobileMenu={[...PRACTICE_ADMIN_MOBILE_MENU]}
         >
             <ProfileEditor
+                canEditSessionPrice
+                allowProfileDesignationChange
                 practice={practice}
                 isSavingProfile={isCreatingProfile}
                 onSubmit={async (profile) => {

--- a/src/pages/providers/practice/profiles/editor/[profileId].tsx
+++ b/src/pages/providers/practice/profiles/editor/[profileId].tsx
@@ -66,6 +66,7 @@ export default function PracticeProfileCreatePage({
             mobileMenu={[...PRACTICE_ADMIN_MOBILE_MENU]}
         >
             <ProfileEditor
+                canEditSessionPrice
                 providerProfile={profile}
                 practice={practice}
                 isSavingProfile={isUpdatingProfile}

--- a/src/pages/providers/therapist/profile/editor.tsx
+++ b/src/pages/providers/therapist/profile/editor.tsx
@@ -78,6 +78,7 @@ export default function TherapistProfileEditorPage({
             <LoadingContainer isLoading={isLoading || isRefetching}>
                 <ProfileEditor
                     onBack={router.back}
+                    canEditSessionPrice
                     providerProfile={refetchedProfile ?? profile}
                     practice={practice}
                     isSavingProfile={isUpdatingProfile}


### PR DESCRIPTION
# Description
Adds `allowProfileDesignationChange` and `canEditSessionPrice` controls to the profile editor.
- Profile designation (`coach` vs `therapist`) can only be edited at profile creation. This scopes it only to practice owners that can set a profile designation.
- Coach profiles can no longer edit their session price in the profile editor by non-practice owners. Coaching Prices can only be edited in the practice owner's profile editor.
- Therapist profiles can still edit session pricing in the editor by non-practice owners.

# Closes issue(s)

# How to test / repro

# Screenshots

# Changes include

-   [ ] Bugfix (non-breaking change that solves an issue)
-   [ ] New feature (non-breaking change that adds functionality)
-   [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Checklist

-   [ ] I have tested this code
-   [ ] I have updated the Readme

# Other comments
As we release Stripe Connect onboarding and session invoicing, it is important that Therify Coaches' negotiated session rates are accurate in their profiles. To achieve this, prices should only be edited by Therify admins. When Coaches onboard to Stripe Connect, their minimum session price will be referenced when creating their Stripe product. This feature aims to guard against incorrect values being entered by coaches resulting in bad Stripe price amounts.