### PR TITLE
chore: reuse invoicing from chat in clients ui

### DIFF
--- a/src/lib/modules/accounts/components/hooks/index.ts
+++ b/src/lib/modules/accounts/components/hooks/index.ts
@@ -1,0 +1,1 @@
+export * from './use-session-invoicing';

--- a/src/lib/modules/accounts/components/hooks/use-session-invoicing/index.ts
+++ b/src/lib/modules/accounts/components/hooks/use-session-invoicing/index.ts
@@ -1,0 +1,1 @@
+export * from './useSessionInvoicing';

--- a/src/lib/modules/accounts/components/hooks/use-session-invoicing/useSessionInvoicing.tsx
+++ b/src/lib/modules/accounts/components/hooks/use-session-invoicing/useSessionInvoicing.tsx
@@ -1,0 +1,160 @@
+import { useContext, useState } from 'react';
+import { isValid as isValidDate, startOfDay } from 'date-fns';
+import { Alerts } from '@/lib/modules/alerts/context';
+import { trpc } from '@/lib/shared/utils/trpc';
+import { Box, CircularProgress } from '@mui/material';
+import {
+    CenteredContainer,
+    Modal,
+    DatePicker,
+} from '@/lib/shared/components/ui';
+interface InvoicedMember {
+    memberId: string;
+    givenName?: string;
+}
+export const useSessionInvoicing = (providerId: string) => {
+    const { createAlert } = useContext(Alerts.Context);
+    const [showModal, setShowModal] = useState(false);
+    const [member, setMember] = useState<InvoicedMember | null>(null);
+    const [sessionDate, setSessionDate] = useState<Date | null>(null);
+    const closeModal = () => {
+        setShowModal(false);
+        setSessionDate(null);
+        setMember(null);
+    };
+    const {
+        mutate: createSessionInvoice,
+        isLoading: isCreatingSessionInvoice,
+    } = trpc.useMutation('accounts.billing.create-coaching-session-checkout', {
+        onSuccess: ({ invoiceId, errors }) => {
+            if (invoiceId) {
+                closeModal();
+                return createAlert({
+                    type: 'success',
+                    title: 'Session invoice created',
+                });
+            }
+            const [error] = errors;
+            if (error) {
+                console.error(error);
+                createAlert({
+                    type: 'error',
+                    title: error,
+                });
+            }
+        },
+        onError: (error) => {
+            console.error(error);
+            if (error instanceof Error) {
+                return createAlert({
+                    type: 'error',
+                    title: error.message,
+                });
+            }
+            createAlert({
+                type: 'error',
+                title: 'There was an error creating the session invoice.',
+            });
+        },
+    });
+
+    const handleSendSessionInvoiceCreation = () => {
+        if (!member) {
+            return createAlert({
+                type: 'error',
+                title: 'Missing member id',
+            });
+        }
+        if (sessionDate === null || !isValidDate(sessionDate)) {
+            return createAlert({
+                type: 'error',
+                title: 'Invalid date selected',
+            });
+        }
+        createSessionInvoice({
+            memberId: member.memberId,
+            providerId,
+            dateOfSession: startOfDay(sessionDate).toISOString(),
+        });
+    };
+
+    return {
+        onInvoiceClient: (member: InvoicedMember) => {
+            console.log({ member });
+            setMember(member);
+            setShowModal(true);
+        },
+        isCreatingSessionInvoice,
+        ConfirmationUi: () => (
+            <>
+                {showModal && (
+                    <ConfirmationModal
+                        memberName={member?.givenName}
+                        closeModal={closeModal}
+                        sessionDate={sessionDate}
+                        setSessionDate={setSessionDate}
+                        isSubmitting={isCreatingSessionInvoice}
+                        isSubmitDisabled={
+                            isCreatingSessionInvoice ||
+                            !isValidDate(sessionDate) ||
+                            !member
+                        }
+                        onSubmit={handleSendSessionInvoiceCreation}
+                    />
+                )}
+            </>
+        ),
+    };
+};
+
+interface ConfirmationModalProps {
+    memberName?: string;
+    closeModal: () => void;
+    isSubmitDisabled: boolean;
+    isSubmitting: boolean;
+    onSubmit: () => void;
+    sessionDate: Date | null;
+    setSessionDate: (date: Date | null) => void;
+}
+
+const ConfirmationModal = ({
+    memberName,
+    closeModal,
+    isSubmitDisabled,
+    isSubmitting,
+    onSubmit,
+    sessionDate,
+    setSessionDate,
+}: ConfirmationModalProps) => (
+    <Modal
+        isOpen
+        onClose={closeModal}
+        title={'Send Session Invoice' + (memberName ? ` to ${memberName}` : '')}
+        message={`An invoice for 1 coaching session will be created for ${
+            memberName ?? 'this member'
+        }. Once the invoice has been paid, payouts can be viewed in your Stripe Connect Dashboard.`}
+        primaryButtonDisabled={isSubmitDisabled}
+        secondaryButtonDisabled={isSubmitting}
+        primaryButtonText="Send"
+        primaryButtonOnClick={onSubmit}
+        postBodySlot={
+            <Box width="100%">
+                <DatePicker
+                    required
+                    disabled={isSubmitting}
+                    label="Date of Session"
+                    value={sessionDate}
+                    onChange={(date) => setSessionDate(date)}
+                />
+                {isSubmitting ? (
+                    <CenteredContainer sx={{ width: '100%' }}>
+                        <CircularProgress />
+                    </CenteredContainer>
+                ) : undefined}
+            </Box>
+        }
+        secondaryButtonText="Cancel"
+        secondaryButtonOnClick={closeModal}
+        fullWidthButtons
+    />
+);

--- a/src/lib/modules/accounts/components/hooks/use-session-invoicing/useSessionInvoicing.tsx
+++ b/src/lib/modules/accounts/components/hooks/use-session-invoicing/useSessionInvoicing.tsx
@@ -80,7 +80,6 @@ export const useSessionInvoicing = (providerId: string) => {
 
     return {
         onInvoiceClient: (member: InvoicedMember) => {
-            console.log({ member });
             setMember(member);
             setShowModal(true);
         },

--- a/src/lib/modules/messaging/components/Chat/ui/ChatActions.tsx
+++ b/src/lib/modules/messaging/components/Chat/ui/ChatActions.tsx
@@ -1,80 +1,26 @@
 import { useChannelStateContext } from 'stream-chat-react';
-import { useContext, useState } from 'react';
-import { isValid as isValidDate, startOfDay } from 'date-fns';
-import { Box, CircularProgress } from '@mui/material';
 import { CreditCardOutlined } from '@mui/icons-material';
-import {
-    CenteredContainer,
-    FloatingList,
-    Modal,
-    DatePicker,
-} from '@/lib/shared/components/ui';
-import { Alerts } from '@/lib/modules/alerts/context';
+import { FloatingList } from '@/lib/shared/components/ui';
 import { adaptUserIdentifier } from '@/lib/shared/vendors/stream-chat/adapt-user-identifier';
-import { trpc } from '@/lib/shared/utils/trpc';
+import { useSessionInvoicing } from '@/lib/modules/accounts/components/hooks';
 
 interface ChatActionsProps {
     userIdentifier: string;
 }
 
 export const ChatActions = ({ userIdentifier }: ChatActionsProps) => {
-    const { createAlert } = useContext(Alerts.Context);
     const { channel } = useChannelStateContext();
-    const [showModal, setShowModal] = useState(false);
-    const [sessionDate, setSessionDate] = useState<Date | null>(null);
-    const closeModal = () => {
-        setShowModal(false);
-        setSessionDate(null);
-    };
-    const {
-        mutate: createCoachingSessionInvoice,
-        isLoading: isCreatingSessionInvoice,
-    } = trpc.useMutation('accounts.billing.create-coaching-session-checkout', {
-        onSuccess: ({ invoiceId, errors }) => {
-            if (invoiceId) {
-                closeModal();
-                return createAlert({
-                    type: 'success',
-                    title: 'Session invoice created',
-                });
-            }
-            const [error] = errors;
-            if (error) {
-                createAlert({
-                    type: 'error',
-                    title: error,
-                });
-            }
-        },
-        onError: (error) => {
-            if (error instanceof Error) {
-                return createAlert({
-                    type: 'error',
-                    title: error.message,
-                });
-            }
-            createAlert({
-                type: 'error',
-                title: 'There was an error creating the session invoice.',
-            });
-        },
-    });
-    const handleSendSessionInvoiceCreation = () => {
+    const { onInvoiceClient, ConfirmationUi: SessionInvoiceConfirmation } =
+        useSessionInvoicing(adaptUserIdentifier.fromStreamChat(userIdentifier));
+    const handleInvoiceClient = () => {
         const memberIdentifier = Object.keys(channel.state.members).find(
             (key) => key != userIdentifier
         );
         if (!memberIdentifier)
             throw new Error('Could not find member id in channel');
-        if (sessionDate === null || !isValidDate(sessionDate)) {
-            return createAlert({
-                type: 'error',
-                title: 'Invalid date selected',
-            });
-        }
-        createCoachingSessionInvoice({
+
+        onInvoiceClient({
             memberId: adaptUserIdentifier.fromStreamChat(memberIdentifier),
-            providerId: adaptUserIdentifier.fromStreamChat(userIdentifier),
-            dateOfSession: startOfDay(sessionDate).toISOString(),
         });
     };
     return (
@@ -91,42 +37,11 @@ export const ChatActions = ({ userIdentifier }: ChatActionsProps) => {
                         icon: <CreditCardOutlined />,
                         text: 'Send Session Invoice',
                         title: 'This will create a Mental Health Coaching Session invoice for the member so they can purchase a session with you. Payment transfers can be viewed in your Stripe Connect Dashboard once the invoice has been paid.',
-                        onClick: () => setShowModal(true),
+                        onClick: handleInvoiceClient,
                     },
                 ]}
             />
-
-            <Modal
-                isOpen={showModal}
-                onClose={closeModal}
-                title="Send Session Invoice"
-                message="An invoice for 1 coaching session will be created for this member. Payment transfers can be viewed in your Stripe Connect Dashboard once the invoice has been paid."
-                primaryButtonDisabled={
-                    isCreatingSessionInvoice || !isValidDate(sessionDate)
-                }
-                secondaryButtonDisabled={isCreatingSessionInvoice}
-                primaryButtonText="Send"
-                primaryButtonOnClick={handleSendSessionInvoiceCreation}
-                postBodySlot={
-                    <Box width="100%">
-                        <DatePicker
-                            required
-                            disabled={isCreatingSessionInvoice}
-                            label="Date of Session"
-                            value={sessionDate}
-                            onChange={(date) => setSessionDate(date)}
-                        />
-                        {isCreatingSessionInvoice ? (
-                            <CenteredContainer sx={{ width: '100%' }}>
-                                <CircularProgress />
-                            </CenteredContainer>
-                        ) : undefined}
-                    </Box>
-                }
-                secondaryButtonText="Cancel"
-                secondaryButtonOnClick={closeModal}
-                fullWidthButtons
-            />
+            <SessionInvoiceConfirmation />
         </>
     );
 };

--- a/src/lib/modules/providers/components/Clients/ClientList/ClientList.tsx
+++ b/src/lib/modules/providers/components/Clients/ClientList/ClientList.tsx
@@ -17,6 +17,7 @@ interface ClientListProps {
     onTerminateConnectionRequest: HandleConnectionRequestAction;
     onReimbursmentRequest: HandleConnectionRequestAction;
     onViewMemberDetails: HandleConnectionRequestAction;
+    onInvoiceClient?: HandleConnectionRequestAction;
 }
 
 export const ClientList = ({
@@ -26,6 +27,7 @@ export const ClientList = ({
     onTerminateConnectionRequest,
     onReimbursmentRequest,
     onViewMemberDetails,
+    onInvoiceClient,
 }: ClientListProps) => {
     const isSmallScreen = useMediaQuery((theme: Theme) =>
         theme.breakpoints.down('md')
@@ -71,6 +73,9 @@ export const ClientList = ({
                             onTerminateConnectionRequest(connectionRequest)
                         }
                         onView={() => onViewMemberDetails(connectionRequest)}
+                        onInvoiceClient={() =>
+                            onInvoiceClient?.(connectionRequest)
+                        }
                         onReimbursmentRequest={() => {
                             onReimbursmentRequest(connectionRequest);
                         }}

--- a/src/lib/modules/providers/components/Clients/ClientList/ClientList.tsx
+++ b/src/lib/modules/providers/components/Clients/ClientList/ClientList.tsx
@@ -73,8 +73,10 @@ export const ClientList = ({
                             onTerminateConnectionRequest(connectionRequest)
                         }
                         onView={() => onViewMemberDetails(connectionRequest)}
-                        onInvoiceClient={() =>
-                            onInvoiceClient?.(connectionRequest)
+                        onInvoiceClient={
+                            onInvoiceClient
+                                ? () => onInvoiceClient(connectionRequest)
+                                : undefined
                         }
                         onReimbursmentRequest={() => {
                             onReimbursmentRequest(connectionRequest);

--- a/src/lib/modules/providers/components/Clients/ClientList/ui/ClientListItem.tsx
+++ b/src/lib/modules/providers/components/Clients/ClientList/ui/ClientListItem.tsx
@@ -7,6 +7,7 @@ import {
     DoNotDisturbAltRounded,
     CheckCircleOutlineRounded,
     PreviewRounded,
+    CreditCardOutlined,
 } from '@mui/icons-material';
 
 import {
@@ -32,6 +33,7 @@ export const ClientListItem = ({
     onDecline,
     onView,
     onReimbursmentRequest,
+    onInvoiceClient,
 }: {
     connectionRequest: ConnectionRequest.Type;
     isSmallScreen?: boolean;
@@ -39,6 +41,7 @@ export const ClientListItem = ({
     onDecline: () => void;
     onTerminate: () => void;
     onView?: () => void;
+    onInvoiceClient?: () => void;
     onReimbursmentRequest: () => void;
 }) => {
     const isPending =
@@ -76,6 +79,16 @@ export const ClientListItem = ({
                       icon: <PaidOutlined />,
                       onClick: onReimbursmentRequest,
                   },
+                  ...(onInvoiceClient
+                      ? [
+                            {
+                                icon: <CreditCardOutlined />,
+                                text: 'Send Session Invoice',
+                                title: 'This will create a Mental Health Coaching Session invoice for the member so they can purchase a session with you. Payment transfers can be viewed in your Stripe Connect Dashboard once the invoice has been paid.',
+                                onClick: onInvoiceClient,
+                            },
+                        ]
+                      : []),
                   // TODO: We need to be able to handle this without breaking confidentiality
                   //   {
                   //       text: 'Remove Client',

--- a/src/lib/shared/components/features/pages/ProviderClientListPage/ProviderClientListPage.tsx
+++ b/src/lib/shared/components/features/pages/ProviderClientListPage/ProviderClientListPage.tsx
@@ -19,12 +19,14 @@ interface ProviderClientListPageProps {
     baseConnectionRequests: ConnectionRequest.Type[];
     designation: ProfileType;
     user: TherifyUser.TherifyUser;
+    onInvoiceClient?: (connectionRequest: ConnectionRequest.Type) => void;
 }
 
 export function ProviderClientListPage({
     baseConnectionRequests,
     designation,
     user,
+    onInvoiceClient,
 }: ProviderClientListPageProps) {
     const theme = useTheme();
     const {
@@ -70,6 +72,7 @@ export function ProviderClientListPage({
                         connectionRequest,
                     })
                 }
+                onInvoiceClient={onInvoiceClient}
                 onReimbursmentRequest={(connectionRequest) =>
                     window?.open(
                         formatReimbursementRequestUrl(

--- a/src/pages/providers/coach/clients.tsx
+++ b/src/pages/providers/coach/clients.tsx
@@ -24,6 +24,8 @@ export default function CoachClientsPage({
     const { onInvoiceClient, ConfirmationUi } = useSessionInvoicing(
         user.userId
     );
+    const canInvoiceClient =
+        flags.hasStripeConnectAccess && user.stripeConnectAccountId;
     return (
         <ProviderNavigationPage
             currentPath={URL_PATHS.PROVIDERS.COACH.CLIENTS}
@@ -35,8 +37,7 @@ export default function CoachClientsPage({
                     designation={ProfileType.coach}
                     baseConnectionRequests={connectionRequests}
                     onInvoiceClient={
-                        flags.hasStripeConnectAccess &&
-                        user.stripeConnectAccountId
+                        canInvoiceClient
                             ? ({ member }) =>
                                   onInvoiceClient({
                                       memberId: member.id,
@@ -46,7 +47,7 @@ export default function CoachClientsPage({
                     }
                 />
             )}
-            {flags.hasStripeConnectAccess && <ConfirmationUi />}
+            {canInvoiceClient && <ConfirmationUi />}
         </ProviderNavigationPage>
     );
 }

--- a/src/pages/providers/coach/clients.tsx
+++ b/src/pages/providers/coach/clients.tsx
@@ -35,7 +35,8 @@ export default function CoachClientsPage({
                     designation={ProfileType.coach}
                     baseConnectionRequests={connectionRequests}
                     onInvoiceClient={
-                        flags.hasStripeConnectAccess
+                        flags.hasStripeConnectAccess &&
+                        user.stripeConnectAccountId
                             ? ({ member }) =>
                                   onInvoiceClient({
                                       memberId: member.id,

--- a/src/pages/providers/coach/clients.tsx
+++ b/src/pages/providers/coach/clients.tsx
@@ -6,6 +6,8 @@ import { ProviderNavigationPage } from '@/lib/shared/components/features/pages/P
 import { ProviderClientsPageProps } from '@/lib/modules/providers/service/page-props/get-clients-page-props/getProviderClientsPageProps';
 import { ProviderClientListPage } from '@/lib/shared/components/features/pages/ProviderClientListPage/ProviderClientListPage';
 import { ProfileType } from '@prisma/client';
+import { useFeatureFlags } from '@/lib/shared/hooks';
+import { useSessionInvoicing } from '@/lib/modules/accounts/components/hooks';
 
 export const getServerSideProps = RBAC.requireCoachAuth(
     withPageAuthRequired({
@@ -18,6 +20,10 @@ export default function CoachClientsPage({
     user,
     connectionRequests,
 }: ProviderClientsPageProps) {
+    const { flags } = useFeatureFlags(user);
+    const { onInvoiceClient, ConfirmationUi } = useSessionInvoicing(
+        user.userId
+    );
     return (
         <ProviderNavigationPage
             currentPath={URL_PATHS.PROVIDERS.COACH.CLIENTS}
@@ -28,8 +34,18 @@ export default function CoachClientsPage({
                     user={user}
                     designation={ProfileType.coach}
                     baseConnectionRequests={connectionRequests}
+                    onInvoiceClient={
+                        flags.hasStripeConnectAccess
+                            ? ({ member }) =>
+                                  onInvoiceClient({
+                                      memberId: member.id,
+                                      givenName: member.givenName,
+                                  })
+                            : undefined
+                    }
                 />
             )}
+            {flags.hasStripeConnectAccess && <ConfirmationUi />}
         </ProviderNavigationPage>
     );
 }


### PR DESCRIPTION
# Description
Moves session invoicing to reusable hook
Uses hook in Chat and Client views

# Closes issue(s)
N/A

# How to test / repro
Ensure feature flag is on an Stripe onboarding has started. Then view Clients action list to create invoice

# Screenshots
<img width="1025" alt="image" src="https://user-images.githubusercontent.com/25045075/230796374-be3744ad-7418-4bcf-aadc-a3db6a40bf8e.png">

# Changes include

-   [ ] Bugfix (non-breaking change that solves an issue)
-   [ ] New feature (non-breaking change that adds functionality)
-   [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Checklist

-   [ ] I have tested this code
-   [ ] I have updated the Readme

# Other comments
