### PR TITLE
chore: handle membership payments

### DIFF
--- a/src/lib/modules/accounts/features/billing/handle-membership-plan-payment/index.ts
+++ b/src/lib/modules/accounts/features/billing/handle-membership-plan-payment/index.ts
@@ -1,0 +1,4 @@
+export { schema as inputSchema } from './input';
+export { schema as outputSchema } from './output';
+export type { Input } from './input';
+export type { Output } from './output';

--- a/src/lib/modules/accounts/features/billing/handle-membership-plan-payment/input.ts
+++ b/src/lib/modules/accounts/features/billing/handle-membership-plan-payment/input.ts
@@ -1,0 +1,38 @@
+import { StripeInvoice } from '@/lib/shared/vendors/stripe';
+import * as z from 'zod';
+
+export const schema = z
+    .object({
+        startDate: z.string(),
+        endDate: z.string(),
+        stripeSubscriptionId: z.string(),
+        stripeCustomerId: z.string(),
+        seats: z.number(),
+        invoiceId: z.string(),
+        invoiceTotal: z.number(),
+        invoiceAmountDue: z.number(),
+        invoiceAmountPaid: z.number(),
+        invoiceAmountRemaining: z.number(),
+        invoicePdf: z.string().optional(),
+        invoiceStatus: StripeInvoice.schema.shape.status,
+        priceId: z.string(),
+        coveredSessions: z.number(),
+    })
+    .refine((data) => data.seats > 0, {
+        message: 'Must have at least one seat.',
+    });
+
+export type Input = z.infer<typeof schema>;
+
+export const validate = (value: unknown): Input => {
+    return schema.parse(value);
+};
+
+export const isValid = (value: unknown): value is Input => {
+    try {
+        validate(value);
+        return true;
+    } catch {
+        return false;
+    }
+};

--- a/src/lib/modules/accounts/features/billing/handle-membership-plan-payment/output.ts
+++ b/src/lib/modules/accounts/features/billing/handle-membership-plan-payment/output.ts
@@ -1,0 +1,20 @@
+import * as z from 'zod';
+
+export const schema = z.object({
+    subscriptionId: z.number(),
+    errors: z.array(z.string()),
+});
+export type Output = z.infer<typeof schema>;
+
+export const validate = (value: unknown): Output => {
+    return schema.parse(value);
+};
+
+export const isValid = (value: unknown): value is Output => {
+    try {
+        validate(value);
+        return true;
+    } catch {
+        return false;
+    }
+};

--- a/src/lib/modules/accounts/features/billing/index.ts
+++ b/src/lib/modules/accounts/features/billing/index.ts
@@ -7,3 +7,4 @@ export * as HandleCoachingSessionPayment from './handle-coaching-session-payment
 export * as RenewPlan from './renew-plan';
 export * as CancelPlan from './cancel-plan';
 export * as HandleReimbursementSubmission from './handle-reimbursement-submission';
+export * as HandleMembershipPlanPayment from './handle-membership-plan-payment';

--- a/src/lib/modules/accounts/service/service/billing/billingFactory.ts
+++ b/src/lib/modules/accounts/service/service/billing/billingFactory.ts
@@ -10,12 +10,14 @@ import { HandleCoachingSessionPayment } from './handle-coaching-session-payment'
 import { HandleInvoiceSent } from './handle-invoice-sent';
 import { HandleCoachingSessionInvoiceUpdated } from './handle-coaching-session-invoice-updated';
 import { HandleReimbursementSubmission } from './handle-reimbursement-submission';
+import { HandleMembershipPlanPayment } from './handle-membership-plan-payment';
 
 export const factory = (context: AccountsServiceParams) => ({
     handleCoachingSessionPayment: HandleCoachingSessionPayment.factory(context),
     handleCoachingSessionInvoiceUpdated:
         HandleCoachingSessionInvoiceUpdated.factory(context),
     handleInvoiceSent: HandleInvoiceSent.factory(context),
+    handleMembershipPlanPayment: HandleMembershipPlanPayment.factory(context),
     handleGroupPracticePlanPayment:
         HandleGroupPracticePlanPayment.factory(context),
     handlePlanChange: HandlePlanChange.factory(context),

--- a/src/lib/modules/accounts/service/service/billing/handle-membership-plan-payment/handleMembershipPlanPayment.ts
+++ b/src/lib/modules/accounts/service/service/billing/handle-membership-plan-payment/handleMembershipPlanPayment.ts
@@ -1,0 +1,24 @@
+import { HandleMembershipPlanPayment } from '@/lib/modules/accounts/features/billing';
+import { TransactionV1 } from '@/lib/shared/utils/transaction';
+import { AccountsServiceParams } from '../../params';
+import {
+    GetAccount,
+    handleMembershipPlanPaymentTransactionDefinition,
+    CreatePlanEntity,
+    CreateInvoiceEntity,
+} from './transaction';
+
+export const factory =
+    (context: AccountsServiceParams) =>
+    async (params: HandleMembershipPlanPayment.Input) => {
+        return await TransactionV1.executeTransaction(
+            handleMembershipPlanPaymentTransactionDefinition,
+            { ...context },
+            {
+                getAccount: GetAccount.factory(params),
+                createPlanEntity: CreatePlanEntity.factory(params),
+                createInvoiceEntity: CreateInvoiceEntity.factory(params),
+            },
+            true
+        );
+    };

--- a/src/lib/modules/accounts/service/service/billing/handle-membership-plan-payment/index.ts
+++ b/src/lib/modules/accounts/service/service/billing/handle-membership-plan-payment/index.ts
@@ -1,0 +1,1 @@
+export * as HandleMembershipPlanPayment from './handleMembershipPlanPayment';

--- a/src/lib/modules/accounts/service/service/billing/handle-membership-plan-payment/transaction/createInvoiceEntity.ts
+++ b/src/lib/modules/accounts/service/service/billing/handle-membership-plan-payment/transaction/createInvoiceEntity.ts
@@ -1,0 +1,44 @@
+import { HandleMembershipPlanPayment } from '@/lib/modules/accounts/features/billing';
+import { HandleMembershipPlanPaymentTransaction } from './definition';
+
+interface CreateInvoiceEntityFactory {
+    (
+        params: HandleMembershipPlanPayment.Input
+    ): HandleMembershipPlanPaymentTransaction['createInvoiceEntity'];
+}
+export const factory: CreateInvoiceEntityFactory = ({
+    invoiceId,
+    invoiceStatus,
+    invoiceTotal,
+    invoiceAmountDue,
+    invoiceAmountPaid,
+    invoiceAmountRemaining,
+    invoicePdf,
+}) => ({
+    async commit(
+        { prisma },
+        { createPlanEntity: { planId }, getAccount: { accountOwnerId } }
+    ) {
+        const invoice = await prisma.stripeInvoice.create({
+            data: {
+                planId,
+                status: invoiceStatus,
+                invoiceId,
+                userId: accountOwnerId,
+                total: invoiceTotal,
+                amountDue: invoiceAmountDue,
+                amountPaid: invoiceAmountPaid,
+                amountRemaining: invoiceAmountRemaining,
+                invoicePdf: invoicePdf,
+            },
+        });
+        return {
+            invoiceId: invoice.id,
+        };
+    },
+    async rollback({ prisma }, { createInvoiceEntity: { invoiceId } }) {
+        return await prisma.stripeInvoice.delete({
+            where: { id: invoiceId },
+        });
+    },
+});

--- a/src/lib/modules/accounts/service/service/billing/handle-membership-plan-payment/transaction/createPlanEntity.ts
+++ b/src/lib/modules/accounts/service/service/billing/handle-membership-plan-payment/transaction/createPlanEntity.ts
@@ -1,0 +1,40 @@
+import { PlanStatus } from '@prisma/client';
+import { HandleMembershipPlanPayment } from '@/lib/modules/accounts/features/billing';
+import { HandleMembershipPlanPaymentTransaction } from './definition';
+
+interface CreateSubscriptionEntityFactory {
+    (
+        params: HandleMembershipPlanPayment.Input
+    ): HandleMembershipPlanPaymentTransaction['createPlanEntity'];
+}
+
+export const factory: CreateSubscriptionEntityFactory = ({
+    startDate,
+    endDate,
+    priceId: stripePriceId,
+    stripeCustomerId,
+    stripeSubscriptionId,
+    seats,
+    coveredSessions,
+}) => ({
+    async commit({ prisma }, { getAccount: { accountId, accountOwnerId } }) {
+        const { id: planId } = await prisma.plan.create({
+            data: {
+                startDate,
+                endDate,
+                status: PlanStatus.active,
+                billingUserId: accountOwnerId,
+                accountId,
+                stripeCustomerId,
+                stripeSubscriptionId,
+                stripePriceId,
+                seats,
+                coveredSessions,
+            },
+        });
+        return { planId };
+    },
+    async rollback({ prisma }, { createPlanEntity: { planId } }) {
+        return prisma.plan.delete({ where: { id: planId } });
+    },
+});

--- a/src/lib/modules/accounts/service/service/billing/handle-membership-plan-payment/transaction/definition.ts
+++ b/src/lib/modules/accounts/service/service/billing/handle-membership-plan-payment/transaction/definition.ts
@@ -1,0 +1,21 @@
+import * as z from 'zod';
+import { TransactionDefinition } from '@/lib/shared/utils/transaction/transaction.v1';
+import { AccountsServiceParams as Context } from '../../../params';
+
+export const handleMembershipPlanPaymentTransactionDefinition = z.object({
+    getAccount: z.object({
+        accountId: z.string(),
+        accountOwnerId: z.string(),
+    }),
+    createPlanEntity: z.object({
+        planId: z.string(),
+    }),
+    createInvoiceEntity: z.object({
+        invoiceId: z.string(),
+    }),
+});
+
+export type HandleMembershipPlanPaymentTransaction = TransactionDefinition<
+    Context,
+    typeof handleMembershipPlanPaymentTransactionDefinition.shape
+>;

--- a/src/lib/modules/accounts/service/service/billing/handle-membership-plan-payment/transaction/getAccount.ts
+++ b/src/lib/modules/accounts/service/service/billing/handle-membership-plan-payment/transaction/getAccount.ts
@@ -1,0 +1,31 @@
+import { HandleMembershipPlanPayment } from '@/lib/modules/accounts/features/billing';
+import { HandleMembershipPlanPaymentTransaction } from './definition';
+
+interface GetTherifyIdentifiersFactory {
+    (
+        params: HandleMembershipPlanPayment.Input
+    ): HandleMembershipPlanPaymentTransaction['getAccount'];
+}
+
+export const factory: GetTherifyIdentifiersFactory = ({
+    stripeCustomerId,
+}) => ({
+    async commit({ prisma }) {
+        const { managedAccount, id: accountOwnerId } =
+            await prisma.user.findUniqueOrThrow({
+                where: { stripeCustomerId },
+                select: {
+                    id: true,
+                    managedAccount: { select: { id: true } },
+                },
+            });
+        const accountId = managedAccount?.id;
+        if (!accountId) {
+            throw new Error('No account found for customer.');
+        }
+        return { accountId, accountOwnerId };
+    },
+    async rollback() {
+        return;
+    },
+});

--- a/src/lib/modules/accounts/service/service/billing/handle-membership-plan-payment/transaction/index.ts
+++ b/src/lib/modules/accounts/service/service/billing/handle-membership-plan-payment/transaction/index.ts
@@ -1,0 +1,4 @@
+export * as GetAccount from './getAccount';
+export * as CreatePlanEntity from './createPlanEntity';
+export * as CreateInvoiceEntity from './createInvoiceEntity';
+export * from './definition';

--- a/src/lib/modules/webhooks/services/stripe/event-handlers/invoices/paid/handlers/handleMembershipPayment.ts
+++ b/src/lib/modules/webhooks/services/stripe/event-handlers/invoices/paid/handlers/handleMembershipPayment.ts
@@ -6,6 +6,7 @@ import {
     NodeEnvironment,
     PRODUCTS,
 } from '@/lib/shared/types';
+import { LineItem } from '@/lib/shared/vendors/stripe/types/lineItem';
 
 const COVERED_COACHING_SESSION = getProductsByEnvironment(
     process.env.VERCEL_ENV as NodeEnvironment
@@ -25,7 +26,13 @@ export const handleMembershipPayment = async ({
 }: HandlePaymentInput) => {
     const [item1, item2] = invoice.lines.data;
 
-    const { plan, coveredSessions } = isValidMembershipPriceId(
+    const {
+        plan,
+        coveredSessions,
+    }: {
+        plan: LineItem;
+        coveredSessions: LineItem | undefined;
+    } = isValidMembershipPriceId(
         item1.price.id,
         process.env.VERCEL_ENV as NodeEnvironment
     )
@@ -45,7 +52,7 @@ export const handleMembershipPayment = async ({
         throw new Error('Invalid covered sessions price id');
     }
     const numberOfCoveredSessions =
-        coveredSessions?.quantity && coveredSessions.quantity > 1
+        !!coveredSessions?.quantity && coveredSessions.quantity > 1
             ? Math.floor(coveredSessions.quantity / plan.quantity)
             : coveredSessions?.quantity ?? 0;
     if (isNaN(numberOfCoveredSessions)) {

--- a/src/lib/modules/webhooks/services/stripe/event-handlers/invoices/paid/handlers/handleMembershipPayment.ts
+++ b/src/lib/modules/webhooks/services/stripe/event-handlers/invoices/paid/handlers/handleMembershipPayment.ts
@@ -1,0 +1,74 @@
+import { StripeInvoice, StripeUtils } from '@/lib/shared/vendors/stripe';
+import { AccountsService } from '@/lib/modules/accounts/service';
+import {
+    getProductsByEnvironment,
+    isValidMembershipPriceId,
+    NodeEnvironment,
+    PRODUCTS,
+} from '@/lib/shared/types';
+
+const COVERED_COACHING_SESSION = getProductsByEnvironment(
+    process.env.VERCEL_ENV as NodeEnvironment
+)[PRODUCTS.COVERED_COACHING_SESSION];
+
+interface HandlePaymentInput {
+    invoice: StripeInvoice.Type;
+    accounts: AccountsService;
+    customerId: string;
+    subscriptionId: string;
+}
+export const handleMembershipPayment = async ({
+    invoice,
+    accounts,
+    customerId: stripeCustomerId,
+    subscriptionId: stripeSubscriptionId,
+}: HandlePaymentInput) => {
+    const [item1, item2] = invoice.lines.data;
+
+    const { plan, coveredSessions } = isValidMembershipPriceId(
+        item1.price.id,
+        process.env.VERCEL_ENV as NodeEnvironment
+    )
+        ? { plan: item1, coveredSessions: item2 }
+        : { plan: item2, coveredSessions: item1 };
+    const isPlanIdValid = isValidMembershipPriceId(
+        plan.price.id,
+        process.env.VERCEL_ENV as NodeEnvironment
+    );
+    const isSessionIdValid =
+        coveredSessions === undefined ||
+        coveredSessions.price.id === COVERED_COACHING_SESSION.PRICES.DEFAULT;
+    if (!isPlanIdValid) {
+        throw new Error('Invalid membership price id');
+    }
+    if (!isSessionIdValid) {
+        throw new Error('Invalid covered sessions price id');
+    }
+    const numberOfCoveredSessions =
+        coveredSessions?.quantity && coveredSessions.quantity > 1
+            ? Math.floor(coveredSessions.quantity / plan.quantity)
+            : coveredSessions?.quantity ?? 0;
+    if (isNaN(numberOfCoveredSessions)) {
+        throw new Error('Unable to calculate number of covered sessions');
+    }
+    return await accounts.billing.handleMembershipPlanPayment({
+        startDate: StripeUtils.getDateFromStripeTimestamp(
+            plan.period.start
+        ).toISOString(),
+        endDate: StripeUtils.getDateFromStripeTimestamp(
+            plan.period.end
+        ).toISOString(),
+        stripeCustomerId,
+        stripeSubscriptionId,
+        priceId: plan.price.id,
+        invoiceStatus: invoice.status,
+        invoiceId: invoice.id,
+        invoiceTotal: invoice.total,
+        invoiceAmountDue: invoice.amount_due,
+        invoiceAmountPaid: invoice.amount_paid,
+        invoiceAmountRemaining: invoice.amount_remaining,
+        invoicePdf: invoice.invoicePdf,
+        seats: plan.quantity,
+        coveredSessions: numberOfCoveredSessions,
+    });
+};

--- a/src/lib/modules/webhooks/services/stripe/event-handlers/invoices/paid/handlers/index.ts
+++ b/src/lib/modules/webhooks/services/stripe/event-handlers/invoices/paid/handlers/index.ts
@@ -1,3 +1,4 @@
 export * from './handlePlanChange';
 export * from './handleGroupPracticePayment';
 export * from './handleOneTimePayment';
+export * from './handleMembershipPayment';

--- a/src/lib/shared/types/products/products.ts
+++ b/src/lib/shared/types/products/products.ts
@@ -111,3 +111,15 @@ export function isValidTherifyPriceId(
     });
     return prices.includes(id);
 }
+
+export function isValidMembershipPriceId(
+    id: string,
+    environment: NodeEnvironment
+) {
+    const products = getProductsByEnvironment(environment);
+    const prices = [
+        ...Object.values(products[PRODUCTS.GROUP_MEMBER_PLAN].PRICES),
+        ...Object.values(products[PRODUCTS.INDIVIDUAL_MEMBER_PLAN].PRICES),
+    ];
+    return prices.includes(id);
+}


### PR DESCRIPTION
# Description
Adds webhook and `accounts.billing` service support to identify and handle plan payments.
- Adds `invoice.paid` handler logic to identify membership payments 
- Hands membership payments to `accounts.billing.handleMembershipPlanPayment` method
- Creates membership plans

# Closes issue(s)

# How to test / repro
Create plans

# Screenshots

# Changes include

-   [ ] Bugfix (non-breaking change that solves an issue)
-   [ ] New feature (non-breaking change that adds functionality)
-   [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Checklist

-   [ ] I have tested this code
-   [ ] I have updated the Readme

# Other comments
