### PR TITLE
chore: remove therapy results from individuals plan

### DIFF
--- a/src/lib/modules/directory/features/provider-search/input.ts
+++ b/src/lib/modules/directory/features/provider-search/input.ts
@@ -1,10 +1,11 @@
-import { Country, Region, UNITED_STATES } from '@/lib/shared/types';
+import { Country, Region } from '@/lib/shared/types';
 import { SelfAssessment } from '@/lib/shared/types/self-assessment';
 import * as z from 'zod';
 
 export const schema = z.object({
     state: z.enum(Region.ENTRIES),
     country: z.enum(Country.ENTRIES),
+    memberId: z.string(),
     memberPreferences: z
         .object({
             insuranceProvider: z.string().optional(),

--- a/src/lib/modules/members/service/get-directory-page-props/getDirectoryPageProps.ts
+++ b/src/lib/modules/members/service/get-directory-page-props/getDirectoryPageProps.ts
@@ -60,6 +60,7 @@ export function factory(params: MembersServiceParams) {
                 directoryService.executeProviderSearch({
                     state: memberProfile.state as Region.Type,
                     country: memberProfile.country as Country.Country,
+                    memberId: session.user.sub,
                     selfAssessment,
                 }),
                 params.prisma.memberFavorites.findMany({

--- a/src/lib/sitemap/menus/member-menu/links.ts
+++ b/src/lib/sitemap/menus/member-menu/links.ts
@@ -46,6 +46,7 @@ export const CHAT: NavigationLink = {
 };
 
 export const BILLING_AND_PAYMENTS: NavigationLink = {
+    icon: NAVIGATION_ICON.BILLING,
     displayName: 'Billing & Payments',
     path: URL_PATHS.MEMBERS.ACCOUNT.BILLING_AND_PAYMENTS,
 };

--- a/src/lib/sitemap/menus/member-menu/menu.tsx
+++ b/src/lib/sitemap/menus/member-menu/menu.tsx
@@ -9,7 +9,6 @@ import {
     BILLING_AND_PAYMENTS,
 } from './links';
 import { LOGOUT } from '../accountLinks';
-import { NavigationLink } from '../../types';
 
 export const MEMBER_MAIN_MENU = [
     // HOME,
@@ -21,13 +20,14 @@ export const MEMBER_MAIN_MENU = [
 
 export const MEMBER_SECONDARY_MENU = [
     // { ...ACCOUNT, icon: undefined },
-    BILLING_AND_PAYMENTS,
+    { ...BILLING_AND_PAYMENTS, icon: undefined },
     { ...THERIFY_WEBSITE, icon: undefined },
     LOGOUT,
 ] as const;
 
 export const MEMBER_MOBILE_MENU = [
     ...MEMBER_MAIN_MENU,
+    BILLING_AND_PAYMENTS,
     THERIFY_WEBSITE,
     // ACCOUNT
 ] as const;
@@ -38,8 +38,7 @@ export const getMemberMenu = (hasChatEnabled: boolean) => [
 ];
 
 export const getMemberMobileMenu = (hasChatEnabled: boolean) => [
-    ...MEMBER_MAIN_MENU,
+    ...MEMBER_MOBILE_MENU,
     ...(hasChatEnabled ? [CHAT] : []),
-    THERIFY_WEBSITE,
     // ACCOUNT
 ];

--- a/src/pages/members/account/billing.tsx
+++ b/src/pages/members/account/billing.tsx
@@ -204,25 +204,36 @@ export default function BillingPage({
                                 </Paragraph>
                                 {accountDetails && (
                                     <>
-                                        <Paragraph>
-                                            Usage:{' '}
-                                            {`${accountDetails.claimedSeats} ${
-                                                accountDetails.claimedSeats ===
-                                                1
-                                                    ? 'seat'
-                                                    : 'seats'
-                                            } claimed of ${
-                                                accountDetails.totalSeats
-                                            } total ${
-                                                accountDetails.totalSeats === 1
-                                                    ? 'seat'
-                                                    : 'seats'
-                                            }`}
-                                        </Paragraph>
+                                        {accountDetails.totalSeats > 1 && (
+                                            <Paragraph>
+                                                Usage:{' '}
+                                                {`${
+                                                    accountDetails.claimedSeats
+                                                } ${
+                                                    accountDetails.claimedSeats ===
+                                                    1
+                                                        ? 'seat'
+                                                        : 'seats'
+                                                } claimed of ${
+                                                    accountDetails.totalSeats
+                                                } total ${
+                                                    accountDetails.totalSeats ===
+                                                    1
+                                                        ? 'seat'
+                                                        : 'seats'
+                                                }`}
+                                            </Paragraph>
+                                        )}
 
                                         <Paragraph>
-                                            Covered Sessions Per seat:{' '}
-                                            {accountDetails.coveredSessions}
+                                            Covered Sessions{' '}
+                                            {accountDetails.totalSeats > 1 &&
+                                                'per seat '}
+                                            {getBillingCycleDisplayText(
+                                                user.plan.startDate,
+                                                user.plan.endDate
+                                            )}
+                                            : {accountDetails.coveredSessions}
                                         </Paragraph>
                                     </>
                                 )}
@@ -323,6 +334,24 @@ const getBillingCycle = (
             return '' as 'Month';
     }
 };
+const getBillingCycleDisplayText = (startDate: string, endDate: string) => {
+    const months = differenceInCalendarMonths(
+        new Date(endDate),
+        new Date(startDate)
+    );
+
+    switch (months) {
+        case 1:
+            return 'per month';
+        case 6:
+            return 'every 6 months';
+        case 12:
+            return 'per year';
+        default:
+            return '';
+    }
+};
+
 const StyledRegistrationLink = styled(Link)(({ theme }) => ({
     ...theme.typography.body2,
     padding: theme.spacing(1),


### PR DESCRIPTION
# Description
When a member signs up as an individual plan holder (a plan with 1 seat), they should not have access to therapists. 
- Checks plan.seats before allowing therapis profiles in directory and self-assessment results
- Minor UI improvements on member billing page

# Closes issue(s)

# How to test / repro

# Screenshots
![image](https://user-images.githubusercontent.com/25045075/232350271-652edd63-d146-43dc-a801-a3ec66a66737.png)

# Changes include

-   [ ] Bugfix (non-breaking change that solves an issue)
-   [ ] New feature (non-breaking change that adds functionality)
-   [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Checklist

-   [ ] I have tested this code
-   [ ] I have updated the Readme

# Other comments
