### PR TITLE
chore: calculate remaining sessions

### DIFF
--- a/src/lib/modules/accounts/service/billing/handle-reimbursement-submission/transaction/claimSession.ts
+++ b/src/lib/modules/accounts/service/billing/handle-reimbursement-submission/transaction/claimSession.ts
@@ -12,7 +12,7 @@ export const factory: GetTherifyUserDetailsFactory = ({ submissionId }) => ({
         { prisma },
         {
             getMemberDetails: { memberId, planId, dateOfSession },
-            getProviderDetails: { providerProfileId },
+            getProviderDetails: { providerProfileId, practiceId },
         }
     ) {
         const { id } = await prisma.redeemedSession.create({
@@ -20,6 +20,7 @@ export const factory: GetTherifyUserDetailsFactory = ({ submissionId }) => ({
                 planId,
                 memberId,
                 profileId: providerProfileId,
+                practiceId,
                 status: RedeemedSessionStatus.claimed,
                 jotformSubmissionId: submissionId,
                 dateOfSession,

--- a/src/lib/modules/accounts/service/billing/handle-reimbursement-submission/transaction/definition.ts
+++ b/src/lib/modules/accounts/service/billing/handle-reimbursement-submission/transaction/definition.ts
@@ -10,6 +10,7 @@ export const handleReimbursementSubmissionDefinition = z.object({
     }),
     getProviderDetails: z.object({
         providerProfileId: z.string(),
+        practiceId: z.string(),
     }),
     claimSession: z.object({
         coveredSessionId: z.string(),

--- a/src/lib/modules/accounts/service/billing/handle-reimbursement-submission/transaction/getProviderDetails.ts
+++ b/src/lib/modules/accounts/service/billing/handle-reimbursement-submission/transaction/getProviderDetails.ts
@@ -11,15 +11,24 @@ export const factory: GetTherifyUserDetailsFactory = ({
     providerProfileId,
 }) => ({
     async commit({ prisma }) {
-        const { id } = await prisma.providerProfile.findUniqueOrThrow({
-            where: { id: providerProfileId },
-            select: {
-                id: true,
-            },
-        });
-
+        const { id, practiceProfile } =
+            await prisma.providerProfile.findUniqueOrThrow({
+                where: { id: providerProfileId },
+                select: {
+                    id: true,
+                    practiceProfile: {
+                        select: {
+                            practiceId: true,
+                        },
+                    },
+                },
+            });
+        if (!practiceProfile?.practiceId) {
+            throw new Error('Provider is not associated with a practice');
+        }
         return {
             providerProfileId: id,
+            practiceId: practiceProfile.practiceId,
         };
     },
     async rollback() {

--- a/src/lib/modules/providers/components/Clients/ClientList/ui/ClientListItem.tsx
+++ b/src/lib/modules/providers/components/Clients/ClientList/ui/ClientListItem.tsx
@@ -48,6 +48,8 @@ export const ClientListItem = ({
         connectionRequest.connectionStatus === ConnectionStatus.pending;
     const isAccepted =
         connectionRequest.connectionStatus === ConnectionStatus.accepted;
+    const hasRemainingCoveredSessions =
+        connectionRequest.member.plan?.remainingSessions ?? 0 > 0;
     const mobileActions = [
         ...(isPending
             ? [
@@ -74,11 +76,15 @@ export const ClientListItem = ({
         ...(isSmallScreen ? mobileActions : []),
         ...(isAccepted
             ? [
-                  {
-                      text: 'Reimbursement Request',
-                      icon: <PaidOutlined />,
-                      onClick: onReimbursmentRequest,
-                  },
+                  ...(hasRemainingCoveredSessions
+                      ? [
+                            {
+                                text: 'Reimbursement Request',
+                                icon: <PaidOutlined />,
+                                onClick: onReimbursmentRequest,
+                            },
+                        ]
+                      : []),
                   ...(onInvoiceClient
                       ? [
                             {

--- a/src/lib/modules/providers/components/Clients/ClientList/ui/ClientListItem.tsx
+++ b/src/lib/modules/providers/components/Clients/ClientList/ui/ClientListItem.tsx
@@ -48,6 +48,8 @@ export const ClientListItem = ({
         connectionRequest.connectionStatus === ConnectionStatus.pending;
     const isAccepted =
         connectionRequest.connectionStatus === ConnectionStatus.accepted;
+    const hasCoveredSessions =
+        connectionRequest.member.plan?.coveredSessions ?? 0 > 0;
     const hasRemainingCoveredSessions =
         connectionRequest.member.plan?.remainingSessions ?? 0 > 0;
     const mobileActions = [
@@ -76,15 +78,21 @@ export const ClientListItem = ({
         ...(isSmallScreen ? mobileActions : []),
         ...(isAccepted
             ? [
-                  ...(hasRemainingCoveredSessions
-                      ? [
-                            {
-                                text: 'Reimbursement Request',
-                                icon: <PaidOutlined />,
-                                onClick: onReimbursmentRequest,
-                            },
-                        ]
-                      : []),
+                  {
+                      disabled: !hasRemainingCoveredSessions,
+                      title: hasRemainingCoveredSessions
+                          ? `${
+                                connectionRequest.member.plan
+                                    ?.remainingSessions ?? 0
+                            } covered sessions remaining.`
+                          : `Member has no covered sessions${
+                                hasCoveredSessions ? ' remaining' : ''
+                            }.`,
+                      text: 'Reimbursement Request',
+                      icon: <PaidOutlined />,
+                      onClick: onReimbursmentRequest,
+                  },
+
                   ...(onInvoiceClient
                       ? [
                             {

--- a/src/lib/modules/providers/components/Clients/MemberDetailsModal/MemberDetailsModal.tsx
+++ b/src/lib/modules/providers/components/Clients/MemberDetailsModal/MemberDetailsModal.tsx
@@ -6,7 +6,7 @@ import {
 import { ConnectionRequest } from '@/lib/shared/types';
 import { Link } from '@mui/material';
 import { useTheme } from '@mui/material/styles';
-import { format } from 'date-fns';
+import { getCoveredSessionsMessage } from '../utils';
 
 interface MemberDetailsModalProps {
     connectionRequest: ConnectionRequest.Type;
@@ -37,14 +37,14 @@ export const MemberDetailsModal = ({
             </Paragraph>
             <Paragraph size={PARAGRAPH_SIZE.SMALL}>
                 {connectionRequest.member.plan &&
-                connectionRequest.member.plan.coveredSessions > 0
-                    ? `${connectionRequest.member.givenName} has ${
-                          connectionRequest.member.plan.coveredSessions
-                      } covered sessions from Therify until ${format(
-                          new Date(connectionRequest.member.plan.endDate),
-                          'MMMM dd, yyyy'
-                      )}`
-                    : 'No covered sessions. They will use their insurance benefit to cover sessions or pay out of pocket.'}
+                    getCoveredSessionsMessage({
+                        coveredSessions:
+                            connectionRequest.member.plan.coveredSessions,
+                        remainingSessions:
+                            connectionRequest.member.plan.remainingSessions,
+                        name: connectionRequest.member.givenName,
+                        planEndDate: connectionRequest.member.plan.endDate,
+                    })}
             </Paragraph>
             <Paragraph bold size={PARAGRAPH_SIZE.LARGE}>
                 Contact

--- a/src/lib/modules/providers/components/Clients/utils/getCoveredSessionsMessage.ts
+++ b/src/lib/modules/providers/components/Clients/utils/getCoveredSessionsMessage.ts
@@ -1,0 +1,26 @@
+import { format } from 'date-fns';
+
+interface GetCoveredSessionsMessageProps {
+    coveredSessions: number;
+    remainingSessions: number;
+    name: string;
+    planEndDate: string;
+}
+export const getCoveredSessionsMessage = ({
+    name,
+    coveredSessions,
+    remainingSessions,
+    planEndDate,
+}: GetCoveredSessionsMessageProps) => {
+    if (coveredSessions === 0) {
+        return `No covered sessions. ${name} will use their insurance benefit to cover sessions or pay out of pocket.`;
+    }
+    if (remainingSessions === 0) {
+        return `${name} has used all of their covered sessions from Therify. They will use their insurance benefit or pay out of pocket.`;
+    }
+
+    return `${name} has ${remainingSessions} covered sessions remaining from Therify until ${format(
+        new Date(planEndDate),
+        'MMMM dd, yyyy'
+    )}`;
+};

--- a/src/lib/modules/providers/components/Clients/utils/getCoveredSessionsMessage.ts
+++ b/src/lib/modules/providers/components/Clients/utils/getCoveredSessionsMessage.ts
@@ -19,7 +19,9 @@ export const getCoveredSessionsMessage = ({
         return `${name} has used all of their covered sessions from Therify. They will use their insurance benefit or pay out of pocket.`;
     }
 
-    return `${name} has ${remainingSessions} covered sessions remaining from Therify until ${format(
+    return `${name} has ${remainingSessions} covered ${
+        remainingSessions === 1 ? 'session' : 'sessions'
+    } remaining from Therify until ${format(
         new Date(planEndDate),
         'MMMM dd, yyyy'
     )}`;

--- a/src/lib/modules/providers/components/Clients/utils/index.ts
+++ b/src/lib/modules/providers/components/Clients/utils/index.ts
@@ -1,0 +1,1 @@
+export { getCoveredSessionsMessage } from './getCoveredSessionsMessage';

--- a/src/lib/shared/components/features/pages/PracticeClientListPage/PracticeClientListPage.tsx
+++ b/src/lib/shared/components/features/pages/PracticeClientListPage/PracticeClientListPage.tsx
@@ -500,6 +500,8 @@ const ClientListItem = ({
         connectionRequest.connectionStatus === ConnectionStatus.pending;
     const isAccepted =
         connectionRequest.connectionStatus === ConnectionStatus.accepted;
+    const hasCoveredSessions =
+        connectionRequest.member.plan?.coveredSessions ?? 0 > 0;
     const hasRemainingCoveredSessions =
         connectionRequest.member.plan?.remainingSessions ?? 0 > 0;
     const mobileActions = [
@@ -538,36 +540,40 @@ const ClientListItem = ({
                       text: 'Send Email',
                       onClick: onEmail,
                   },
-                  ...(hasRemainingCoveredSessions
-                      ? [
-                            {
-                                text: 'Reimbursement Request',
-                                icon: <PaidOutlined />,
-                                onClick: () => {
-                                    if (onReimbursementRequest) {
-                                        // feature flag is on
-                                        onReimbursementRequest();
-                                        return;
-                                    }
-                                    window.open(
-                                        formatReimbursementRequestUrl({
-                                            baseUrl: REIMBURSEMENT_REQUEST_URL,
-                                            designation:
-                                                providerProfile.designation,
-                                            connectionRequest: {
-                                                ...connectionRequest,
-                                                providerProfile: {
-                                                    ...providerProfile,
-                                                    practice,
-                                                },
-                                            },
-                                        }),
-                                        '_blank'
-                                    );
-                                },
-                            },
-                        ]
-                      : []),
+                  {
+                      disabled: !hasRemainingCoveredSessions,
+                      title: hasRemainingCoveredSessions
+                          ? `${
+                                connectionRequest.member.plan
+                                    ?.remainingSessions ?? 0
+                            } covered sessions remaining.`
+                          : `Member has no covered sessions${
+                                hasCoveredSessions ? ' remaining' : ''
+                            }.`,
+                      text: 'Reimbursement Request',
+                      icon: <PaidOutlined />,
+                      onClick: () => {
+                          if (onReimbursementRequest) {
+                              // feature flag is on
+                              onReimbursementRequest();
+                              return;
+                          }
+                          window.open(
+                              formatReimbursementRequestUrl({
+                                  baseUrl: REIMBURSEMENT_REQUEST_URL,
+                                  designation: providerProfile.designation,
+                                  connectionRequest: {
+                                      ...connectionRequest,
+                                      providerProfile: {
+                                          ...providerProfile,
+                                          practice,
+                                      },
+                                  },
+                              }),
+                              '_blank'
+                          );
+                      },
+                  },
                   ...(onTerminate
                       ? [
                             // TODO: We need to be able to handle this without breaking confidentiality

--- a/src/lib/shared/components/features/pages/PracticeClientListPage/PracticeClientListPage.tsx
+++ b/src/lib/shared/components/features/pages/PracticeClientListPage/PracticeClientListPage.tsx
@@ -500,6 +500,8 @@ const ClientListItem = ({
         connectionRequest.connectionStatus === ConnectionStatus.pending;
     const isAccepted =
         connectionRequest.connectionStatus === ConnectionStatus.accepted;
+    const hasRemainingCoveredSessions =
+        connectionRequest.member.plan?.remainingSessions ?? 0 > 0;
     const mobileActions = [
         ...(isPending
             ? [
@@ -536,31 +538,36 @@ const ClientListItem = ({
                       text: 'Send Email',
                       onClick: onEmail,
                   },
-                  {
-                      text: 'Reimbursement Request',
-                      icon: <PaidOutlined />,
-                      onClick: () => {
-                          if (onReimbursementRequest) {
-                              // feature flag is on
-                              onReimbursementRequest();
-                              return;
-                          }
-                          window.open(
-                              formatReimbursementRequestUrl({
-                                  baseUrl: REIMBURSEMENT_REQUEST_URL,
-                                  designation: providerProfile.designation,
-                                  connectionRequest: {
-                                      ...connectionRequest,
-                                      providerProfile: {
-                                          ...providerProfile,
-                                          practice,
-                                      },
-                                  },
-                              }),
-                              '_blank'
-                          );
-                      },
-                  },
+                  ...(hasRemainingCoveredSessions
+                      ? [
+                            {
+                                text: 'Reimbursement Request',
+                                icon: <PaidOutlined />,
+                                onClick: () => {
+                                    if (onReimbursementRequest) {
+                                        // feature flag is on
+                                        onReimbursementRequest();
+                                        return;
+                                    }
+                                    window.open(
+                                        formatReimbursementRequestUrl({
+                                            baseUrl: REIMBURSEMENT_REQUEST_URL,
+                                            designation:
+                                                providerProfile.designation,
+                                            connectionRequest: {
+                                                ...connectionRequest,
+                                                providerProfile: {
+                                                    ...providerProfile,
+                                                    practice,
+                                                },
+                                            },
+                                        }),
+                                        '_blank'
+                                    );
+                                },
+                            },
+                        ]
+                      : []),
                   ...(onTerminate
                       ? [
                             // TODO: We need to be able to handle this without breaking confidentiality

--- a/src/lib/shared/components/features/pages/PracticeClientListPage/PracticeClientListPage.tsx
+++ b/src/lib/shared/components/features/pages/PracticeClientListPage/PracticeClientListPage.tsx
@@ -31,7 +31,7 @@ import {
     EmailOutlined,
 } from '@mui/icons-material';
 import { ConnectionStatus } from '@prisma/client';
-import { format } from 'date-fns';
+import { getCoveredSessionsMessage } from '@/lib/modules/providers/components/Clients/utils';
 
 const REIMBURSEMENT_REQUEST_URL =
     process.env.NEXT_PUBLIC_VERCEL_ENV === 'production'
@@ -348,16 +348,17 @@ export function PracticeClientListPage({
                     </Paragraph>
                     <Paragraph size={PARAGRAPH_SIZE.SMALL}>
                         {targetConnection.member.plan &&
-                        targetConnection.member.plan.coveredSessions > 0
-                            ? `${targetConnection.member.givenName} has ${
-                                  targetConnection.member.plan.coveredSessions
-                              } covered sessions from Therify until ${format(
-                                  new Date(
-                                      targetConnection.member.plan.endDate
-                                  ),
-                                  'MMMM dd, yyyy'
-                              )}`
-                            : 'No covered sessions. They will likely be using their insurance benefit to cover session costs or will pay out of pocket.'}
+                            getCoveredSessionsMessage({
+                                coveredSessions:
+                                    targetConnection.member.plan
+                                        .coveredSessions,
+                                remainingSessions:
+                                    targetConnection.member.plan
+                                        .remainingSessions,
+                                name: targetConnection.member.givenName,
+                                planEndDate:
+                                    targetConnection.member.plan.endDate,
+                            })}
                     </Paragraph>
                     <Paragraph bold size={PARAGRAPH_SIZE.LARGE}>
                         Contact

--- a/src/lib/shared/types/connection-request/connectionRequest.ts
+++ b/src/lib/shared/types/connection-request/connectionRequest.ts
@@ -40,6 +40,7 @@ export const schema = z.object({
                 endDate: z.string(),
                 status: PlanSchema.shape.status,
                 coveredSessions: z.number(),
+                remainingSessions: z.number(),
             })
             .nullable(),
     }),

--- a/src/pages/api/dev/create-redeemed-session.ts
+++ b/src/pages/api/dev/create-redeemed-session.ts
@@ -26,13 +26,13 @@ export default async function handler(
     req: NextApiRequest,
     res: NextApiResponse<any>
 ) {
-    if (req.method !== 'POST' || API_KEY === 'undefined') {
+    if (req.method !== 'POST' || API_KEY === undefined) {
         return res.status(404).end();
     }
-    // if (req.headers.api_key !== API_KEY) {
-    //     console.log('Invalid API key', { key: req.headers.api_key });
-    //     return res.status(400).end();
-    // }
+    if (req.headers.api_key !== API_KEY) {
+        console.log('Invalid API key', { key: req.headers.api_key });
+        return res.status(400).end();
+    }
     const input = redemeedSessionInputSchema.parse(req.body);
     const dateOfSession = new Date(input.dateOfSession);
     if (!isValid(dateOfSession)) {

--- a/src/pages/api/dev/create-redeemed-session.ts
+++ b/src/pages/api/dev/create-redeemed-session.ts
@@ -1,0 +1,52 @@
+// Next.js API route support: https://nextjs.org/docs/api-routes/introduction
+import { prisma } from '@/lib/prisma';
+import type { NextApiRequest, NextApiResponse } from 'next';
+import { get } from 'env-var';
+import { RedeemedSessionStatus, Role } from '@prisma/client';
+import * as z from 'zod';
+import { isValid } from 'date-fns';
+
+const redemeedSessionInputSchema = z.object({
+    memberId: z.string(),
+    profileId: z.string().optional(),
+    practiceId: z.string().optional(),
+    jotformSubmissionId: z.string(),
+    planId: z.string(),
+    status: z.enum([
+        RedeemedSessionStatus.available,
+        RedeemedSessionStatus.voided,
+        RedeemedSessionStatus.claimed,
+    ]),
+    dateOfSession: z.string(),
+});
+
+const API_KEY = get('CREATE_REDEEMED_SESSION').asString();
+
+export default async function handler(
+    req: NextApiRequest,
+    res: NextApiResponse<any>
+) {
+    if (req.method !== 'POST' || API_KEY === undefined) {
+        return res.status(404).end();
+    }
+    if (req.headers.api_key !== API_KEY) {
+        console.log('Invalid API key', { key: req.headers.api_key });
+        return res.status(400).end();
+    }
+    const input = redemeedSessionInputSchema.parse(req.body);
+    const dateOfSession = new Date(input.dateOfSession);
+    if (!isValid(dateOfSession)) {
+        throw new Error('Invalid date of session');
+    }
+    const redeemedSession = await prisma.redeemedSession.create({
+        data: {
+            ...input,
+            createdAt: new Date(),
+            updatedAt: new Date(),
+            dateOfSession,
+        },
+    });
+    return res.status(200).json({
+        redeemedSession,
+    });
+}

--- a/src/pages/api/dev/create-redeemed-session.ts
+++ b/src/pages/api/dev/create-redeemed-session.ts
@@ -20,7 +20,7 @@ const redemeedSessionInputSchema = z.object({
     dateOfSession: z.string(),
 });
 
-const API_KEY = get('THERIFYDEV_CREATE_REDEEMED_SESSION').asString();
+const API_KEY = get('THERIFY_DEV_CREATE_REDEEMED_SESSION').asString();
 
 export default async function handler(
     req: NextApiRequest,

--- a/src/pages/api/dev/create-redeemed-session.ts
+++ b/src/pages/api/dev/create-redeemed-session.ts
@@ -20,19 +20,19 @@ const redemeedSessionInputSchema = z.object({
     dateOfSession: z.string(),
 });
 
-const API_KEY = get('CREATE_REDEEMED_SESSION').asString();
+const API_KEY = get('THERIFYDEV_CREATE_REDEEMED_SESSION').asString();
 
 export default async function handler(
     req: NextApiRequest,
     res: NextApiResponse<any>
 ) {
-    if (req.method !== 'POST' || API_KEY === undefined) {
+    if (req.method !== 'POST' || API_KEY === 'undefined') {
         return res.status(404).end();
     }
-    if (req.headers.api_key !== API_KEY) {
-        console.log('Invalid API key', { key: req.headers.api_key });
-        return res.status(400).end();
-    }
+    // if (req.headers.api_key !== API_KEY) {
+    //     console.log('Invalid API key', { key: req.headers.api_key });
+    //     return res.status(400).end();
+    // }
     const input = redemeedSessionInputSchema.parse(req.body);
     const dateOfSession = new Date(input.dateOfSession);
     if (!isValid(dateOfSession)) {

--- a/src/pages/api/dev/remove-connected-stripe-account.ts
+++ b/src/pages/api/dev/remove-connected-stripe-account.ts
@@ -4,7 +4,7 @@ import { get } from 'env-var';
 import { vendorStripe } from '@/lib/shared/vendors/stripe';
 import { prisma } from '@/lib/prisma';
 
-const API_KEY = get('REMOVE_STRIPE_CONNECT_ACCOUNT').asString();
+const API_KEY = get('THERIFY_DEV_REMOVE_STRIPE_CONNECT_ACCOUNT').asString();
 
 export default async function handler(
     req: NextApiRequest,


### PR DESCRIPTION
# Description
- Adds `remainingSessions` to Connection Requests. 
- Improves `Clients` UI to communicate remaining sessions
- Disables reimbursement request action list item when no remaining sessions.
- Adds `{baseUrl}/api/dev/create-redeemed-session` endpoint to manually create a redeemed session

# Closes issue(s)
NA

# How to test / repro

# Screenshots
### Remaining sessions message - None left
<img width="745" alt="image" src="https://user-images.githubusercontent.com/25045075/233806116-b21460bd-3edd-4289-8cf1-0a62e75d6cee.png">

### Remaining sessions message - Sessions left
<img width="735" alt="image" src="https://user-images.githubusercontent.com/25045075/233806139-6ecddb91-8d7e-4fd7-8069-89152d9a7823.png">

### Reimbursement action enabled w/ title
<img width="360" alt="image" src="https://user-images.githubusercontent.com/25045075/233806149-ceae860d-4c52-4d9d-a0b6-75ff000ff700.png">

### Reimbursement action disabled w/ title
<img width="454" alt="image" src="https://user-images.githubusercontent.com/25045075/233806198-0253c71e-ad65-4e33-b037-18904eab7c92.png">


# Changes include

-   [ ] Bugfix (non-breaking change that solves an issue)
-   [ ] New feature (non-breaking change that adds functionality)
-   [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Checklist

-   [ ] I have tested this code
-   [ ] I have updated the Readme

# Other comments
