### PR TITLE
feat: add client invoices UI

### DIFF
--- a/src/lib/modules/accounts/components/hooks/use-session-invoicing/index.ts
+++ b/src/lib/modules/accounts/components/hooks/use-session-invoicing/index.ts
@@ -1,1 +1,2 @@
 export * from './useSessionInvoicing';
+export type { OnVoidInvoiceCallback } from './useSessionInvoicing';

--- a/src/lib/modules/accounts/components/hooks/use-session-invoicing/useSessionInvoicing.tsx
+++ b/src/lib/modules/accounts/components/hooks/use-session-invoicing/useSessionInvoicing.tsx
@@ -28,6 +28,8 @@ export const useSessionInvoicing = (providerId: string) => {
     const [showModal, setShowModal] = useState(false);
     const [member, setMember] = useState<InvoicedMember | null>(null);
     const [sessionDate, setSessionDate] = useState<Date | null>(null);
+    const [createSessionSuccessCallbackFn, setCreateSessionSuccessCbFn] =
+        useState<(() => void) | null>(null);
     let voidSessionCallbackFn: OnVoidInvoiceCallback | null = null;
 
     const closeModal = () => {
@@ -42,10 +44,13 @@ export const useSessionInvoicing = (providerId: string) => {
         onSuccess: ({ invoiceId, errors }) => {
             if (invoiceId) {
                 closeModal();
-                return createAlert({
+                createAlert({
                     type: 'success',
                     title: 'Session invoice created',
                 });
+                createSessionSuccessCallbackFn?.();
+                setCreateSessionSuccessCbFn(null);
+                return;
             }
             const [error] = errors;
             if (error) {
@@ -114,9 +119,13 @@ export const useSessionInvoicing = (providerId: string) => {
         });
 
     return {
-        onInvoiceClient: (member: InvoicedMember) => {
+        onInvoiceClient: (
+            member: InvoicedMember,
+            successCallback?: () => void
+        ) => {
             setMember(member);
             setShowModal(true);
+            setCreateSessionSuccessCbFn(() => successCallback ?? null);
         },
         onVoidInvoice: (
             input: VoidCoachingSessionInvoice.Input,

--- a/src/lib/modules/accounts/features/billing/get-provider-session-invoices-by-member-id/index.ts
+++ b/src/lib/modules/accounts/features/billing/get-provider-session-invoices-by-member-id/index.ts
@@ -1,0 +1,5 @@
+export { schema as inputSchema } from './input';
+export { schema as outputSchema } from './output';
+export type { Input } from './input';
+export type { Output } from './output';
+export { ROUTE as TRPC_ROUTE } from './trpc';

--- a/src/lib/modules/accounts/features/billing/get-provider-session-invoices-by-member-id/input.ts
+++ b/src/lib/modules/accounts/features/billing/get-provider-session-invoices-by-member-id/input.ts
@@ -1,0 +1,23 @@
+import { SessionInvoiceSchema } from '@/lib/shared/schema';
+import * as z from 'zod';
+
+export const schema = z.object({
+    memberId: z.string(),
+    providerId: z.string(),
+    status: SessionInvoiceSchema.shape.status.optional(),
+});
+
+export type Input = z.infer<typeof schema>;
+
+export const validate = (value: unknown): Input => {
+    return schema.parse(value);
+};
+
+export const isValid = (value: unknown): value is Input => {
+    try {
+        validate(value);
+        return true;
+    } catch {
+        return false;
+    }
+};

--- a/src/lib/modules/accounts/features/billing/get-provider-session-invoices-by-member-id/output.ts
+++ b/src/lib/modules/accounts/features/billing/get-provider-session-invoices-by-member-id/output.ts
@@ -1,0 +1,28 @@
+import * as z from 'zod';
+import { SessionInvoiceSchema, UserSchema } from '@/lib/shared/schema';
+
+export const schema = z.object({
+    invoices: SessionInvoiceSchema.extend({
+        member: UserSchema.pick({
+            id: true,
+            givenName: true,
+            surname: true,
+            emailAddress: true,
+        }),
+    }).array(),
+    errors: z.array(z.string()),
+});
+export type Output = z.infer<typeof schema>;
+
+export const validate = (value: unknown): Output => {
+    return schema.parse(value);
+};
+
+export const isValid = (value: unknown): value is Output => {
+    try {
+        validate(value);
+        return true;
+    } catch {
+        return false;
+    }
+};

--- a/src/lib/modules/accounts/features/billing/get-provider-session-invoices-by-member-id/trpc.ts
+++ b/src/lib/modules/accounts/features/billing/get-provider-session-invoices-by-member-id/trpc.ts
@@ -1,0 +1,2 @@
+export const ROUTE =
+    'billing.get-provider-session-invoice-by-member-id' as const;

--- a/src/lib/modules/accounts/features/billing/index.ts
+++ b/src/lib/modules/accounts/features/billing/index.ts
@@ -1,4 +1,5 @@
 export * as CreateCoachingSessionInvoice from './create-coaching-session-checkout';
+export * as GetProviderSessionInvoicesByMemberId from './get-provider-session-invoices-by-member-id';
 export * as CreateStripeConnectLoginUrl from './create-stripe-connect-login-url';
 export * as HandleGroupPracticePlanPayment from './handle-group-practice-plan-payment';
 export * as HandlePlanChange from './handle-plan-change';

--- a/src/lib/modules/accounts/features/billing/index.ts
+++ b/src/lib/modules/accounts/features/billing/index.ts
@@ -9,3 +9,4 @@ export * as RenewPlan from './renew-plan';
 export * as CancelPlan from './cancel-plan';
 export * as HandleReimbursementSubmission from './handle-reimbursement-submission';
 export * as HandleMembershipPlanPayment from './handle-membership-plan-payment';
+export * as VoidCoachingSessionInvoice from './void-coaching-session-invoice';

--- a/src/lib/modules/accounts/features/billing/void-coaching-session-invoice/index.ts
+++ b/src/lib/modules/accounts/features/billing/void-coaching-session-invoice/index.ts
@@ -1,0 +1,5 @@
+export { schema as inputSchema } from './input';
+export { schema as outputSchema } from './output';
+export type { Input } from './input';
+export type { Output } from './output';
+export { ROUTE as TRPC_ROUTE } from './trpc';

--- a/src/lib/modules/accounts/features/billing/void-coaching-session-invoice/input.ts
+++ b/src/lib/modules/accounts/features/billing/void-coaching-session-invoice/input.ts
@@ -1,0 +1,22 @@
+import * as z from 'zod';
+
+export const schema = z.object({
+    memberId: z.string(),
+    providerId: z.string(),
+    sessionInvoiceId: z.string(),
+});
+
+export type Input = z.infer<typeof schema>;
+
+export const validate = (value: unknown): Input => {
+    return schema.parse(value);
+};
+
+export const isValid = (value: unknown): value is Input => {
+    try {
+        validate(value);
+        return true;
+    } catch {
+        return false;
+    }
+};

--- a/src/lib/modules/accounts/features/billing/void-coaching-session-invoice/output.ts
+++ b/src/lib/modules/accounts/features/billing/void-coaching-session-invoice/output.ts
@@ -1,0 +1,20 @@
+import * as z from 'zod';
+
+export const schema = z.object({
+    voided: z.boolean(),
+    errors: z.array(z.string()),
+});
+export type Output = z.infer<typeof schema>;
+
+export const validate = (value: unknown): Output => {
+    return schema.parse(value);
+};
+
+export const isValid = (value: unknown): value is Output => {
+    try {
+        validate(value);
+        return true;
+    } catch {
+        return false;
+    }
+};

--- a/src/lib/modules/accounts/features/billing/void-coaching-session-invoice/trpc.ts
+++ b/src/lib/modules/accounts/features/billing/void-coaching-session-invoice/trpc.ts
@@ -1,0 +1,1 @@
+export const ROUTE = 'billing.void-coaching-session-invoice' as const;

--- a/src/lib/modules/accounts/routes/resolvers/index.ts
+++ b/src/lib/modules/accounts/routes/resolvers/index.ts
@@ -10,5 +10,6 @@ export { registerMemberResolver } from './register-member';
 export { handleStripeConnectOnboardingResolver } from './handle-stripe-connect-onboarding';
 export { createStripeConnectLoginUrlResolver } from './create-stripe-connect-login-url';
 export { createCoachingSessionInvoiceResolver } from './create-coaching-session-invoice';
+export { voidCoachingSessionInvoiceResolver } from './void-coaching-session-invoice';
 export { registerAccountOwnerResolver } from './register-account-owner';
 export { getAccountByOwnerIdResolver } from './get-account-by-owner-id';

--- a/src/lib/modules/accounts/routes/resolvers/void-coaching-session-invoice/index.ts
+++ b/src/lib/modules/accounts/routes/resolvers/void-coaching-session-invoice/index.ts
@@ -1,0 +1,1 @@
+export { resolve as voidCoachingSessionInvoiceResolver } from './resolver';

--- a/src/lib/modules/accounts/routes/resolvers/void-coaching-session-invoice/resolver.ts
+++ b/src/lib/modules/accounts/routes/resolvers/void-coaching-session-invoice/resolver.ts
@@ -1,0 +1,31 @@
+import { Context } from '@/lib/server/context';
+import { VoidCoachingSessionInvoice } from '@/lib/modules/accounts/features/billing';
+import { ProcedureResolver } from '@trpc/server/dist/declarations/src/internals/procedure';
+
+export const resolve: ProcedureResolver<
+    Context,
+    VoidCoachingSessionInvoice.Input,
+    VoidCoachingSessionInvoice.Output
+> = async function ({
+    input,
+    ctx,
+}): Promise<VoidCoachingSessionInvoice.Output> {
+    try {
+        const { voided } =
+            await ctx.accounts.billing.voidCoachingSessionInvoice(input);
+        return {
+            voided,
+            errors: [],
+        };
+    } catch (error) {
+        let errorMessage =
+            'Voiding Stripe session invoice failed with an unknown error.';
+        if (error instanceof Error) {
+            errorMessage = error.message;
+        }
+        return {
+            voided: false,
+            errors: [errorMessage],
+        };
+    }
+};

--- a/src/lib/modules/accounts/routes/router.ts
+++ b/src/lib/modules/accounts/routes/router.ts
@@ -30,12 +30,14 @@ import {
     handleAccountOnboardingResolver,
     registerAccountOwnerResolver,
     getAccountByOwnerIdResolver,
+    voidCoachingSessionInvoiceResolver,
 } from './resolvers';
 import { Context } from '../../../server/context';
 import {
     HandleStripeConnectOnboarding,
     CreateStripeConnectLoginUrl,
     CreateCoachingSessionInvoice,
+    VoidCoachingSessionInvoice,
 } from '../features/billing';
 import { GetAccountByOwnerId } from '../features';
 
@@ -105,6 +107,11 @@ export const router = trpc
         input: CreateCoachingSessionInvoice.inputSchema,
         output: CreateCoachingSessionInvoice.outputSchema,
         resolve: createCoachingSessionInvoiceResolver,
+    })
+    .mutation(VoidCoachingSessionInvoice.TRPC_ROUTE, {
+        input: VoidCoachingSessionInvoice.inputSchema,
+        output: VoidCoachingSessionInvoice.outputSchema,
+        resolve: voidCoachingSessionInvoiceResolver,
     })
     .mutation(SendEmailVerification.TRPC_ROUTE, {
         input: SendEmailVerification.inputSchema,

--- a/src/lib/modules/accounts/service/billing/billingFactory.ts
+++ b/src/lib/modules/accounts/service/billing/billingFactory.ts
@@ -12,12 +12,14 @@ import { HandleCoachingSessionInvoiceUpdated } from './handle-coaching-session-i
 import { HandleReimbursementSubmission } from './handle-reimbursement-submission';
 import { HandleMembershipPlanPayment } from './handle-membership-plan-payment';
 import { GetProviderSessionInvoicesByMemberId } from './get-provider-session-invoices-by-member-id';
+import { VoidCoachingSessionInvoice } from './void-coaching-session-invoice';
 
 export const factory = (context: AccountsServiceParams) => ({
     handleCoachingSessionPayment: HandleCoachingSessionPayment.factory(context),
     handleCoachingSessionInvoiceUpdated:
         HandleCoachingSessionInvoiceUpdated.factory(context),
     handleInvoiceSent: HandleInvoiceSent.factory(context),
+    voidCoachingSessionInvoice: VoidCoachingSessionInvoice.factory(context),
     handleMembershipPlanPayment: HandleMembershipPlanPayment.factory(context),
     handleGroupPracticePlanPayment:
         HandleGroupPracticePlanPayment.factory(context),

--- a/src/lib/modules/accounts/service/billing/billingFactory.ts
+++ b/src/lib/modules/accounts/service/billing/billingFactory.ts
@@ -11,6 +11,7 @@ import { HandleInvoiceSent } from './handle-invoice-sent';
 import { HandleCoachingSessionInvoiceUpdated } from './handle-coaching-session-invoice-updated';
 import { HandleReimbursementSubmission } from './handle-reimbursement-submission';
 import { HandleMembershipPlanPayment } from './handle-membership-plan-payment';
+import { GetProviderSessionInvoicesByMemberId } from './get-provider-session-invoices-by-member-id';
 
 export const factory = (context: AccountsServiceParams) => ({
     handleCoachingSessionPayment: HandleCoachingSessionPayment.factory(context),
@@ -27,6 +28,8 @@ export const factory = (context: AccountsServiceParams) => ({
         HandleStripeConnectOnboarding.factory(context),
     createStripeConnectLoginUrl: CreateStripeConnectLoginUrl.factory(context),
     createCoachingSessionInvoice: CreateCoachingSessionInvoice.factory(context),
+    getProviderSessionInvoicesByMemberId:
+        GetProviderSessionInvoicesByMemberId.factory(context),
     handleReimbursementSubmission:
         HandleReimbursementSubmission.factory(context),
 });

--- a/src/lib/modules/accounts/service/billing/create-coaching-session-invoice/createCoachingSessionInvoice.ts
+++ b/src/lib/modules/accounts/service/billing/create-coaching-session-invoice/createCoachingSessionInvoice.ts
@@ -5,7 +5,7 @@ import { Role } from '@prisma/client';
 
 const THERIFY_COACHING_FEE_IN_CENTS = 2000;
 export const factory =
-    ({ prisma, stripe, streamChat }: AccountsServiceParams) =>
+    ({ prisma, stripe }: AccountsServiceParams) =>
     async ({
         memberId,
         providerId,

--- a/src/lib/modules/accounts/service/billing/get-provider-session-invoices-by-member-id/getProviderSessionInvoicesByMemberId.ts
+++ b/src/lib/modules/accounts/service/billing/get-provider-session-invoices-by-member-id/getProviderSessionInvoicesByMemberId.ts
@@ -29,9 +29,7 @@ export const factory =
         });
         return {
             invoices: sessionInvoices.sort(
-                (a, b) =>
-                    (b.dateOfSession?.getTime() ?? 0) -
-                    (a.dateOfSession?.getTime() ?? 0)
+                (a, b) => b.createdAt.getTime() - a.createdAt.getTime()
             ),
         };
     };

--- a/src/lib/modules/accounts/service/billing/get-provider-session-invoices-by-member-id/getProviderSessionInvoicesByMemberId.ts
+++ b/src/lib/modules/accounts/service/billing/get-provider-session-invoices-by-member-id/getProviderSessionInvoicesByMemberId.ts
@@ -1,0 +1,37 @@
+import { GetProviderSessionInvoicesByMemberId } from '@/lib/modules/accounts/features/billing';
+import { AccountsServiceParams } from '../../params';
+
+export const factory =
+    ({ prisma }: AccountsServiceParams) =>
+    async ({
+        memberId,
+        providerId,
+        status,
+    }: GetProviderSessionInvoicesByMemberId.Input): Promise<
+        Pick<GetProviderSessionInvoicesByMemberId.Output, 'invoices'>
+    > => {
+        const sessionInvoices = await prisma.sessionInvoice.findMany({
+            where: {
+                providerId,
+                memberId,
+                status,
+            },
+            include: {
+                member: {
+                    select: {
+                        emailAddress: true,
+                        id: true,
+                        givenName: true,
+                        surname: true,
+                    },
+                },
+            },
+        });
+        return {
+            invoices: sessionInvoices.sort(
+                (a, b) =>
+                    (b.dateOfSession?.getTime() ?? 0) -
+                    (a.dateOfSession?.getTime() ?? 0)
+            ),
+        };
+    };

--- a/src/lib/modules/accounts/service/billing/get-provider-session-invoices-by-member-id/index.ts
+++ b/src/lib/modules/accounts/service/billing/get-provider-session-invoices-by-member-id/index.ts
@@ -1,0 +1,1 @@
+export * as GetProviderSessionInvoicesByMemberId from './getProviderSessionInvoicesByMemberId';

--- a/src/lib/modules/accounts/service/billing/void-coaching-session-invoice/index.ts
+++ b/src/lib/modules/accounts/service/billing/void-coaching-session-invoice/index.ts
@@ -1,0 +1,1 @@
+export * as VoidCoachingSessionInvoice from './voidCoachingSessionInvoice';

--- a/src/lib/modules/accounts/service/billing/void-coaching-session-invoice/voidCoachingSessionInvoice.ts
+++ b/src/lib/modules/accounts/service/billing/void-coaching-session-invoice/voidCoachingSessionInvoice.ts
@@ -11,7 +11,7 @@ export const factory =
     }: VoidCoachingSessionInvoice.Input): Promise<{
         voided: true;
     }> => {
-        const { status, invoice } =
+        const { status, invoice: stripeInvoice } =
             await prisma.sessionInvoice.findFirstOrThrow({
                 where: {
                     id: sessionInvoiceId,
@@ -34,7 +34,8 @@ export const factory =
                 "Session invoice cannot be voided in it's current state"
             );
         }
-        const { voided } = await stripe.voidInvoice(invoice.id);
+
+        const { voided } = await stripe.voidInvoice(stripeInvoice.invoiceId);
         return {
             voided,
         };

--- a/src/lib/modules/accounts/service/billing/void-coaching-session-invoice/voidCoachingSessionInvoice.ts
+++ b/src/lib/modules/accounts/service/billing/void-coaching-session-invoice/voidCoachingSessionInvoice.ts
@@ -1,0 +1,41 @@
+import { VoidCoachingSessionInvoice } from '@/lib/modules/accounts/features/billing';
+import { AccountsServiceParams } from '../../params';
+import { SessionInvoiceStatus } from '@prisma/client';
+
+export const factory =
+    ({ prisma, stripe }: AccountsServiceParams) =>
+    async ({
+        memberId,
+        providerId,
+        sessionInvoiceId,
+    }: VoidCoachingSessionInvoice.Input): Promise<{
+        voided: true;
+    }> => {
+        const { status, invoice } =
+            await prisma.sessionInvoice.findFirstOrThrow({
+                where: {
+                    id: sessionInvoiceId,
+                    providerId,
+                    memberId,
+                },
+                include: {
+                    invoice: true,
+                },
+            });
+        if (
+            !(
+                [
+                    SessionInvoiceStatus.draft,
+                    SessionInvoiceStatus.open,
+                ] as SessionInvoiceStatus[]
+            ).includes(status)
+        ) {
+            throw new Error(
+                "Session invoice cannot be voided in it's current state"
+            );
+        }
+        const { voided } = await stripe.voidInvoice(invoice.id);
+        return {
+            voided,
+        };
+    };

--- a/src/lib/modules/directory/features/get-connection-request/index.ts
+++ b/src/lib/modules/directory/features/get-connection-request/index.ts
@@ -1,0 +1,5 @@
+export { ROUTE as TRPC_ROUTE } from './trpc';
+export { schema as inputSchema } from './input';
+export type { Input } from './input';
+export { schema as outputSchema } from './output';
+export type { Output } from './output';

--- a/src/lib/modules/directory/features/get-connection-request/input.ts
+++ b/src/lib/modules/directory/features/get-connection-request/input.ts
@@ -1,0 +1,21 @@
+import * as z from 'zod';
+
+export const schema = z.object({
+    providerId: z.string(),
+    memberId: z.string(),
+});
+
+export type Input = z.infer<typeof schema>;
+
+export const validate = (value: unknown): Input => {
+    return schema.parse(value);
+};
+
+export const isValid = (value: unknown): value is Input => {
+    try {
+        validate(value);
+        return true;
+    } catch {
+        return false;
+    }
+};

--- a/src/lib/modules/directory/features/get-connection-request/output.ts
+++ b/src/lib/modules/directory/features/get-connection-request/output.ts
@@ -1,0 +1,22 @@
+import { ConnectionRequest } from '@/lib/shared/types';
+import * as z from 'zod';
+
+export const schema = z.object({
+    connectionRequest: ConnectionRequest.schema,
+    errors: z.array(z.string()),
+});
+
+export type Output = z.infer<typeof schema>;
+
+export const validate = (value: unknown): Output => {
+    return schema.parse(value);
+};
+
+export const isValid = (value: unknown): value is Output => {
+    try {
+        validate(value);
+        return true;
+    } catch {
+        return false;
+    }
+};

--- a/src/lib/modules/directory/features/get-connection-request/output.ts
+++ b/src/lib/modules/directory/features/get-connection-request/output.ts
@@ -2,7 +2,7 @@ import { ConnectionRequest } from '@/lib/shared/types';
 import * as z from 'zod';
 
 export const schema = z.object({
-    connectionRequest: ConnectionRequest.schema,
+    connectionRequest: ConnectionRequest.schema.nullable(),
     errors: z.array(z.string()),
 });
 

--- a/src/lib/modules/directory/features/get-connection-request/trpc.ts
+++ b/src/lib/modules/directory/features/get-connection-request/trpc.ts
@@ -1,0 +1,1 @@
+export const ROUTE = 'get-connection-request' as const;

--- a/src/lib/modules/directory/features/index.ts
+++ b/src/lib/modules/directory/features/index.ts
@@ -2,5 +2,6 @@ export * as ProviderSearch from './provider-search';
 export * as CreateConnectionRequest from './create-connection-request';
 export * as ListConnectionRequestsByProviderId from './list-connection-requests-by-provider-id';
 export * as ListConnectionRequestsByPracticeOwnerId from './list-connection-requests-by-practice-owner-id';
+export * as GetConnectionRequest from './get-connection-request';
 export * as UpdateConnectionRequestStatus from './update-connection-request-status';
 export * as GenerateRecommendations from './generate-recommendations';

--- a/src/lib/modules/directory/routes/resolvers/get-connection-request/index.ts
+++ b/src/lib/modules/directory/routes/resolvers/get-connection-request/index.ts
@@ -1,0 +1,1 @@
+export { resolve as getConnectionRequestResolver } from './resolver';

--- a/src/lib/modules/directory/routes/resolvers/get-connection-request/resolver.ts
+++ b/src/lib/modules/directory/routes/resolvers/get-connection-request/resolver.ts
@@ -1,0 +1,33 @@
+import { ProcedureResolver } from '@trpc/server/dist/declarations/src/internals/procedure';
+import { GetConnectionRequest } from '@/lib/modules/directory/features';
+import { Context } from '@/lib/server/context';
+
+export const resolve: ProcedureResolver<
+    Context,
+    GetConnectionRequest.Input,
+    GetConnectionRequest.Output
+> = async function ({ input, ctx }) {
+    try {
+        const connectionRequest = await ctx.directory.getConnectionRequest(
+            input
+        );
+        return {
+            connectionRequest,
+            errors: [],
+        };
+    } catch (error) {
+        if (error instanceof Error) {
+            return {
+                connectionRequest: null,
+                errors: [error.message],
+            };
+        }
+        const errorMessage =
+            (error as { message: string })?.message ??
+            'Could not get connection request.';
+        return {
+            connectionRequest: null,
+            errors: [errorMessage],
+        };
+    }
+};

--- a/src/lib/modules/directory/routes/resolvers/index.ts
+++ b/src/lib/modules/directory/routes/resolvers/index.ts
@@ -1,2 +1,3 @@
 export * from './create-connection-request';
 export * from './update-connection-request-status';
+export * from './get-connection-request';

--- a/src/lib/modules/directory/routes/router.ts
+++ b/src/lib/modules/directory/routes/router.ts
@@ -2,15 +2,22 @@ import { Context } from '@/lib/server/context';
 import * as trpc from '@trpc/server';
 import {
     CreateConnectionRequest,
+    GetConnectionRequest,
     UpdateConnectionRequestStatus,
 } from '../features';
 import {
     createConnectionRequestResolver,
     updateConnectionRequestStatusResolver,
+    getConnectionRequestResolver,
 } from './resolvers';
 
 export const router = trpc
     .router<Context>()
+    .query(GetConnectionRequest.TRPC_ROUTE, {
+        input: GetConnectionRequest.inputSchema,
+        output: GetConnectionRequest.outputSchema,
+        resolve: getConnectionRequestResolver,
+    })
     .mutation(CreateConnectionRequest.TRPC_ROUTE, {
         input: CreateConnectionRequest.inputSchema,
         output: CreateConnectionRequest.outputSchema,

--- a/src/lib/modules/directory/service/get-connection-request/getConnectionRequest.ts
+++ b/src/lib/modules/directory/service/get-connection-request/getConnectionRequest.ts
@@ -21,7 +21,7 @@ export function factory({ prisma }: DirectoryServiceParams) {
                 },
             }
         );
-        const rawRequest = await prisma.connectionRequest.findFirstOrThrow({
+        const rawRequest = await prisma.connectionRequest.findFirst({
             where: {
                 profileId,
                 memberId,
@@ -82,6 +82,9 @@ export function factory({ prisma }: DirectoryServiceParams) {
                 },
             },
         });
+        if (!rawRequest) {
+            return null;
+        }
         const rawPlan = getCurrentPlan(rawRequest.member.account?.plans ?? []);
         let plan: ConnectionRequest.Type['member']['plan'] = null;
         if (rawPlan) {

--- a/src/lib/modules/directory/service/get-connection-request/index.ts
+++ b/src/lib/modules/directory/service/get-connection-request/index.ts
@@ -1,0 +1,1 @@
+export * as GetConnectionRequest from './getConnectionRequest';

--- a/src/lib/modules/directory/service/index.ts
+++ b/src/lib/modules/directory/service/index.ts
@@ -7,6 +7,7 @@ import { DirectoryServiceParams } from './params';
 import { UpdateConnectionRequestStatus } from './update-connection-request-status';
 import { ExecuteProviderSearch } from './execute-provider-search';
 import { GenerateRecommendations } from './generate-recommendations';
+import { GetConnectionRequest } from './get-connection-request';
 
 const params: DirectoryServiceParams = {
     prisma,
@@ -20,6 +21,7 @@ export const directoryService = {
         ListConnectionRequestsByProviderId.factory(params),
     listConnectionRequestsByPracticeOwnerId:
         ListConnectionRequestsByPracticeOwnerId.factory(params),
+    getConnectionRequest: GetConnectionRequest.factory(params),
     updateConnectionRequestStatus:
         UpdateConnectionRequestStatus.factory(params),
     generateRecommendations: GenerateRecommendations.factory(params),

--- a/src/lib/modules/directory/service/list-connection-requests-by-practice-owner-id/listConnectionRequestsByPracticeOwnerId.ts
+++ b/src/lib/modules/directory/service/list-connection-requests-by-practice-owner-id/listConnectionRequestsByPracticeOwnerId.ts
@@ -1,9 +1,9 @@
-import { isBefore } from 'date-fns';
 import { ListConnectionRequestsByPracticeOwnerId } from '@/lib/modules/directory/features';
 import {
     ConnectionRequest,
     PracticeProfileConnectionRequests,
 } from '@/lib/shared/types';
+import { getRemainingSessionCount } from '@/lib/shared/utils';
 import { DirectoryServiceParams } from '../params';
 
 export function factory({ prisma }: DirectoryServiceParams) {
@@ -139,28 +139,15 @@ export function factory({ prisma }: DirectoryServiceParams) {
                                     startDate,
                                     ...planDetails
                                 } = rawPlan;
-                                const sessionsInPlan =
-                                    connection.member.redeemedSessions.filter(
-                                        (session) =>
-                                            // dateOfSession is after startDate and before endDate
-                                            isBefore(
-                                                startDate,
-                                                session.dateOfSession
-                                            ) &&
-                                            isBefore(
-                                                session.dateOfSession,
-                                                endDate
-                                            )
-                                    );
-                                const remainingSessions =
-                                    (coveredSessions ?? 0) -
-                                    sessionsInPlan.length;
                                 plan = {
                                     ...planDetails,
                                     startDate: startDate.toISOString(),
                                     endDate: endDate.toISOString(),
                                     coveredSessions,
-                                    remainingSessions,
+                                    remainingSessions: getRemainingSessionCount(
+                                        { coveredSessions, endDate, startDate },
+                                        connection.member.redeemedSessions
+                                    ),
                                 };
                             }
                             return {

--- a/src/lib/modules/providers/components/Clients/ClientDetails/ClientDetails.tsx
+++ b/src/lib/modules/providers/components/Clients/ClientDetails/ClientDetails.tsx
@@ -1,6 +1,5 @@
-import { useState } from 'react';
 import { format } from 'date-fns';
-import { ProfileType, SessionInvoiceStatus } from '@prisma/client';
+import { SessionInvoiceStatus } from '@prisma/client';
 import { Box, Link } from '@mui/material';
 import { styled, useTheme } from '@mui/material/styles';
 import { URL_PATHS } from '@/lib/sitemap';
@@ -29,31 +28,30 @@ import {
     EmailOutlined,
 } from '@mui/icons-material';
 import { ProfileDetails } from './ui';
-import { ReimbursementModal } from '../ReimbursementModal';
 
 interface ClientDetailsProps {
-    designation: ProfileType;
     connectionRequest: ProviderClientDetailsPageProps['connectionRequest'];
     provider: ProviderClientDetailsPageProps['user'];
     invoices: ProviderClientDetailsPageProps['invoices'];
+    isLoading?: boolean;
     onBack?: () => void;
     onCreateInvoice?: () => void;
     onVoidInvoice: (
         invoice: ProviderClientDetailsPageProps['invoices'][number]
     ) => void;
+    onReimbursement: () => void;
 }
 export const ClientDetails = ({
     connectionRequest,
-    designation,
     provider,
     invoices,
+    isLoading,
     onBack,
     onCreateInvoice,
     onVoidInvoice,
+    onReimbursement,
 }: ClientDetailsProps) => {
     const theme = useTheme();
-    const [isReimbursementModalOpen, setIsReimbursementModalOpen] =
-        useState(false);
     const canBeVoided = (status: string) => {
         const voidableStatuses: string[] = [
             SessionInvoiceStatus.draft,
@@ -143,7 +141,7 @@ export const ClientDetails = ({
                     {hasSessionsRemaining && (
                         <Button
                             endIcon={<RequestQuoteOutlined />}
-                            onClick={() => setIsReimbursementModalOpen(true)}
+                            onClick={onReimbursement}
                         >
                             Submit Reimbursement Request
                         </Button>
@@ -151,7 +149,10 @@ export const ClientDetails = ({
                 </ButtonsContainer>
             </TitleContainer>
             <Container>
-                <ProfileDetails {...connectionRequest.member} />
+                <ProfileDetails
+                    {...connectionRequest.member}
+                    isLoading={isLoading}
+                />
             </Container>
             <EmailButton
                 type="outlined"
@@ -244,13 +245,6 @@ export const ClientDetails = ({
                     ))}
                 </List>
             </Container>
-            {isReimbursementModalOpen && (
-                <ReimbursementModal
-                    designation={designation}
-                    connectionRequest={connectionRequest}
-                    onClose={() => setIsReimbursementModalOpen(false)}
-                />
-            )}
         </PageContainer>
     );
 };

--- a/src/lib/modules/providers/components/Clients/ClientDetails/ClientDetails.tsx
+++ b/src/lib/modules/providers/components/Clients/ClientDetails/ClientDetails.tsx
@@ -1,4 +1,4 @@
-import { Box } from '@mui/material';
+import { Box, Link } from '@mui/material';
 import { styled, useTheme } from '@mui/material/styles';
 import {
     H1,
@@ -16,6 +16,7 @@ import { ProviderClientDetailsPageProps } from '../../../service/page-props/get-
 import { format } from 'date-fns';
 import { SessionInvoiceStatus } from '@prisma/client';
 import { ChevronLeft, MoneyOff } from '@mui/icons-material';
+import { URL_PATHS } from '@/lib/sitemap';
 
 interface ClientDetailsProps {
     memberDetails: ProviderClientDetailsPageProps['memberDetails'];
@@ -29,6 +30,7 @@ interface ClientDetailsProps {
 }
 export const ClientDetails = ({
     memberDetails,
+    provider,
     invoices,
     onBack,
     onCreateInvoice,
@@ -65,7 +67,7 @@ export const ClientDetails = ({
                     {memberDetails.givenName} {memberDetails.surname}
                 </Title>
                 <Box>
-                    {onCreateInvoice && (
+                    {onCreateInvoice && provider.stripeConnectAccountId && (
                         <Button onClick={onCreateInvoice}>
                             Send Session Invoice
                         </Button>
@@ -84,6 +86,16 @@ export const ClientDetails = ({
                             </Paragraph>
                         </LineItemContent>
                     </ListItem>
+                    {!provider.stripeConnectAccountId && (
+                        <Paragraph marginTop={4}>
+                            You must have a Therify Stripe Connect account to
+                            send invoices to your clients. Please visit your{' '}
+                            <Link href={URL_PATHS.PROVIDERS.COACH.PAYMENTS}>
+                                payments page
+                            </Link>{' '}
+                            to sign up for a Stripe Connect account.
+                        </Paragraph>
+                    )}
                     {invoices.map((invoice) => (
                         <ListItem key={invoice.id}>
                             <LineItemContent>

--- a/src/lib/modules/providers/components/Clients/ClientDetails/ClientDetails.tsx
+++ b/src/lib/modules/providers/components/Clients/ClientDetails/ClientDetails.tsx
@@ -1,5 +1,5 @@
 import { Box } from '@mui/material';
-import { styled } from '@mui/material/styles';
+import { styled, useTheme } from '@mui/material/styles';
 import {
     H1,
     Button,
@@ -8,18 +8,20 @@ import {
     Badge,
     BADGE_COLOR,
     BADGE_SIZE,
+    BUTTON_SIZE,
     ListItem,
     FloatingList,
 } from '@/lib/shared/components/ui';
 import { ProviderClientDetailsPageProps } from '../../../service/page-props/get-client-details-page-props';
 import { format } from 'date-fns';
 import { SessionInvoiceStatus } from '@prisma/client';
-import { MoneyOff } from '@mui/icons-material';
+import { ChevronLeft, MoneyOff } from '@mui/icons-material';
 
 interface ClientDetailsProps {
     memberDetails: ProviderClientDetailsPageProps['memberDetails'];
     provider: ProviderClientDetailsPageProps['user'];
     invoices: ProviderClientDetailsPageProps['invoices'];
+    onBack?: () => void;
     onCreateInvoice?: () => void;
     onVoidInvoice: (
         invoice: ProviderClientDetailsPageProps['invoices'][number]
@@ -28,9 +30,11 @@ interface ClientDetailsProps {
 export const ClientDetails = ({
     memberDetails,
     invoices,
+    onBack,
     onCreateInvoice,
     onVoidInvoice,
 }: ClientDetailsProps) => {
+    const theme = useTheme();
     const canBeVoided = (status: string) => {
         const voidableStatuses: string[] = [
             SessionInvoiceStatus.draft,
@@ -40,7 +44,23 @@ export const ClientDetails = ({
     };
     return (
         <PageContainer>
-            <TitleContainer>
+            {onBack && (
+                <Button
+                    size={BUTTON_SIZE.SMALL}
+                    color="info"
+                    type="text"
+                    onClick={onBack}
+                    startIcon={<ChevronLeft />}
+                    style={{ margin: theme.spacing(6, 0, 0, 2) }}
+                >
+                    Back
+                </Button>
+            )}
+            <TitleContainer
+                style={{
+                    marginTop: theme.spacing(onBack ? 4 : 6),
+                }}
+            >
                 <Title>
                     {memberDetails.givenName} {memberDetails.surname}
                 </Title>
@@ -59,42 +79,44 @@ export const ClientDetails = ({
                             <Paragraph bold noMargin>
                                 Invoice
                             </Paragraph>
-                            <Box width={'25%'}>
-                                <Paragraph bold noMargin>
-                                    Status
-                                </Paragraph>
-                            </Box>
+                            <Paragraph className="invoice-status" bold noMargin>
+                                Status
+                            </Paragraph>
                         </LineItemContent>
                     </ListItem>
                     {invoices.map((invoice) => (
                         <ListItem key={invoice.id}>
                             <LineItemContent>
-                                <Paragraph bold noMargin>
-                                    Mental Health Coaching Session{' '}
-                                    {invoice.dateOfSession
-                                        ? 'on ' +
-                                          format(
-                                              new Date(invoice.dateOfSession),
-                                              'MMMM do, yyyy'
-                                          )
-                                        : ''}
-                                </Paragraph>
+                                <Box>
+                                    <Paragraph bold noMargin>
+                                        Mental Health Coaching Session{' '}
+                                        {invoice.dateOfSession
+                                            ? 'on ' +
+                                              format(
+                                                  new Date(
+                                                      invoice.dateOfSession
+                                                  ),
+                                                  'MMMM do, yyyy'
+                                              )
+                                            : ''}
+                                    </Paragraph>
+                                    <MobileBadge>
+                                        {getBadge(invoice.status)}
+                                    </MobileBadge>
+                                </Box>
                                 <Box className="invoice-status">
-                                    {getBadge(invoice.status)}
+                                    <DesktopBadge>
+                                        {getBadge(invoice.status)}
+                                    </DesktopBadge>
                                     <FloatingList
-                                        sx={{ marginLeft: 2 }}
-                                        // headerSlot={
-                                        //     isPending &&
-                                        //     isSmallScreen && (
-                                        //         <Badge
-                                        //             color={BADGE_COLOR.WARNING}
-                                        //             icon={<PendingOutlined />}
-                                        //             size={BADGE_SIZE.SMALL}
-                                        //         >
-                                        //             Pending
-                                        //         </Badge>
-                                        //     )
-                                        // }
+                                        sx={{
+                                            marginLeft: 2,
+                                            '& button': {
+                                                width: '60px',
+                                                height: '60px',
+                                                padding: 0,
+                                            },
+                                        }}
                                         listItems={[
                                             {
                                                 disabled: canBeVoided(
@@ -181,9 +203,32 @@ const LineItemContent = styled(Box)(({ theme }) => ({
         flex: 1,
     },
     '& .invoice-status': {
-        width: '25%',
+        width: 'auto',
         display: 'flex',
         justifyContent: 'space-between',
         alignItems: 'center',
+        flexWrap: 'wrap',
+        [theme.breakpoints.up('md')]: {
+            width: '25%',
+        },
+    },
+    '& p.invoice-status': {
+        display: 'none',
+        [theme.breakpoints.up('md')]: {
+            display: 'block',
+        },
+    },
+}));
+
+const MobileBadge = styled(Box)(({ theme }) => ({
+    display: 'block',
+    [theme.breakpoints.up('md')]: {
+        display: 'none',
+    },
+}));
+const DesktopBadge = styled(Box)(({ theme }) => ({
+    display: 'none',
+    [theme.breakpoints.up('md')]: {
+        display: 'block',
     },
 }));

--- a/src/lib/modules/providers/components/Clients/ClientDetails/ClientDetails.tsx
+++ b/src/lib/modules/providers/components/Clients/ClientDetails/ClientDetails.tsx
@@ -96,6 +96,12 @@ export const ClientDetails = ({
                             to sign up for a Stripe Connect account.
                         </Paragraph>
                     )}
+                    {provider.stripeConnectAccountId &&
+                        invoices.length === 0 && (
+                            <Paragraph marginTop={4}>
+                                No invoices have been created for this client.
+                            </Paragraph>
+                        )}
                     {invoices.map((invoice) => (
                         <ListItem key={invoice.id}>
                             <LineItemContent>
@@ -211,7 +217,7 @@ const LineItemContent = styled(Box)(({ theme }) => ({
     justifyContent: 'space-between',
     alignItems: 'center',
     width: '100%',
-    '& >:first-child': {
+    '& >:first-of-type': {
         flex: 1,
     },
     '& .invoice-status': {

--- a/src/lib/modules/providers/components/Clients/ClientDetails/ClientDetails.tsx
+++ b/src/lib/modules/providers/components/Clients/ClientDetails/ClientDetails.tsx
@@ -1,0 +1,147 @@
+import { Box } from '@mui/material';
+import { styled } from '@mui/material/styles';
+import {
+    H1,
+    Button,
+    List,
+    Paragraph,
+    Badge,
+    BADGE_COLOR,
+    BADGE_SIZE,
+    ListItem,
+} from '@/lib/shared/components/ui';
+import { ProviderClientDetailsPageProps } from '../../../service/page-props/get-client-details-page-props';
+import { format } from 'date-fns';
+import { SessionInvoiceStatus } from '@prisma/client';
+
+interface ClientDetailsProps {
+    memberDetails: ProviderClientDetailsPageProps['memberDetails'];
+    provider: ProviderClientDetailsPageProps['user'];
+    invoices: ProviderClientDetailsPageProps['invoices'];
+    onCreateInvoice?: () => void;
+}
+export const ClientDetails = ({
+    memberDetails,
+    invoices,
+    onCreateInvoice,
+}: ClientDetailsProps) => {
+    return (
+        <PageContainer>
+            <TitleContainer>
+                <Title>
+                    {memberDetails.givenName} {memberDetails.surname}
+                    <Box>
+                        {onCreateInvoice && (
+                            <Button onClick={onCreateInvoice}>
+                                Send Session Invoice
+                            </Button>
+                        )}
+                    </Box>
+                </Title>
+            </TitleContainer>
+            <Container>
+                <List style={{ width: '100%' }}>
+                    <ListItem sx={{ display: 'flex', alignItems: 'center' }}>
+                        <LineItemContent>
+                            <Paragraph bold noMargin>
+                                Invoice
+                            </Paragraph>
+                            <Box width={'25%'}>
+                                <Paragraph bold noMargin>
+                                    Status
+                                </Paragraph>
+                            </Box>
+                        </LineItemContent>
+                    </ListItem>
+                    {invoices.map((invoice) => (
+                        <ListItem key={invoice.id}>
+                            <LineItemContent>
+                                <Paragraph bold noMargin>
+                                    Mental Health Coaching Session{' '}
+                                    {invoice.dateOfSession
+                                        ? 'on ' +
+                                          format(
+                                              new Date(invoice.dateOfSession),
+                                              'MMMM do, yyyy'
+                                          )
+                                        : ''}
+                                </Paragraph>
+                                <Box width={'25%'}>
+                                    {getBadge(invoice.status)}
+                                </Box>
+                            </LineItemContent>
+                        </ListItem>
+                    ))}
+                </List>
+            </Container>
+        </PageContainer>
+    );
+};
+
+const getBadge = (status: SessionInvoiceStatus) => {
+    let badgeColor: (typeof BADGE_COLOR)[keyof typeof BADGE_COLOR] =
+        BADGE_COLOR.WARNING;
+    let badgeText = 'Awaiting Payment';
+    const failureStatuses = [
+        SessionInvoiceStatus.uncollectible,
+        SessionInvoiceStatus.void,
+    ];
+    switch (status) {
+        case SessionInvoiceStatus.paid:
+            badgeColor = BADGE_COLOR.SUCCESS;
+            badgeText = 'Paid';
+            break;
+        case SessionInvoiceStatus.uncollectible:
+            badgeColor = BADGE_COLOR.ERROR;
+            badgeText = 'Uncollectible';
+            break;
+        case SessionInvoiceStatus.void:
+            badgeColor = BADGE_COLOR.NEUTRAL_LIGHT;
+            badgeText = 'Void';
+            break;
+        case SessionInvoiceStatus.draft:
+            badgeColor = BADGE_COLOR.NEUTRAL_LIGHT;
+            badgeText = 'Draft';
+            break;
+        case SessionInvoiceStatus.open:
+        default:
+            break;
+    }
+
+    return (
+        <Badge color={badgeColor} size={BADGE_SIZE.SMALL}>
+            {badgeText}
+        </Badge>
+    );
+};
+
+const PageContainer = styled(Box)(({ theme }) => ({
+    width: '100%',
+}));
+
+const Title = styled(H1)(({ theme }) => ({
+    ...theme.typography.h3,
+}));
+const Container = styled(Box)(({ theme }) => ({
+    margin: theme.spacing(6, 6),
+}));
+const TitleContainer = styled(Container)(({ theme }) => ({
+    display: 'flex',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+}));
+
+const LineItemContent = styled(Box)(({ theme }) => ({
+    display: 'flex',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    width: '100%',
+    '& >:first-child': {
+        width: '75%',
+    },
+    '& >:last-child': {
+        width: ' 25%',
+        display: 'flex',
+        justifyContent: 'center',
+    },
+}));

--- a/src/lib/modules/providers/components/Clients/ClientDetails/index.ts
+++ b/src/lib/modules/providers/components/Clients/ClientDetails/index.ts
@@ -1,0 +1,1 @@
+export { ClientDetails } from './ClientDetails';

--- a/src/lib/modules/providers/components/Clients/ClientDetails/ui/ProfileDetails.tsx
+++ b/src/lib/modules/providers/components/Clients/ClientDetails/ui/ProfileDetails.tsx
@@ -1,7 +1,12 @@
-import { Box, Tooltip as MuiTooltip } from '@mui/material';
+import { Box, CircularProgress, Tooltip as MuiTooltip } from '@mui/material';
 import { styled } from '@mui/material/styles';
 import { colors } from '@/lib/shared/components/themes/therify-design-system';
-import { H4, Paragraph, Caption } from '@/lib/shared/components/ui';
+import {
+    H4,
+    Paragraph,
+    Caption,
+    CenteredContainer,
+} from '@/lib/shared/components/ui';
 import { getCoveredSessionsMessage } from '../../utils';
 import { ProviderClientDetailsPageProps } from '../../../../service/page-props/get-client-details-page-props';
 import { InfoOutlined } from '@mui/icons-material';
@@ -10,17 +15,29 @@ export const ProfileDetails = ({
     givenName,
     memberProfile,
     plan,
-}: ProviderClientDetailsPageProps['connectionRequest']['member']) => {
-    const remainingSesssions = plan?.remainingSessions ?? 0;
+    isLoading,
+}: ProviderClientDetailsPageProps['connectionRequest']['member'] & {
+    isLoading?: boolean;
+}) => {
+    const remainingSessions = plan?.remainingSessions ?? 0;
     const coveredSessions = plan?.coveredSessions ?? 0;
+    const hasRemainingSessions = remainingSessions > 0;
     return (
         <Container>
-            <RemainingSessions remainingSessions={remainingSesssions}>
-                <Paragraph className="count" bold>
-                    {remainingSesssions}
-                </Paragraph>
+            <RemainingSessions hasRemainingSessions={hasRemainingSessions}>
+                {isLoading ? (
+                    <CenteredContainer marginBottom={4}>
+                        <CircularProgress
+                            color={hasRemainingSessions ? 'success' : 'info'}
+                        />
+                    </CenteredContainer>
+                ) : (
+                    <Paragraph className="count" bold>
+                        {remainingSessions}
+                    </Paragraph>
+                )}
                 <Caption margin={0}>
-                    Covered {remainingSesssions === 1 ? 'session' : 'sessions'}{' '}
+                    Covered {remainingSessions === 1 ? 'session' : 'sessions'}{' '}
                     {coveredSessions > 0 ? 'remaining' : ''}
                 </Caption>
                 <Tooltip
@@ -29,7 +46,7 @@ export const ProfileDetails = ({
                             ? getCoveredSessionsMessage({
                                   name: givenName,
                                   coveredSessions: coveredSessions,
-                                  remainingSessions: remainingSesssions,
+                                  remainingSessions,
                                   planEndDate: plan.endDate,
                               })
                             : 'No plan information could be found.'
@@ -76,18 +93,20 @@ const DetailsContainer = styled(Box)(({ theme }) => ({
     },
 }));
 
-const RemainingSessions = styled(Box)<{
-    remainingSessions: number;
-}>(({ theme, remainingSessions }) => ({
+const RemainingSessions = styled(Box, {
+    shouldForwardProp: (prop) => prop !== 'hasRemainingSessions',
+})<{
+    hasRemainingSessions: boolean;
+}>(({ theme, hasRemainingSessions }) => ({
     display: 'flex',
     justifyContent: 'center',
     alignItems: 'center',
     width: '100%',
     minHeight: '180px',
-    background:
-        remainingSessions > 0 ? colors.success[50] : colors.neutral.black[100],
-    color:
-        remainingSessions > 0 ? colors.success[800] : theme.palette.info.dark,
+    background: hasRemainingSessions
+        ? colors.success[50]
+        : colors.neutral.black[100],
+    color: hasRemainingSessions ? colors.success[800] : theme.palette.info.dark,
     borderRadius: theme.shape.borderRadius,
     flexDirection: 'column',
     marginBottom: theme.spacing(4),

--- a/src/lib/modules/providers/components/Clients/ClientDetails/ui/ProfileDetails.tsx
+++ b/src/lib/modules/providers/components/Clients/ClientDetails/ui/ProfileDetails.tsx
@@ -1,0 +1,106 @@
+import { Box, Tooltip as MuiTooltip } from '@mui/material';
+import { styled } from '@mui/material/styles';
+import { colors } from '@/lib/shared/components/themes/therify-design-system';
+import { H4, Paragraph, Caption } from '@/lib/shared/components/ui';
+import { getCoveredSessionsMessage } from '../../utils';
+import { ProviderClientDetailsPageProps } from '../../../../service/page-props/get-client-details-page-props';
+import { InfoOutlined } from '@mui/icons-material';
+
+export const ProfileDetails = ({
+    givenName,
+    memberProfile,
+    plan,
+}: ProviderClientDetailsPageProps['connectionRequest']['member']) => {
+    const remainingSesssions = plan?.remainingSessions ?? 0;
+    const coveredSessions = plan?.coveredSessions ?? 0;
+    return (
+        <Container>
+            <RemainingSessions remainingSessions={remainingSesssions}>
+                <Paragraph className="count" bold>
+                    {remainingSesssions}
+                </Paragraph>
+                <Caption margin={0}>
+                    Covered {remainingSesssions === 1 ? 'session' : 'sessions'}{' '}
+                    {coveredSessions > 0 ? 'remaining' : ''}
+                </Caption>
+                <Tooltip
+                    title={
+                        plan
+                            ? getCoveredSessionsMessage({
+                                  name: givenName,
+                                  coveredSessions: coveredSessions,
+                                  remainingSessions: remainingSesssions,
+                                  planEndDate: plan.endDate,
+                              })
+                            : 'No plan information could be found.'
+                    }
+                >
+                    <InfoOutlined fontSize="small" />
+                </Tooltip>
+            </RemainingSessions>
+            <DetailsContainer>
+                <H4>Concerns</H4>
+                {memberProfile.concerns.length === 0 && (
+                    <Paragraph>No concerns selected.</Paragraph>
+                )}
+                {memberProfile.concerns.length && (
+                    <Paragraph>{memberProfile.concerns.join(', ')}</Paragraph>
+                )}
+                <H4>Goals</H4>
+                {memberProfile.goals.length === 0 && (
+                    <Paragraph>No goals shared.</Paragraph>
+                )}
+                {memberProfile.goals.length && (
+                    <Paragraph>{memberProfile.goals.join(', ')}</Paragraph>
+                )}
+            </DetailsContainer>
+        </Container>
+    );
+};
+
+const Container = styled(Box)(({ theme }) => ({
+    display: 'flex',
+    width: '100%',
+    flex: 1,
+    flexDirection: 'column',
+    [theme.breakpoints.up('md')]: {
+        flexDirection: 'row',
+    },
+}));
+
+const DetailsContainer = styled(Box)(({ theme }) => ({
+    marginTop: theme.spacing(4),
+    flex: 1,
+    [theme.breakpoints.up('md')]: {
+        marginTop: 0,
+    },
+}));
+
+const RemainingSessions = styled(Box)<{
+    remainingSessions: number;
+}>(({ theme, remainingSessions }) => ({
+    display: 'flex',
+    justifyContent: 'center',
+    alignItems: 'center',
+    width: '100%',
+    minHeight: '180px',
+    background:
+        remainingSessions > 0 ? colors.success[50] : colors.neutral.black[100],
+    color:
+        remainingSessions > 0 ? colors.success[800] : theme.palette.info.dark,
+    borderRadius: theme.shape.borderRadius,
+    flexDirection: 'column',
+    marginBottom: theme.spacing(4),
+    [theme.breakpoints.up('md')]: {
+        width: '50%',
+        maxWidth: '350px',
+        marginRight: theme.spacing(8),
+    },
+    '& .count': {
+        fontSize: theme.typography.h1.fontSize,
+    },
+}));
+
+const Tooltip = styled(MuiTooltip)(({ theme }) => ({
+    marginTop: theme.spacing(2),
+}));

--- a/src/lib/modules/providers/components/Clients/ClientDetails/ui/index.ts
+++ b/src/lib/modules/providers/components/Clients/ClientDetails/ui/index.ts
@@ -1,0 +1,1 @@
+export { ProfileDetails } from './ProfileDetails';

--- a/src/lib/modules/providers/components/Clients/ClientList/ClientList.tsx
+++ b/src/lib/modules/providers/components/Clients/ClientList/ClientList.tsx
@@ -17,6 +17,7 @@ interface ClientListProps {
     onTerminateConnectionRequest: HandleConnectionRequestAction;
     onReimbursmentRequest: HandleConnectionRequestAction;
     onViewMemberDetails: HandleConnectionRequestAction;
+    onClientSelect: HandleConnectionRequestAction;
     onInvoiceClient?: HandleConnectionRequestAction;
 }
 
@@ -27,6 +28,7 @@ export const ClientList = ({
     onTerminateConnectionRequest,
     onReimbursmentRequest,
     onViewMemberDetails,
+    onClientSelect,
     onInvoiceClient,
 }: ClientListProps) => {
     const isSmallScreen = useMediaQuery((theme: Theme) =>
@@ -72,7 +74,12 @@ export const ClientList = ({
                         onTerminate={() =>
                             onTerminateConnectionRequest(connectionRequest)
                         }
-                        onView={() => onViewMemberDetails(connectionRequest)}
+                        onClientSelect={() => {
+                            onClientSelect(connectionRequest);
+                        }}
+                        onViewSummary={() =>
+                            onViewMemberDetails(connectionRequest)
+                        }
                         onInvoiceClient={
                             onInvoiceClient
                                 ? () => onInvoiceClient(connectionRequest)

--- a/src/lib/modules/providers/components/Clients/ClientList/ui/ActionButtons.tsx
+++ b/src/lib/modules/providers/components/Clients/ClientList/ui/ActionButtons.tsx
@@ -45,7 +45,7 @@ export const ActionButtons = ({
                     type="outlined"
                     onClick={onView}
                 >
-                    View Member
+                    Member Summary
                 </Button>
             )}
         </>

--- a/src/lib/modules/providers/components/Clients/ClientList/ui/ClientListItem.tsx
+++ b/src/lib/modules/providers/components/Clients/ClientList/ui/ClientListItem.tsx
@@ -119,7 +119,10 @@ export const ClientListItem = ({
         <ListItem
             key={connectionRequest.member.id}
             sx={{ width: '100%', paddingX: 0 }}
-            onClick={onClientSelect}
+            onClick={() => {
+                // Only open client page for accepted connections
+                isAccepted ? onClientSelect?.() : onViewSummary?.();
+            }}
         >
             <ClientListItemContainer>
                 <CellContainer>

--- a/src/lib/modules/providers/components/Clients/ClientList/ui/ClientListItem.tsx
+++ b/src/lib/modules/providers/components/Clients/ClientList/ui/ClientListItem.tsx
@@ -31,7 +31,8 @@ export const ClientListItem = ({
     isSmallScreen,
     onAccept,
     onDecline,
-    onView,
+    onViewSummary,
+    onClientSelect,
     onReimbursmentRequest,
     onInvoiceClient,
 }: {
@@ -40,7 +41,8 @@ export const ClientListItem = ({
     onAccept: () => void;
     onDecline: () => void;
     onTerminate: () => void;
-    onView?: () => void;
+    onViewSummary?: () => void;
+    onClientSelect?: () => void;
     onInvoiceClient?: () => void;
     onReimbursmentRequest: () => void;
 }) => {
@@ -70,8 +72,8 @@ export const ClientListItem = ({
 
         {
             icon: <PreviewRounded />,
-            text: ' View Member Details',
-            onClick: onView,
+            text: ' View Member Summary',
+            onClick: onViewSummary,
         },
     ];
     const actionList = [
@@ -117,7 +119,7 @@ export const ClientListItem = ({
         <ListItem
             key={connectionRequest.member.id}
             sx={{ width: '100%', paddingX: 0 }}
-            onClick={onView}
+            onClick={onClientSelect}
         >
             <ClientListItemContainer>
                 <CellContainer>
@@ -170,7 +172,7 @@ export const ClientListItem = ({
                             connectionRequest={connectionRequest}
                             onAccept={onAccept}
                             onDecline={onDecline}
-                            onView={onView}
+                            onView={onViewSummary}
                         />
                     )}
                     {isPending && isSmallScreen && (

--- a/src/lib/modules/providers/components/Clients/ReimbursementModal/ReimbursementModal.tsx
+++ b/src/lib/modules/providers/components/Clients/ReimbursementModal/ReimbursementModal.tsx
@@ -5,6 +5,7 @@ import { styled } from '@mui/material/styles';
 import { formatReimbursementRequestUrl } from '@/lib/shared/utils';
 import { Close } from '@mui/icons-material';
 import { ProfileType } from '@prisma/client';
+import { useRef, useEffect, useState } from 'react';
 
 const REIMBURSEMENT_REQUEST_URL =
     'https://hipaa.jotform.com/221371005584146?' as const;
@@ -13,15 +14,37 @@ interface ReimbursementModalProps {
     designation: ProfileType;
     connectionRequest: ConnectionRequest.Type;
     onClose: () => void;
+    onSubmitCallback?: () => void;
 }
 
 export const ReimbursementModal = ({
     designation,
     connectionRequest,
     onClose,
+    onSubmitCallback,
 }: ReimbursementModalProps) => {
+    const timeoutRef = useRef<number>();
+    const [shouldCallCb, setShouldCallCb] = useState(false);
+
+    useEffect(() => {
+        if (typeof window === 'undefined') return;
+        timeoutRef.current = window.setTimeout(() => {
+            setShouldCallCb(true);
+        }, 5000);
+
+        return () => {
+            clearTimeout(timeoutRef.current);
+        };
+    }, []);
+
+    const handleClose = () => {
+        if (shouldCallCb && onSubmitCallback) {
+            onSubmitCallback();
+        }
+        onClose();
+    };
     return (
-        <Modal open onClose={onClose}>
+        <Modal open onClose={handleClose}>
             <ModalContent>
                 <TitleContainer>
                     <Box>
@@ -33,7 +56,7 @@ export const ReimbursementModal = ({
                             {connectionRequest.member.surname}
                         </H3>
                     </Box>
-                    <IconButton color="info" type="text" onClick={onClose}>
+                    <IconButton color="info" type="text" onClick={handleClose}>
                         <Close />
                     </IconButton>
                 </TitleContainer>

--- a/src/lib/modules/providers/components/Clients/index.ts
+++ b/src/lib/modules/providers/components/Clients/index.ts
@@ -2,3 +2,4 @@ export * from './ActionConfirmationModal';
 export * from './ClientList';
 export * from './MemberDetailsModal';
 export * from './ReimbursementModal';
+export * from './ClientDetails';

--- a/src/lib/modules/providers/components/Clients/utils/getCoveredSessionsMessage.ts
+++ b/src/lib/modules/providers/components/Clients/utils/getCoveredSessionsMessage.ts
@@ -13,10 +13,10 @@ export const getCoveredSessionsMessage = ({
     planEndDate,
 }: GetCoveredSessionsMessageProps) => {
     if (coveredSessions === 0) {
-        return `No covered sessions. ${name} will use their insurance benefit to cover sessions or pay out of pocket.`;
+        return `No covered sessions. ${name} will use insurance benefits to cover sessions or pay out of pocket.`;
     }
     if (remainingSessions === 0) {
-        return `${name} has used all of their covered sessions from Therify. They will use their insurance benefit or pay out of pocket.`;
+        return `${name} has used all covered sessions from Therify. ${name} will now use insurance benefits or pay out of pocket.`;
     }
 
     return `${name} has ${remainingSessions} covered ${

--- a/src/lib/modules/providers/service/page-props/get-client-details-page-props/getClientDetailsPageProps.ts
+++ b/src/lib/modules/providers/service/page-props/get-client-details-page-props/getClientDetailsPageProps.ts
@@ -1,0 +1,91 @@
+import { TherifyUser } from '@/lib/shared/types/therify-user';
+import { getSession } from '@auth0/nextjs-auth0';
+import { GetServerSideProps } from 'next';
+import { ProvidersServiceParams } from '../../params';
+import { GetProviderTherifyUser } from '../../get-provider-therify-user';
+import { URL_PATHS } from '@/lib/sitemap';
+import { GetProviderSessionInvoicesByMemberId } from '@/lib/modules/accounts/features/billing';
+import { AccountsService } from '@/lib/modules/accounts/service';
+import { prisma } from '@/lib/prisma';
+
+export interface ProviderClientDetailsPageProps {
+    user: TherifyUser.TherifyUser;
+    memberDetails: {
+        id: string;
+        givenName: string;
+        surname: string;
+        emailAddress: string;
+        // coveredSessions: number;
+        // remainingSesssions: number;
+    };
+    invoices: GetProviderSessionInvoicesByMemberId.Output['invoices'];
+}
+
+export const factory = (params: ProvidersServiceParams) => {
+    const getClientDetailsPageProps: GetServerSideProps<
+        ProviderClientDetailsPageProps
+    > = async (context) => {
+        const { memberId } = context.query;
+        if (typeof memberId !== 'string') {
+            return {
+                notFound: true,
+            };
+        }
+        const session = await getSession(context.req, context.res);
+        if (!session) {
+            return {
+                redirect: {
+                    destination: URL_PATHS.AUTH.LOGIN,
+                    permanent: false,
+                },
+            };
+        }
+        const getUser = GetProviderTherifyUser.factory(params);
+        const [{ user }, connectionRequest, { invoices }] = await Promise.all([
+            getUser({ userId: session.user.sub }),
+            // TODO: move to service method so we can get covered and remaining sessions
+            prisma.connectionRequest.findFirst({
+                where: {
+                    memberId,
+                    providerProfile: { userId: session.user.sub },
+                },
+                select: {
+                    member: {
+                        select: {
+                            id: true,
+                            givenName: true,
+                            surname: true,
+                            emailAddress: true,
+                        },
+                    },
+                },
+            }),
+            AccountsService.billing.getProviderSessionInvoicesByMemberId({
+                memberId,
+                providerId: session.user.sub,
+            }),
+        ]);
+        if (user === null) {
+            return {
+                redirect: {
+                    destination: URL_PATHS.AUTH.LOGIN,
+                    permanent: false,
+                },
+            };
+        }
+
+        if (connectionRequest === null) {
+            return {
+                notFound: true,
+            };
+        }
+
+        const props: ProviderClientDetailsPageProps = {
+            user,
+            memberDetails: connectionRequest.member,
+            invoices,
+        };
+        return JSON.parse(JSON.stringify({ props }));
+    };
+    return getClientDetailsPageProps;
+};

--- a/src/lib/modules/providers/service/page-props/get-client-details-page-props/getClientDetailsPageProps.ts
+++ b/src/lib/modules/providers/service/page-props/get-client-details-page-props/getClientDetailsPageProps.ts
@@ -19,12 +19,13 @@ export const factory = (params: ProvidersServiceParams) => {
     const getClientDetailsPageProps: GetServerSideProps<
         ProviderClientDetailsPageProps
     > = async (context) => {
-        const { memberId } = context.query;
-        if (typeof memberId !== 'string') {
+        const { memberId: memberIdentifier } = context.query;
+        if (typeof memberIdentifier !== 'string') {
             return {
                 notFound: true,
             };
         }
+        const memberId = `auth0|${memberIdentifier}`;
         const session = await getSession(context.req, context.res);
         if (!session) {
             return {

--- a/src/lib/modules/providers/service/page-props/get-client-details-page-props/index.ts
+++ b/src/lib/modules/providers/service/page-props/get-client-details-page-props/index.ts
@@ -1,0 +1,2 @@
+export * as GetClientDetailsPageProps from './getClientDetailsPageProps';
+export type { ProviderClientDetailsPageProps } from './getClientDetailsPageProps';

--- a/src/lib/modules/providers/service/page-props/index.ts
+++ b/src/lib/modules/providers/service/page-props/index.ts
@@ -1,6 +1,7 @@
 import { ProvidersServiceParams } from '../params';
 import { GetBillingPageProps } from './get-billing-page-props';
 import { GetChatPageProps } from './get-chat-page-props';
+import { GetClientDetailsPageProps } from './get-client-details-page-props';
 import { GetProviderClientsPageProps } from './get-clients-page-props';
 import { GetPracticeClientsPageProps } from './get-practice-clients-page-props';
 import { GetProviderProfileEditorPageProps } from './get-provider-profile-editor-page-props';
@@ -21,4 +22,5 @@ export const pagePropsFactory = (params: ProvidersServiceParams) => ({
     getProviderProfileEditorPageProps:
         GetProviderProfileEditorPageProps.factory(params),
     getChatPageProps: GetChatPageProps.factory(params),
+    getClientDetailsPageProps: GetClientDetailsPageProps.factory(params),
 });

--- a/src/lib/shared/components/features/pages/ProviderClientListPage/ProviderClientListPage.tsx
+++ b/src/lib/shared/components/features/pages/ProviderClientListPage/ProviderClientListPage.tsx
@@ -50,7 +50,12 @@ export function ProviderClientListPage({
     const [reimbursementDetails, setReimbursementDetails] =
         useState<ConnectionRequest.Type>();
     const handleClientSelect = (cr: ConnectionRequest.Type) =>
-        router.push(`${URL_PATHS.PROVIDERS.COACH.CLIENTS}/${cr.member.id}`);
+        router.push(
+            `${URL_PATHS.PROVIDERS.COACH.CLIENTS}/${cr.member.id.replace(
+                'auth0|',
+                ''
+            )}`
+        );
 
     return (
         <PageContainer>

--- a/src/lib/shared/components/features/pages/ProviderClientListPage/ProviderClientListPage.tsx
+++ b/src/lib/shared/components/features/pages/ProviderClientListPage/ProviderClientListPage.tsx
@@ -13,6 +13,8 @@ import { useProviderConnectionRequests } from '@/lib/modules/providers/component
 import { H1 } from '@/lib/shared/components/ui';
 import { ProfileType } from '@prisma/client';
 import { useFeatureFlags } from '@/lib/shared/hooks';
+import { useRouter } from 'next/router';
+import { URL_PATHS } from '@/lib/sitemap';
 
 const REIMBURSEMENT_REQUEST_URL =
     'https://hipaa.jotform.com/221371005584146?' as const;
@@ -31,6 +33,7 @@ export function ProviderClientListPage({
     onInvoiceClient,
 }: ProviderClientListPageProps) {
     const theme = useTheme();
+    const router = useRouter();
     const { flags } = useFeatureFlags(user);
     const {
         connectionRequests,
@@ -46,6 +49,9 @@ export function ProviderClientListPage({
         useState<ConnectionRequest.Type>();
     const [reimbursementDetails, setReimbursementDetails] =
         useState<ConnectionRequest.Type>();
+    const handleClientSelect = (cr: ConnectionRequest.Type) =>
+        router.push(`${URL_PATHS.PROVIDERS.COACH.CLIENTS}/${cr.member.id}`);
+
     return (
         <PageContainer>
             <Box
@@ -58,6 +64,11 @@ export function ProviderClientListPage({
             <ClientList
                 connectionRequests={connectionRequests}
                 designation={designation}
+                onClientSelect={
+                    designation === ProfileType.coach
+                        ? handleClientSelect
+                        : setMemberDetails
+                }
                 onViewMemberDetails={setMemberDetails}
                 onAcceptConnectionRequest={(connectionRequest) =>
                     setConfirmationConnectionRequest({

--- a/src/lib/shared/components/features/pages/ProviderClientListPage/ProviderClientListPage.tsx
+++ b/src/lib/shared/components/features/pages/ProviderClientListPage/ProviderClientListPage.tsx
@@ -65,7 +65,8 @@ export function ProviderClientListPage({
                 connectionRequests={connectionRequests}
                 designation={designation}
                 onClientSelect={
-                    designation === ProfileType.coach
+                    designation === ProfileType.coach &&
+                    user.stripeConnectAccountId
                         ? handleClientSelect
                         : setMemberDetails
                 }

--- a/src/lib/shared/utils/get-plan-by-date/getPlanByDate.ts
+++ b/src/lib/shared/utils/get-plan-by-date/getPlanByDate.ts
@@ -1,0 +1,20 @@
+import { Plan } from '@prisma/client';
+
+export const getPlanByDate = (plans: Plan[], date: Date) => {
+    return plans.find((plan) => {
+        const { startDate, endDate } = plan;
+        return startDate <= date && endDate >= date;
+    });
+};
+
+export const getCurrentPlan = (plans: Plan[]) => {
+    if (plans.length === 0) {
+        return null;
+    }
+
+    if (plans.length === 1) {
+        return plans[0];
+    }
+
+    return getPlanByDate(plans, new Date()) ?? null;
+};

--- a/src/lib/shared/utils/get-plan-by-date/index.ts
+++ b/src/lib/shared/utils/get-plan-by-date/index.ts
@@ -1,0 +1,1 @@
+export { getPlanByDate, getCurrentPlan } from './getPlanByDate';

--- a/src/lib/shared/utils/get-remaining-sessions-count/getRemainingSessionCount.ts
+++ b/src/lib/shared/utils/get-remaining-sessions-count/getRemainingSessionCount.ts
@@ -1,0 +1,21 @@
+import { Plan, RedeemedSession } from '@prisma/client';
+import { isBefore } from 'date-fns';
+
+export const getRemainingSessionCount = (
+    plan: {
+        coveredSessions: Plan['coveredSessions'];
+        endDate: Plan['endDate'];
+        startDate: Plan['startDate'];
+    },
+    redeemedSessions: RedeemedSession[]
+) => {
+    const { coveredSessions, endDate, startDate } = plan;
+    const sessionsInPlan = redeemedSessions.filter(
+        (session) =>
+            // dateOfSession is after startDate and before endDate
+            isBefore(startDate, session.dateOfSession) &&
+            isBefore(session.dateOfSession, endDate)
+    );
+    const remainingSessions = coveredSessions - sessionsInPlan.length;
+    return remainingSessions;
+};

--- a/src/lib/shared/utils/get-remaining-sessions-count/index.ts
+++ b/src/lib/shared/utils/get-remaining-sessions-count/index.ts
@@ -1,0 +1,1 @@
+export { getRemainingSessionCount } from './getRemainingSessionCount';

--- a/src/lib/shared/utils/index.ts
+++ b/src/lib/shared/utils/index.ts
@@ -10,3 +10,5 @@ export * from './get-urls';
 export * from './convert-nested-dates-to-iso-string';
 export * from './format-reimbursement-request-url';
 export * from './format-membership-plan-change-request-url ';
+export * from './get-remaining-sessions-count';
+export * from './get-plan-by-date';

--- a/src/lib/shared/vendors/stripe/client/void-invoice/index.ts
+++ b/src/lib/shared/vendors/stripe/client/void-invoice/index.ts
@@ -1,0 +1,1 @@
+export * as VoidInvoice from './voidInvoice';

--- a/src/lib/shared/vendors/stripe/client/void-invoice/voidInvoice.ts
+++ b/src/lib/shared/vendors/stripe/client/void-invoice/voidInvoice.ts
@@ -1,0 +1,10 @@
+import { StripeVendorFactoryParams } from '../types';
+
+export interface SendInvoiceFactoryParams extends StripeVendorFactoryParams {}
+
+export const factory =
+    ({ stripe }: SendInvoiceFactoryParams) =>
+    async (invoiceId: string): Promise<{ voided: true }> => {
+        await stripe.invoices.voidInvoice(invoiceId);
+        return { voided: true };
+    };

--- a/src/lib/shared/vendors/stripe/index.ts
+++ b/src/lib/shared/vendors/stripe/index.ts
@@ -17,6 +17,7 @@ import { CreatePrice } from './client/create-price';
 import { ArchivePrice } from './client/archive-price';
 import { CreateInvoice } from './client/create-invoice';
 import { SendInvoice } from './client/send-invoice';
+import { VoidInvoice } from './client/void-invoice';
 
 export * from './types';
 export * as StripeUtils from './utils';
@@ -49,6 +50,7 @@ export const vendorStripe = withStripeConfiguration((CONFIG) => {
         }),
         createInvoice: CreateInvoice.factory({ stripe }),
         sendInvoice: SendInvoice.factory({ stripe }),
+        voidInvoice: VoidInvoice.factory({ stripe }),
         createProduct: CreateProduct.factory({
             stripe,
         }),

--- a/src/pages/providers/coach/clients/[memberId].tsx
+++ b/src/pages/providers/coach/clients/[memberId].tsx
@@ -10,7 +10,7 @@ import { ClientDetails } from '@/lib/modules/providers/components/Clients';
 import { CenteredContainer, Modal } from '@/lib/shared/components/ui';
 import { format } from 'date-fns';
 import { CircularProgress } from '@mui/material';
-import { SessionInvoiceStatus } from '@prisma/client';
+import { ProfileType, SessionInvoiceStatus } from '@prisma/client';
 import { Alerts } from '@/lib/modules/alerts/context';
 import { MoneyOff } from '@mui/icons-material';
 import {
@@ -27,7 +27,7 @@ export const getServerSideProps = RBAC.requireCoachAuth(
 
 export default function ClientDetailsPage({
     user,
-    memberDetails,
+    connectionRequest,
     invoices: ssInvoices,
 }: ProviderClientDetailsPageProps) {
     const { createAlert } = useContext(Alerts.Context);
@@ -91,7 +91,8 @@ export default function ClientDetailsPage({
         >
             <ClientDetails
                 provider={user}
-                memberDetails={memberDetails}
+                designation={ProfileType.coach}
+                connectionRequest={connectionRequest}
                 invoices={invoices}
                 onBack={router.back}
                 onCreateInvoice={
@@ -99,8 +100,9 @@ export default function ClientDetailsPage({
                         ? () =>
                               onInvoiceClient(
                                   {
-                                      memberId: memberDetails.id,
-                                      givenName: memberDetails.givenName,
+                                      memberId: connectionRequest.member.id,
+                                      givenName:
+                                          connectionRequest.member.givenName,
                                   },
                                   refreshWindow
                               )
@@ -140,7 +142,7 @@ export default function ClientDetailsPage({
                         onVoidInvoice(
                             {
                                 sessionInvoiceId: invoiceToVoid.id,
-                                memberId: memberDetails.id,
+                                memberId: connectionRequest.member.id,
                                 providerId: user.userId,
                             },
                             voidInvoiceCallback

--- a/src/pages/providers/coach/clients/[memberId].tsx
+++ b/src/pages/providers/coach/clients/[memberId].tsx
@@ -46,7 +46,6 @@ export default function ClientDetailsPage({
     } = useSessionInvoicing(user?.userId);
 
     const voidInvoiceCallback: OnVoidInvoiceCallback = (result, error) => {
-        console.log('handleVoidSuccess', { result, error });
         if (error) {
             createAlert({
                 title: error.message,

--- a/src/pages/providers/coach/clients/[memberId].tsx
+++ b/src/pages/providers/coach/clients/[memberId].tsx
@@ -21,7 +21,6 @@ import {
     OnVoidInvoiceCallback,
 } from '@/lib/modules/accounts/components/hooks';
 import { trpc } from '@/lib/shared/utils/trpc';
-import { ConnectionRequest } from '@/lib/shared/types';
 
 export const getServerSideProps = RBAC.requireCoachAuth(
     withPageAuthRequired({

--- a/src/pages/providers/coach/clients/[memberId].tsx
+++ b/src/pages/providers/coach/clients/[memberId].tsx
@@ -81,6 +81,9 @@ export default function ClientDetailsPage({
             type: 'error',
         });
     };
+    const refreshWindow = () => {
+        if (typeof window !== 'undefined') window.location.reload();
+    };
     if (!user) return null;
     return (
         <ProviderNavigationPage
@@ -93,10 +96,13 @@ export default function ClientDetailsPage({
                 invoices={invoices}
                 onBack={router.back}
                 onCreateInvoice={() =>
-                    onInvoiceClient({
-                        memberId: memberDetails.id,
-                        givenName: memberDetails.givenName,
-                    })
+                    onInvoiceClient(
+                        {
+                            memberId: memberDetails.id,
+                            givenName: memberDetails.givenName,
+                        },
+                        refreshWindow
+                    )
                 }
                 onVoidInvoice={(invoice) => setInvoiceToVoid(invoice)}
             />

--- a/src/pages/providers/coach/clients/[memberId].tsx
+++ b/src/pages/providers/coach/clients/[memberId].tsx
@@ -1,3 +1,4 @@
+import { useContext, useState } from 'react';
 import { ProviderNavigationPage } from '@/lib/shared/components/features/pages';
 import { URL_PATHS } from '@/lib/sitemap';
 import { RBAC } from '@/lib/shared/utils';
@@ -5,6 +6,16 @@ import { withPageAuthRequired } from '@auth0/nextjs-auth0';
 import { ProvidersService } from '@/lib/modules/providers/service';
 import { ProviderClientDetailsPageProps } from '@/lib/modules/providers/service/page-props/get-client-details-page-props';
 import { ClientDetails } from '@/lib/modules/providers/components/Clients';
+import { CenteredContainer, Modal } from '@/lib/shared/components/ui';
+import { format } from 'date-fns';
+import { CircularProgress } from '@mui/material';
+import { SessionInvoiceStatus } from '@prisma/client';
+import { Alerts } from '@/lib/modules/alerts/context';
+import { MoneyOff } from '@mui/icons-material';
+import {
+    useSessionInvoicing,
+    OnVoidInvoiceCallback,
+} from '@/lib/modules/accounts/components/hooks';
 
 export const getServerSideProps = RBAC.requireCoachAuth(
     withPageAuthRequired({
@@ -16,8 +27,59 @@ export const getServerSideProps = RBAC.requireCoachAuth(
 export default function ClientDetailsPage({
     user,
     memberDetails,
-    invoices,
+    invoices: ssInvoices,
 }: ProviderClientDetailsPageProps) {
+    const { createAlert } = useContext(Alerts.Context);
+    const [invoices, setInvoices] =
+        useState<ProviderClientDetailsPageProps['invoices']>(ssInvoices);
+    const [invoiceToVoid, setInvoiceToVoid] = useState<
+        ProviderClientDetailsPageProps['invoices'][number] | null
+    >(null);
+
+    const {
+        onInvoiceClient,
+        ConfirmationUi: CreateInvoiceConfirmationModal,
+        onVoidInvoice,
+        isVoidingInvoice,
+    } = useSessionInvoicing(user?.userId);
+
+    const handleVoidSuccess: OnVoidInvoiceCallback = (result, error) => {
+        console.log('handleVoidSuccess', { result, error });
+        if (error) {
+            createAlert({
+                title: error.message,
+                type: 'error',
+            });
+            return;
+        }
+        const { voided, errors } = result;
+        if (voided) {
+            setInvoices(
+                invoices.map((invoice) => {
+                    if (invoice.id === invoiceToVoid?.id) {
+                        return {
+                            ...invoice,
+                            status: SessionInvoiceStatus.void,
+                        };
+                    }
+                    return invoice;
+                })
+            );
+            setInvoiceToVoid(null);
+            createAlert({
+                title: 'Invoice voided successfully',
+                type: 'success',
+            });
+            return;
+        }
+
+        const [errorMessage] = errors;
+        createAlert({
+            title: errorMessage ?? 'Error voiding invoice',
+            type: 'error',
+        });
+    };
+    if (!user) return null;
     return (
         <ProviderNavigationPage
             currentPath={URL_PATHS.PROVIDERS.COACH.CLIENTS}
@@ -27,7 +89,55 @@ export default function ClientDetailsPage({
                 provider={user}
                 memberDetails={memberDetails}
                 invoices={invoices}
+                onCreateInvoice={() =>
+                    onInvoiceClient({
+                        memberId: memberDetails.id,
+                        givenName: memberDetails.givenName,
+                    })
+                }
+                onVoidInvoice={(invoice) => setInvoiceToVoid(invoice)}
             />
+            {invoiceToVoid && (
+                <Modal
+                    isOpen
+                    title={
+                        invoiceToVoid.dateOfSession
+                            ? `Session on ${format(
+                                  new Date(invoiceToVoid.dateOfSession),
+                                  'MMMM dd, yyyy'
+                              )}`
+                            : 'Void Invoice'
+                    }
+                    message="Are you sure you want to void this invoice? It will no longer be possible to collect payment for this charge."
+                    showCloseButton={false}
+                    fullWidthButtons
+                    onClose={() => setInvoiceToVoid(null)}
+                    postBodySlot={
+                        isVoidingInvoice ? (
+                            <CenteredContainer fillSpace>
+                                <CircularProgress />
+                            </CenteredContainer>
+                        ) : null
+                    }
+                    secondaryButtonText="Cancel"
+                    secondaryButtonOnClick={() => setInvoiceToVoid(null)}
+                    secondaryButtonDisabled={isVoidingInvoice}
+                    primaryButtonText="Void"
+                    primaryButtonEndIcon={<MoneyOff />}
+                    primaryButtonDisabled={isVoidingInvoice}
+                    primaryButtonOnClick={() => {
+                        onVoidInvoice(
+                            {
+                                sessionInvoiceId: invoiceToVoid.id,
+                                memberId: memberDetails.id,
+                                providerId: user.userId,
+                            },
+                            handleVoidSuccess
+                        );
+                    }}
+                />
+            )}
+            <CreateInvoiceConfirmationModal />
         </ProviderNavigationPage>
     );
 }

--- a/src/pages/providers/coach/clients/[memberId].tsx
+++ b/src/pages/providers/coach/clients/[memberId].tsx
@@ -95,14 +95,17 @@ export default function ClientDetailsPage({
                 memberDetails={memberDetails}
                 invoices={invoices}
                 onBack={router.back}
-                onCreateInvoice={() =>
-                    onInvoiceClient(
-                        {
-                            memberId: memberDetails.id,
-                            givenName: memberDetails.givenName,
-                        },
-                        refreshWindow
-                    )
+                onCreateInvoice={
+                    user.stripeConnectAccountId
+                        ? () =>
+                              onInvoiceClient(
+                                  {
+                                      memberId: memberDetails.id,
+                                      givenName: memberDetails.givenName,
+                                  },
+                                  refreshWindow
+                              )
+                        : undefined
                 }
                 onVoidInvoice={(invoice) => setInvoiceToVoid(invoice)}
             />

--- a/src/pages/providers/coach/clients/[memberId].tsx
+++ b/src/pages/providers/coach/clients/[memberId].tsx
@@ -1,0 +1,33 @@
+import { ProviderNavigationPage } from '@/lib/shared/components/features/pages';
+import { URL_PATHS } from '@/lib/sitemap';
+import { RBAC } from '@/lib/shared/utils';
+import { withPageAuthRequired } from '@auth0/nextjs-auth0';
+import { ProvidersService } from '@/lib/modules/providers/service';
+import { ProviderClientDetailsPageProps } from '@/lib/modules/providers/service/page-props/get-client-details-page-props';
+import { ClientDetails } from '@/lib/modules/providers/components/Clients';
+
+export const getServerSideProps = RBAC.requireCoachAuth(
+    withPageAuthRequired({
+        getServerSideProps:
+            ProvidersService.pageProps.getClientDetailsPageProps,
+    })
+);
+
+export default function ClientDetailsPage({
+    user,
+    memberDetails,
+    invoices,
+}: ProviderClientDetailsPageProps) {
+    return (
+        <ProviderNavigationPage
+            currentPath={URL_PATHS.PROVIDERS.COACH.CLIENTS}
+            user={user}
+        >
+            <ClientDetails
+                provider={user}
+                memberDetails={memberDetails}
+                invoices={invoices}
+            />
+        </ProviderNavigationPage>
+    );
+}

--- a/src/pages/providers/coach/clients/[memberId].tsx
+++ b/src/pages/providers/coach/clients/[memberId].tsx
@@ -45,7 +45,7 @@ export default function ClientDetailsPage({
         isVoidingInvoice,
     } = useSessionInvoicing(user?.userId);
 
-    const handleVoidSuccess: OnVoidInvoiceCallback = (result, error) => {
+    const voidInvoiceCallback: OnVoidInvoiceCallback = (result, error) => {
         console.log('handleVoidSuccess', { result, error });
         if (error) {
             createAlert({
@@ -144,7 +144,7 @@ export default function ClientDetailsPage({
                                 memberId: memberDetails.id,
                                 providerId: user.userId,
                             },
-                            handleVoidSuccess
+                            voidInvoiceCallback
                         );
                     }}
                 />

--- a/src/pages/providers/coach/clients/[memberId].tsx
+++ b/src/pages/providers/coach/clients/[memberId].tsx
@@ -1,4 +1,5 @@
 import { useContext, useState } from 'react';
+import { useRouter } from 'next/router';
 import { ProviderNavigationPage } from '@/lib/shared/components/features/pages';
 import { URL_PATHS } from '@/lib/sitemap';
 import { RBAC } from '@/lib/shared/utils';
@@ -30,6 +31,7 @@ export default function ClientDetailsPage({
     invoices: ssInvoices,
 }: ProviderClientDetailsPageProps) {
     const { createAlert } = useContext(Alerts.Context);
+    const router = useRouter();
     const [invoices, setInvoices] =
         useState<ProviderClientDetailsPageProps['invoices']>(ssInvoices);
     const [invoiceToVoid, setInvoiceToVoid] = useState<
@@ -89,6 +91,7 @@ export default function ClientDetailsPage({
                 provider={user}
                 memberDetails={memberDetails}
                 invoices={invoices}
+                onBack={router.back}
                 onCreateInvoice={() =>
                     onInvoiceClient({
                         memberId: memberDetails.id,


### PR DESCRIPTION
# Description
Adds page for Coaches to view member details and invoices that have been sent to a client.
Coaches can create invoices and void unpaid invoices from this screen.
Coaches can submit reimbursement requests from this screen.
# Closes issue(s)

# How to test / repro

# Screenshots
<img width="1360" alt="image" src="https://user-images.githubusercontent.com/25045075/236056050-ad94e9de-81dd-4e6b-aaef-126357707daf.png">

![image](https://user-images.githubusercontent.com/25045075/235267006-db218c47-f882-4d5e-abcc-4b73f1cb5904.png)


![image](https://user-images.githubusercontent.com/25045075/235266981-64f68f13-e4e6-43c4-a6a7-4d4f0b964ed1.png)

# Changes include

-   [ ] Bugfix (non-breaking change that solves an issue)
-   [x] New feature (non-breaking change that adds functionality)
-   [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Checklist

-   [ ] I have tested this code
-   [ ] I have updated the Readme

# Other comments
