### PR TITLE
chore: feature flag coach client details page

### DIFF
--- a/src/lib/shared/components/features/pages/ProviderClientListPage/ProviderClientListPage.tsx
+++ b/src/lib/shared/components/features/pages/ProviderClientListPage/ProviderClientListPage.tsx
@@ -56,7 +56,10 @@ export function ProviderClientListPage({
                 ''
             )}`
         );
-
+    const shouldAllowClientSelect =
+        flags.canAccessClientDetailsPage &&
+        designation === ProfileType.coach &&
+        user.stripeConnectAccountId;
     return (
         <PageContainer>
             <Box
@@ -70,8 +73,7 @@ export function ProviderClientListPage({
                 connectionRequests={connectionRequests}
                 designation={designation}
                 onClientSelect={
-                    designation === ProfileType.coach &&
-                    user.stripeConnectAccountId
+                    shouldAllowClientSelect
                         ? handleClientSelect
                         : setMemberDetails
                 }

--- a/src/lib/shared/types/feature-flags/featureFlags.ts
+++ b/src/lib/shared/types/feature-flags/featureFlags.ts
@@ -4,6 +4,7 @@ export const schema = z.object({
     didFlagsLoad: z.boolean(),
     hasStripeConnectAccess: z.boolean(),
     useIframeReimbursementRequest: z.boolean(),
+    canAccessClientDetailsPage: z.boolean(),
 });
 
 export type Type = z.infer<typeof schema>;
@@ -15,6 +16,7 @@ export const defaultFlags: FeatureFlags = {
     didFlagsLoad: false,
     hasStripeConnectAccess: false,
     useIframeReimbursementRequest: false,
+    canAccessClientDetailsPage: false,
 };
 
 export const isValid = (flags: unknown): boolean => {


### PR DESCRIPTION
# Description
- Adds `canAccessClientDetailsPage` feature flag to block client side access to Client Details page
- Handles `Cannot read properties of undefined` type error from serverside prerendered page
# Closes issue(s)

# How to test / repro

# Screenshots

# Changes include

-   [ ] Bugfix (non-breaking change that solves an issue)
-   [ ] New feature (non-breaking change that adds functionality)
-   [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Checklist

-   [ ] I have tested this code
-   [ ] I have updated the Readme

# Other comments
