### PR TITLE
feat: add banner UI

### DIFF
--- a/src/lib/shared/components/features/pages/SideNavigationPage/SideNavigationPage.tsx
+++ b/src/lib/shared/components/features/pages/SideNavigationPage/SideNavigationPage.tsx
@@ -1,10 +1,15 @@
 import { useState } from 'react';
-import { List, Box } from '@mui/material';
+import { List, Box, Color } from '@mui/material';
 import { styled, useTheme } from '@mui/material/styles';
-import { Button, BUTTON_TYPE } from '@/lib/shared/components/ui';
+import {
+    Banner,
+    Button,
+    BUTTON_TYPE,
+    BannerProps,
+} from '@/lib/shared/components/ui';
 import { ActionNavListItem } from '@/lib/shared/components/ui/Navigation/NavigationMenu';
 import { NavigationLink, URL_PATHS } from '@/lib/sitemap';
-import { usePlanMonitoring } from '@/lib/shared/hooks';
+import { usePlanMonitoring, useFeatureFlags } from '@/lib/shared/hooks';
 import { TherifyUser } from '@/lib/shared/types';
 import {
     SideNavigationLayout,
@@ -44,6 +49,7 @@ export const SideNavigationPage = ({
     const { hasAccess } = usePlanMonitoring(user);
     const [isMobileMenuOpen, setIsMobileMenuOpen] = useState(false);
     const theme = useTheme();
+    const { flags } = useFeatureFlags(user);
     const {
         drawer: notificationDrawer,
         notifications,
@@ -54,6 +60,18 @@ export const SideNavigationPage = ({
     } = useInAppNotificationDrawer();
     return (
         <SideNavigationLayout
+            bannerSlot={
+                flags.bannerContent.message && (
+                    <Banner
+                        message={flags.bannerContent.message}
+                        color={
+                            flags.bannerContent.color as BannerProps['color']
+                        }
+                        linkText={flags.bannerContent.linkText}
+                        linkUrl={flags.bannerContent.linkUrl}
+                    />
+                )
+            }
             topbarSlot={
                 <SecondaryTopBar
                     menu={secondaryMenu}

--- a/src/lib/shared/components/features/pages/SideNavigationPage/SideNavigationPage.tsx
+++ b/src/lib/shared/components/features/pages/SideNavigationPage/SideNavigationPage.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react';
-import { List, Box, Color } from '@mui/material';
+import { List, Box } from '@mui/material';
 import { styled, useTheme } from '@mui/material/styles';
 import {
     Banner,

--- a/src/lib/shared/components/features/pages/TopNavigationPage/TopNavigationPage.tsx
+++ b/src/lib/shared/components/features/pages/TopNavigationPage/TopNavigationPage.tsx
@@ -4,8 +4,10 @@ import { LogoutRounded as LogoutIcon } from '@mui/icons-material';
 import { styled, useTheme } from '@mui/material/styles';
 import { NavigationLink, URL_PATHS } from '@/lib/sitemap';
 import { TherifyUser } from '@/lib/shared/types';
-import { usePlanMonitoring } from '@/lib/shared/hooks';
+import { usePlanMonitoring, useFeatureFlags } from '@/lib/shared/hooks';
 import {
+    Banner,
+    BannerProps,
     Button,
     BUTTON_TYPE,
     TopNavigationLayout,
@@ -42,6 +44,7 @@ export const TopNavigationPage = ({
     const { hasAccess } = usePlanMonitoring(user);
     const [isMobileMenuOpen, setIsMobileMenuOpen] = useState(false);
     const theme = useTheme();
+    const { flags } = useFeatureFlags(user ?? undefined);
     const {
         drawer: notificationDrawer,
         notifications,
@@ -53,6 +56,18 @@ export const TopNavigationPage = ({
 
     return (
         <TopNavigationLayout
+            bannerSlot={
+                flags.bannerContent.message && (
+                    <Banner
+                        message={flags.bannerContent.message}
+                        color={
+                            flags.bannerContent.color as BannerProps['color']
+                        }
+                        linkText={flags.bannerContent.linkText}
+                        linkUrl={flags.bannerContent.linkUrl}
+                    />
+                )
+            }
             navigationSlot={
                 user && (
                     <TopNavigationBar

--- a/src/lib/shared/components/ui/Banner/Banner.spec.tsx
+++ b/src/lib/shared/components/ui/Banner/Banner.spec.tsx
@@ -1,0 +1,45 @@
+import { Banner, TEST_IDS } from './Banner';
+import { renderWithTheme } from '../../fixtures/renderWithTheme';
+
+describe('Banner', () => {
+    const mockMessage = 'Hello world';
+    const mockUrl = 'therify.co';
+    it('renders Banner text', () => {
+        const { getByText } = renderWithTheme(<Banner message={mockMessage} />);
+        expect(getByText(mockMessage)).toBeVisible();
+    });
+
+    it('renders link as href', () => {
+        const { getByTestId } = renderWithTheme(
+            <Banner message={mockMessage} linkUrl={mockUrl} />
+        );
+        const linkEl = getByTestId(TEST_IDS.LINK);
+        expect(linkEl).toHaveAttribute('href', mockUrl);
+    });
+
+    it('renders arrow link text as default', () => {
+        const { getByTestId } = renderWithTheme(
+            <Banner message={mockMessage} linkUrl={mockUrl} />
+        );
+        expect(getByTestId(TEST_IDS.ARROW_ICON)).toBeVisible();
+    });
+
+    it('renders link text when provided', () => {
+        const { getByText, queryByTestId } = renderWithTheme(
+            <Banner
+                message={mockMessage}
+                linkUrl={mockUrl}
+                linkText="Click here"
+            />
+        );
+        expect(getByText('Click here')).toBeVisible();
+        expect(queryByTestId(TEST_IDS.ARROW_ICON)).toBeNull();
+    });
+
+    it('does not render link when no url provided', () => {
+        const { queryByTestId } = renderWithTheme(
+            <Banner message={mockMessage} />
+        );
+        expect(queryByTestId(TEST_IDS.LINK)).toBeNull();
+    });
+});

--- a/src/lib/shared/components/ui/Banner/Banner.stories.tsx
+++ b/src/lib/shared/components/ui/Banner/Banner.stories.tsx
@@ -1,0 +1,18 @@
+import { Meta, StoryFn } from '@storybook/react';
+import { Banner as BannerUi } from './Banner';
+
+const meta: Meta<typeof BannerUi> = {
+    title: 'Components/Banner',
+    component: BannerUi,
+    args: {
+        message: 'Did you know we have banners?',
+        linkText: 'Click Here',
+        linkUrl: '/',
+    },
+};
+
+export default meta;
+
+export const Default: StoryFn<typeof BannerUi> = (args) => (
+    <BannerUi {...args} />
+);

--- a/src/lib/shared/components/ui/Banner/Banner.tsx
+++ b/src/lib/shared/components/ui/Banner/Banner.tsx
@@ -1,0 +1,94 @@
+import { Theme, styled } from '@mui/material/styles';
+import { Box, Link } from '@mui/material';
+import { Paragraph } from '../Typography/Paragraph';
+import { ArrowCircleRightRounded } from '@mui/icons-material';
+
+interface BannerProps {
+    message: string;
+    color?: 'primary' | 'secondary' | 'success' | 'error' | 'warning' | 'info';
+    linkUrl?: string;
+    linkText?: string;
+}
+
+export const TEST_IDS = {
+    LINK: 'link',
+    ARROW_ICON: 'arrow-icon',
+} as const;
+
+export const Banner = ({ message, color, linkUrl, linkText }: BannerProps) => {
+    return (
+        <BannerContainer color={color}>
+            <Paragraph noMargin>{message}</Paragraph>
+            {linkUrl && (
+                <Link href={linkUrl} data-testid={TEST_IDS.LINK}>
+                    {linkText ?? (
+                        <ArrowCircleRightRounded
+                            data-testid={TEST_IDS.ARROW_ICON}
+                        />
+                    )}
+                </Link>
+            )}
+        </BannerContainer>
+    );
+};
+
+const BannerContainer = styled(Box, {
+    shouldForwardProp: (prop) => prop !== 'color',
+})<{ color: BannerProps['color'] }>(({ theme, color: colorInput }) => {
+    const { color, background } = getColor(colorInput, theme);
+    return {
+        width: '100%',
+        height: '70px',
+        padding: theme.spacing(4, 8),
+        textAlign: 'center',
+        color,
+        background,
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        '& a': {
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+            color,
+            textDecorationColor: color,
+            padding: theme.spacing(2),
+        },
+    };
+});
+
+function getColor(color: BannerProps['color'], { palette }: Theme) {
+    switch (color) {
+        case 'secondary':
+            return {
+                background: palette.secondary.main,
+                color: palette.secondary.contrastText,
+            };
+        case 'error':
+            return {
+                background: palette.error.main,
+                color: palette.error.contrastText,
+            };
+        case 'info':
+            return {
+                background: palette.info.main,
+                color: palette.info.contrastText,
+            };
+        case 'warning':
+            return {
+                background: palette.warning.main,
+                color: palette.warning.contrastText,
+            };
+        case 'success':
+            return {
+                background: palette.success.main,
+                color: palette.success.contrastText,
+            };
+        case 'primary':
+        default:
+            return {
+                background: palette.primary.main,
+                color: palette.primary.contrastText,
+            };
+    }
+}

--- a/src/lib/shared/components/ui/Banner/Banner.tsx
+++ b/src/lib/shared/components/ui/Banner/Banner.tsx
@@ -3,7 +3,7 @@ import { Box, Link } from '@mui/material';
 import { Paragraph } from '../Typography/Paragraph';
 import { ArrowCircleRightRounded } from '@mui/icons-material';
 
-interface BannerProps {
+export interface BannerProps {
     message: string;
     color?: 'primary' | 'secondary' | 'success' | 'error' | 'warning' | 'info';
     linkUrl?: string;

--- a/src/lib/shared/components/ui/Banner/index.ts
+++ b/src/lib/shared/components/ui/Banner/index.ts
@@ -1,0 +1,1 @@
+export { Banner } from './Banner';

--- a/src/lib/shared/components/ui/Banner/index.ts
+++ b/src/lib/shared/components/ui/Banner/index.ts
@@ -1,1 +1,2 @@
 export { Banner } from './Banner';
+export type { BannerProps } from './Banner';

--- a/src/lib/shared/components/ui/Layout/SideNavigationLayout/SideNavigationLayout.spec.tsx
+++ b/src/lib/shared/components/ui/Layout/SideNavigationLayout/SideNavigationLayout.spec.tsx
@@ -13,6 +13,17 @@ describe('SideNavigationLayout', () => {
         expect(getByText('Topbar')).toBeVisible();
     });
 
+    it('renders banner content', () => {
+        const { getByText } = render(
+            <SideNavigationLayout
+                bannerSlot={<div>Banner</div>}
+                topbarSlot={<div>Topbar</div>}
+                navigationSlot={<div />}
+            ></SideNavigationLayout>
+        );
+        expect(getByText('Banner')).toBeVisible();
+    });
+
     it('renders navigation content', () => {
         const { getByText } = render(
             <SideNavigationLayout
@@ -20,7 +31,7 @@ describe('SideNavigationLayout', () => {
                 navigationSlot={<div>Navigation</div>}
             ></SideNavigationLayout>
         );
-        expect(getByText('Navigation')).not.toBeVisible();
+        expect(getByText('Navigation')).toBeInTheDocument();
     });
 
     it('renders children content', () => {

--- a/src/lib/shared/components/ui/Layout/SideNavigationLayout/SideNavigationLayout.tsx
+++ b/src/lib/shared/components/ui/Layout/SideNavigationLayout/SideNavigationLayout.tsx
@@ -4,15 +4,18 @@ import { styled } from '@mui/material/styles';
 
 interface SideNavigationLayoutProps {
     topbarSlot: React.ReactNode;
+    bannerSlot?: React.ReactNode;
     navigationSlot: React.ReactNode;
 }
 export const SideNavigationLayout = ({
     topbarSlot,
+    bannerSlot,
     navigationSlot,
     children,
 }: PropsWithChildren<SideNavigationLayoutProps>) => {
     return (
         <LayoutContainer>
+            {bannerSlot}
             {topbarSlot}
             <ContentContainer>
                 <SideBarContainer component="nav">

--- a/src/lib/shared/components/ui/Layout/TopNavigationLayout/TopNavigationLayout.spec.tsx
+++ b/src/lib/shared/components/ui/Layout/TopNavigationLayout/TopNavigationLayout.spec.tsx
@@ -11,6 +11,16 @@ describe('TopNavigationLayout', () => {
         expect(getByText('Navigation')).toBeInTheDocument();
     });
 
+    it('renders banner content', () => {
+        const { getByText } = render(
+            <TopNavigationLayout
+                bannerSlot={<div>Banner</div>}
+                navigationSlot={<div>Navigation</div>}
+            ></TopNavigationLayout>
+        );
+        expect(getByText('Banner')).toBeInTheDocument();
+    });
+
     it('renders children content', () => {
         const { getByText } = render(
             <TopNavigationLayout navigationSlot={<div>Navigation</div>}>

--- a/src/lib/shared/components/ui/Layout/TopNavigationLayout/index.tsx
+++ b/src/lib/shared/components/ui/Layout/TopNavigationLayout/index.tsx
@@ -2,9 +2,11 @@ import { Box } from '@mui/material';
 import React, { PropsWithChildren } from 'react';
 
 interface TopNavigationLayoutProps {
+    bannerSlot?: React.ReactNode;
     navigationSlot: React.ReactNode;
 }
 export const TopNavigationLayout = ({
+    bannerSlot,
     navigationSlot,
     children,
 }: PropsWithChildren<TopNavigationLayoutProps>) => {
@@ -16,6 +18,7 @@ export const TopNavigationLayout = ({
             flexDirection="column"
             overflow="hidden"
         >
+            {bannerSlot}
             {navigationSlot}
             <Box flexGrow={1} overflow="hidden">
                 {children}

--- a/src/lib/shared/components/ui/index.ts
+++ b/src/lib/shared/components/ui/index.ts
@@ -15,6 +15,7 @@ export {
     TEST_IDS as BADGE_TEST_IDS,
 } from './Badge';
 export { Banner } from './Banner';
+export type { BannerProps } from './Banner';
 export { BlockQuote, BLOCK_QUOTE_SIZE } from './BlockQuote';
 export { CallToActionCard } from './CallToActionCard';
 export { Carousel } from './Carousel';

--- a/src/lib/shared/components/ui/index.ts
+++ b/src/lib/shared/components/ui/index.ts
@@ -14,6 +14,7 @@ export {
     BADGE_TYPE,
     TEST_IDS as BADGE_TEST_IDS,
 } from './Badge';
+export { Banner } from './Banner';
 export { BlockQuote, BLOCK_QUOTE_SIZE } from './BlockQuote';
 export { CallToActionCard } from './CallToActionCard';
 export { Carousel } from './Carousel';

--- a/src/lib/shared/types/feature-flags/featureFlags.ts
+++ b/src/lib/shared/types/feature-flags/featureFlags.ts
@@ -5,6 +5,12 @@ export const schema = z.object({
     hasStripeConnectAccess: z.boolean(),
     useIframeReimbursementRequest: z.boolean(),
     canAccessClientDetailsPage: z.boolean(),
+    bannerContent: z.object({
+        message: z.string().optional(),
+        color: z.string().optional(),
+        linkUrl: z.string().optional(),
+        linkText: z.string().optional(),
+    }),
 });
 
 export type Type = z.infer<typeof schema>;
@@ -17,6 +23,7 @@ export const defaultFlags: FeatureFlags = {
     hasStripeConnectAccess: false,
     useIframeReimbursementRequest: false,
     canAccessClientDetailsPage: false,
+    bannerContent: {},
 };
 
 export const isValid = (flags: unknown): boolean => {


### PR DESCRIPTION
# Description
Adds Feature flag driven Banner solution
- Adds `Banner` shared UI component
- Adds `bannerContent` JSON feature flag
- Adds Banners to Sidenavigation layout and top navigation layout pages

Banner content feature flage schema: 
```
bannerContent: z.object({
        message: z.string().optional(),
        color: z.string().optional(),
        linkUrl: z.string().optional(),
        linkText: z.string().optional(),
    }),
```

# Closes issue(s)

# How to test / repro
To render a banner, a new banner content object will need to be added as a variation to the Launch Darkly feature flag.
After the variation is added, you can add rule to evaluate when and to whom that content should be shown. 

# Screenshots
### Side navigation Banner
<img width="1781" alt="image" src="https://github.com/Therify/directory/assets/25045075/027a0492-7c42-4e26-8f9f-e2d22ddc523a">

### Top navigation Banner
<img width="1792" alt="image" src="https://github.com/Therify/directory/assets/25045075/616dcc92-451e-493a-b099-efb6a47d6567">



# Changes include

-   [ ] Bugfix (non-breaking change that solves an issue)
-   [x] New feature (non-breaking change that adds functionality)
-   [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Checklist

-   [x] I have tested this code
-   [ ] I have updated the Readme

# Other comments
