### PR TITLE
chore: add British Columbia + reimbursement prefill improvements

### DIFF
--- a/src/lib/shared/types/address/canada/province.ts
+++ b/src/lib/shared/types/address/canada/province.ts
@@ -1,8 +1,9 @@
 import * as z from 'zod';
-export const ENTRIES = ['Alberta', 'Ontario'] as const;
+export const ENTRIES = ['Alberta', 'British Columbia', 'Ontario'] as const;
 
 export const MAP = {
     ALBERTA: 'Alberta',
+    BRITISH_COLUMBIA: 'British Columbia',
     ONTARIO: 'Ontario',
 } as const;
 

--- a/src/lib/shared/types/provider-profile/providerProfile.ts
+++ b/src/lib/shared/types/provider-profile/providerProfile.ts
@@ -4,7 +4,7 @@ import { ProviderProfileSchema } from '../../schema';
 import { ProviderCredential } from '../provider-credential';
 import { ProviderSupervisor } from '../provider-supervisor';
 import { AcceptedInsurance } from '../accepted-insurance';
-import { convertNestedDatesToISOString } from '../../utils';
+import { convertNestedDatesToISOString } from '../../utils/convert-nested-dates-to-iso-string';
 
 export const schema = ProviderProfileSchema.extend({
     pronouns: Pronoun.schema,

--- a/src/lib/shared/utils/format-reimbursement-request-url/formatReimbursementRequestUrl.spec.ts
+++ b/src/lib/shared/utils/format-reimbursement-request-url/formatReimbursementRequestUrl.spec.ts
@@ -1,5 +1,5 @@
 import { ConnectionStatus, ProfileType } from '@prisma/client';
-import { ConnectionRequest, UNITED_STATES } from '../../types';
+import { CANADA, ConnectionRequest, UNITED_STATES } from '../../types';
 import {
     formatReimbursementRequestUrl,
     generateTherifyReimbursementDetails,
@@ -117,5 +117,28 @@ describe('formatReimbursementRequestUrl', () => {
                 connectionRequest: requestMissingLastName,
             }).includes(lastNameKey)
         ).toBe(false);
+    });
+
+    it('should prefill Candian Province', () => {
+        const requestWithCanadianProvince = {
+            ...mockConnectionRequest,
+            member: {
+                ...mockConnectionRequest.member,
+                memberProfile: {
+                    ...mockConnectionRequest.member.memberProfile,
+                    state: CANADA.PROVINCE.MAP.ALBERTA,
+                    country: CANADA.COUNTRY.CODE,
+                },
+            },
+        } as unknown as ConnectionRequest.Type;
+        const url = formatReimbursementRequestUrl({
+            baseUrl,
+            designation: ProfileType.therapist,
+            connectionRequest: requestWithCanadianProvince,
+        });
+        expect(
+            url.includes(`clientprovince=${CANADA.PROVINCE.MAP.ALBERTA}`)
+        ).toBe(true);
+        expect(url.includes('clientstate')).toBe(false);
     });
 });

--- a/src/lib/shared/utils/format-reimbursement-request-url/formatReimbursementRequestUrl.ts
+++ b/src/lib/shared/utils/format-reimbursement-request-url/formatReimbursementRequestUrl.ts
@@ -1,5 +1,5 @@
 import { ProfileType } from '@prisma/client';
-import { CANADA, ConnectionRequest } from '../../types';
+import { CANADA, ConnectionRequest } from '@/lib/shared/types';
 
 const REIMBURSEMENT_KEY_MAPS = [
     ['clientname[first]', 'member.givenName'],

--- a/src/lib/shared/utils/format-reimbursement-request-url/formatReimbursementRequestUrl.ts
+++ b/src/lib/shared/utils/format-reimbursement-request-url/formatReimbursementRequestUrl.ts
@@ -1,5 +1,5 @@
 import { ProfileType } from '@prisma/client';
-import { ConnectionRequest } from '../../types';
+import { CANADA, ConnectionRequest } from '../../types';
 
 const REIMBURSEMENT_KEY_MAPS = [
     ['clientname[first]', 'member.givenName'],
@@ -39,7 +39,15 @@ export function formatReimbursementRequestUrl({
                 connectionRequest,
                 connectionRequestKey
             );
-            if (value) return `${queryKey}=${value}`;
+            if (value) {
+                const isClientProvinceKey =
+                    queryKey === 'clientstate' &&
+                    connectionRequest.member.memberProfile.country ===
+                        CANADA.COUNTRY.CODE;
+                const key = isClientProvinceKey ? 'clientprovince' : queryKey;
+                return `${key}=${value}`;
+            }
+            return undefined;
         }
     ).filter(Boolean);
 


### PR DESCRIPTION
# Description
- Adds `British columbia` as a Canadian province option
- Fixes prefill for Canadian province on reimbursement request Jotform URL

# Closes issue(s)

# How to test / repro

# Screenshots
![image](https://github.com/Therify/directory/assets/25045075/3427352f-6e33-4396-85f4-af2cdfa2a914)

# Changes include

-   [x] Bugfix (non-breaking change that solves an issue)
-   [ ] New feature (non-breaking change that adds functionality)
-   [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Checklist

-   [ ] I have tested this code
-   [ ] I have updated the Readme

# Other comments
