### PR TITLE
chore: handle JotForm submission with no therify details

### DIFF
--- a/src/lib/modules/accounts/features/billing/handle-raw-reimbursement-submission/index.ts
+++ b/src/lib/modules/accounts/features/billing/handle-raw-reimbursement-submission/index.ts
@@ -1,0 +1,4 @@
+export { schema as InputSchema } from './input';
+export { schema as OutputSchema } from './output';
+export type { Input } from './input';
+export type { Output } from './output';

--- a/src/lib/modules/accounts/features/billing/handle-raw-reimbursement-submission/input.ts
+++ b/src/lib/modules/accounts/features/billing/handle-raw-reimbursement-submission/input.ts
@@ -1,0 +1,28 @@
+import * as z from 'zod';
+
+export const schema = z.object({
+    submissionId: z.string(),
+    memberEmail: z.string(),
+    dateOfSession: z.date(),
+    provider: z.object({
+        firstName: z.string(),
+        lastName: z.string(),
+        email: z.string(),
+        practiceName: z.string(),
+    }),
+});
+
+export type Input = z.infer<typeof schema>;
+
+export const validate = (value: unknown): Input => {
+    return schema.parse(value);
+};
+
+export const isValid = (value: unknown): value is Input => {
+    try {
+        validate(value);
+        return true;
+    } catch {
+        return false;
+    }
+};

--- a/src/lib/modules/accounts/features/billing/handle-raw-reimbursement-submission/output.ts
+++ b/src/lib/modules/accounts/features/billing/handle-raw-reimbursement-submission/output.ts
@@ -1,0 +1,20 @@
+import * as z from 'zod';
+
+export const schema = z.object({
+    success: z.boolean(),
+    errors: z.array(z.string()),
+});
+export type Output = z.infer<typeof schema>;
+
+export const validate = (value: unknown): Output => {
+    return schema.parse(value);
+};
+
+export const isValid = (value: unknown): value is Output => {
+    try {
+        validate(value);
+        return true;
+    } catch {
+        return false;
+    }
+};

--- a/src/lib/modules/accounts/features/billing/index.ts
+++ b/src/lib/modules/accounts/features/billing/index.ts
@@ -8,5 +8,6 @@ export * as HandleCoachingSessionPayment from './handle-coaching-session-payment
 export * as RenewPlan from './renew-plan';
 export * as CancelPlan from './cancel-plan';
 export * as HandleReimbursementSubmission from './handle-reimbursement-submission';
+export * as HandleRawReimbursementSubmission from './handle-raw-reimbursement-submission';
 export * as HandleMembershipPlanPayment from './handle-membership-plan-payment';
 export * as VoidCoachingSessionInvoice from './void-coaching-session-invoice';

--- a/src/lib/modules/accounts/service/billing/billingFactory.ts
+++ b/src/lib/modules/accounts/service/billing/billingFactory.ts
@@ -12,6 +12,7 @@ import { HandleReimbursementSubmission } from './handle-reimbursement-submission
 import { HandleMembershipPlanPayment } from './handle-membership-plan-payment';
 import { GetProviderSessionInvoicesByMemberId } from './get-provider-session-invoices-by-member-id';
 import { VoidCoachingSessionInvoice } from './void-coaching-session-invoice';
+import { HandleRawReimbursementSubmission } from './handle-raw-reimbursement-submission';
 
 export const factory = (context: AccountsServiceParams) => ({
     handleCoachingSessionPayment: HandleCoachingSessionPayment.factory(context),
@@ -31,4 +32,6 @@ export const factory = (context: AccountsServiceParams) => ({
         GetProviderSessionInvoicesByMemberId.factory(context),
     handleReimbursementSubmission:
         HandleReimbursementSubmission.factory(context),
+    handleRawReimbursementSubmission:
+        HandleRawReimbursementSubmission.factory(context),
 });

--- a/src/lib/modules/accounts/service/billing/handle-raw-reimbursement-submission/getConnectionDetails.ts
+++ b/src/lib/modules/accounts/service/billing/handle-raw-reimbursement-submission/getConnectionDetails.ts
@@ -1,0 +1,153 @@
+import { Practice, PrismaClient, ProviderProfile, User } from '@prisma/client';
+interface ProviderInput {
+    firstName: string;
+    lastName: string;
+    email: string;
+    practiceName: string;
+}
+interface getConnectionDetailsParams {
+    memberId: string;
+    provider: ProviderInput;
+    prisma: PrismaClient;
+}
+
+export const getConnectionDetails = async ({
+    memberId,
+    provider,
+    prisma,
+}: getConnectionDetailsParams): Promise<{
+    memberId: string;
+    providerProfileId?: string;
+    practiceId?: string;
+}> => {
+    // Get connection request from member Id
+    // Find provider profile Id from connection request comparing provider name and email
+    // Find practice Id from provider profile Id
+    const connectionRequests = await prisma.connectionRequest.findMany({
+        where: { memberId },
+        select: {
+            connectionStatus: true,
+            providerProfile: {
+                select: {
+                    id: true,
+                    givenName: true,
+                    surname: true,
+                    contactEmail: true,
+                    user: true,
+                    practiceProfile: {
+                        select: {
+                            practice: true,
+                        },
+                    },
+                },
+            },
+        },
+    });
+
+    const matchingConnectionRequests = connectionRequests.filter((request) => {
+        const { providerProfile } = request;
+        if (!providerProfile) return false;
+        return isProvider(providerProfile, provider);
+    });
+    const [accepted] = matchingConnectionRequests.filter(
+        (request) => request.connectionStatus === 'accepted'
+    );
+    if (accepted) {
+        return {
+            memberId,
+            providerProfileId: accepted.providerProfile.id,
+            practiceId: accepted.providerProfile.practiceProfile?.practice.id,
+        };
+    }
+    if (matchingConnectionRequests.length > 0) {
+        // Matching profile, but no accepted connection requests
+        if (matchingConnectionRequests.length === 1) {
+            // assume the one connection request is the provider and they just didnt accept the client
+            const [matchedRequest] = matchingConnectionRequests;
+            return {
+                memberId: memberId,
+                providerProfileId: matchedRequest.providerProfile.id,
+                practiceId:
+                    matchedRequest.providerProfile.practiceProfile?.practice.id,
+            };
+        }
+        // No accepted connection requests found
+        throw new Error(
+            '[getConnectionDetails]: Cannot determine which provider issued session'
+        );
+    }
+
+    if (connectionRequests.length > 0) {
+        //check if we can at least find a matching practice
+        const matchedPracticeRequest = connectionRequests.find(
+            ({ providerProfile }) => {
+                return isPractice(
+                    providerProfile.practiceProfile?.practice,
+                    provider.practiceName
+                );
+            }
+        );
+
+        if (matchedPracticeRequest) {
+            return {
+                memberId,
+                practiceId:
+                    matchedPracticeRequest.providerProfile.practiceProfile
+                        ?.practice.id,
+            };
+        }
+    }
+
+    return {
+        memberId,
+    };
+};
+
+const isProvider = (
+    providerProfile: Pick<
+        ProviderProfile,
+        'id' | 'givenName' | 'surname' | 'contactEmail'
+    > & {
+        user: User | null;
+        practiceProfile?: {
+            practice: Practice | null;
+        } | null;
+    },
+    provider: ProviderInput
+) => {
+    if (!providerProfile) return false;
+    const { user: profileOwner } = providerProfile;
+    if (profileOwner) {
+        const isEmailMatch = profileOwner.emailAddress === provider.email;
+        const isNameMatch =
+            isSameString(profileOwner.givenName, provider.firstName) &&
+            isSameString(profileOwner.surname, provider.lastName);
+        if (isEmailMatch || isNameMatch) return true;
+    }
+
+    const isProfileEmailMatch = providerProfile.contactEmail === provider.email;
+    const isProfileNameMatch =
+        isSameString(providerProfile.givenName, provider.firstName) &&
+        isSameString(providerProfile.surname, provider.lastName);
+
+    if (isProfileEmailMatch || isProfileNameMatch) return true;
+
+    return false;
+};
+
+const isPractice = (practice: Practice | undefined, practiceName: string) => {
+    if (!practice) return false;
+    return (
+        isSameString(practice.name, practiceName) ||
+        cleanString(practice.name).includes(cleanString(practiceName)) ||
+        cleanString(practiceName).includes(cleanString(practice.name))
+    );
+};
+
+const cleanString = (str: string) => {
+    return str.toLowerCase().trim();
+};
+
+const isSameString = (str1: string, str2: string) => {
+    return cleanString(str1) === cleanString(str2);
+};

--- a/src/lib/modules/accounts/service/billing/handle-raw-reimbursement-submission/getMemberId.ts
+++ b/src/lib/modules/accounts/service/billing/handle-raw-reimbursement-submission/getMemberId.ts
@@ -1,0 +1,17 @@
+import { PrismaClient, Role } from '@prisma/client';
+
+export const getMemberId = async (
+    memberEmail: string | undefined,
+    prisma: PrismaClient
+): Promise<{ memberId: string }> => {
+    if (!memberEmail) throw new Error('[getMember]: No member email provided');
+    const member = await prisma.user.findFirst({
+        where: { emailAddress: memberEmail },
+        select: { id: true, roles: true },
+    });
+    if (!member) throw new Error('[getMember]: No member user found');
+    if (!member.roles.includes(Role.member))
+        throw new Error('[getMember]: User is not a member');
+
+    return { memberId: member.id };
+};

--- a/src/lib/modules/accounts/service/billing/handle-raw-reimbursement-submission/getPlanForMember.ts
+++ b/src/lib/modules/accounts/service/billing/handle-raw-reimbursement-submission/getPlanForMember.ts
@@ -1,0 +1,41 @@
+import { PrismaClient } from '@prisma/client';
+
+export const getPlanForMember = async (
+    { memberId, dateOfSession }: { memberId: string; dateOfSession: Date },
+    prisma: PrismaClient
+) => {
+    const { account } = await prisma.user.findUniqueOrThrow({
+        where: { id: memberId },
+        select: {
+            account: {
+                select: {
+                    id: true,
+                    plans: {
+                        where: {
+                            startDate: {
+                                lte: dateOfSession,
+                            },
+                            endDate: {
+                                gte: dateOfSession,
+                            },
+                        },
+                        take: 1,
+                    },
+                },
+            },
+        },
+    });
+    if (!account)
+        throw new Error(
+            '[getPlanForMember]: No account found for member: ' + memberId
+        );
+    const [plan] = account.plans;
+    if (!plan)
+        throw new Error(
+            '[getPlanForMember]: No plan found for account: ' +
+                account.id +
+                ' for member: ' +
+                memberId
+        );
+    return plan.id;
+};

--- a/src/lib/modules/accounts/service/billing/handle-raw-reimbursement-submission/handleRawReimbursementSubmission.ts
+++ b/src/lib/modules/accounts/service/billing/handle-raw-reimbursement-submission/handleRawReimbursementSubmission.ts
@@ -1,0 +1,38 @@
+import { HandleRawReimbursementSubmission } from '@/lib/modules/accounts/features/billing';
+import { AccountsServiceParams } from '../../params';
+import { getMemberId } from './getMemberId';
+import { getConnectionDetails } from './getConnectionDetails';
+import { getPlanForMember } from './getPlanForMember';
+import { RedeemedSessionStatus } from '@prisma/client';
+
+export const factory =
+    ({ prisma }: AccountsServiceParams) =>
+    async ({
+        provider,
+        dateOfSession,
+        memberEmail,
+        submissionId,
+    }: HandleRawReimbursementSubmission.Input) => {
+        const { memberId } = await getMemberId(memberEmail, prisma);
+        const { practiceId, providerProfileId } = await getConnectionDetails({
+            memberId,
+            provider,
+            prisma,
+        });
+        const planId = await getPlanForMember(
+            { memberId, dateOfSession },
+            prisma
+        );
+        const redeemedSession = await prisma.redeemedSession.create({
+            data: {
+                dateOfSession,
+                memberId,
+                ...(providerProfileId ? { profileId: providerProfileId } : {}),
+                ...(practiceId ? { practiceId } : {}),
+                jotformSubmissionId: submissionId,
+                planId,
+                status: RedeemedSessionStatus.claimed,
+            },
+        });
+        return redeemedSession;
+    };

--- a/src/lib/modules/accounts/service/billing/handle-raw-reimbursement-submission/index.ts
+++ b/src/lib/modules/accounts/service/billing/handle-raw-reimbursement-submission/index.ts
@@ -1,0 +1,1 @@
+export * as HandleRawReimbursementSubmission from './handleRawReimbursementSubmission';

--- a/src/lib/modules/providers/components/Clients/ReimbursementModal/ReimbursementModal.tsx
+++ b/src/lib/modules/providers/components/Clients/ReimbursementModal/ReimbursementModal.tsx
@@ -8,7 +8,7 @@ import { ProfileType } from '@prisma/client';
 import { useRef, useEffect, useState } from 'react';
 
 const REIMBURSEMENT_REQUEST_URL =
-    'https://hipaa.jotform.com/221371005584146?' as const;
+    'https://hipaa.jotform.com/221371005584146' as const;
 
 interface ReimbursementModalProps {
     designation: ProfileType;

--- a/src/lib/modules/webhooks/services/jotform/form-submissions/formIds.ts
+++ b/src/lib/modules/webhooks/services/jotform/form-submissions/formIds.ts
@@ -11,7 +11,7 @@ export const FORMS = {
 export type Form = (typeof FORMS)[keyof typeof FORMS];
 
 export const DEVELOPMENT_FORM_IDS: Record<Form, string> = {
-    [FORMS.REIMBURSMENT_REQUEST_V2]: '230950700793153',
+    [FORMS.REIMBURSMENT_REQUEST_V2]: '231355344303144',
 } as const;
 
 export const PRODUCTION_FORM_IDS: Record<Form, string> = {

--- a/src/lib/modules/webhooks/services/jotform/form-submissions/handlers/reimbursment-request/handler.ts
+++ b/src/lib/modules/webhooks/services/jotform/form-submissions/handlers/reimbursment-request/handler.ts
@@ -10,30 +10,53 @@ interface ReimbursementRequestHandlerParams {
 export const factory =
     ({ accounts }: JotformWebhookParams) =>
     async ({ submissionId, payload }: ReimbursementRequestHandlerParams) => {
-        const { dateofsession, therifydetails } = payload;
+        const {
+            dateofsession,
+            therifydetails,
+            provideremail,
+            providername,
+            practice: practiceName,
+            clientemail,
+        } = payload;
         const dateString = `${dateofsession.year}-${dateofsession.month}-${dateofsession.day}`;
-        const date = new Date(dateString);
-        const therifyDetails = JSON.parse(therifydetails);
-        if (!isValid(date)) {
+        const dateOfSession = new Date(dateString);
+        if (!isValid(dateOfSession)) {
             throw new Error('Date of session is invalid!');
         }
-        const result = await accounts.billing.handleReimbursementSubmission({
-            memberId: therifyDetails.memberId,
-            providerProfileId: therifyDetails.providerProfileId,
-            practiceId: therifyDetails.practiceId,
-            dateOfSession: date.toDateString(),
-            submissionId,
-        });
-        if (result.isErr()) {
-            let errorMessage = 'Could not handle form submission';
-            result.mapErr(([errorStep, error]) => {
-                const message = (error as Error)?.message;
-                const failedStepMessage = `Failed on step: ${errorStep}`;
-                errorMessage = `[handleInvoicePayment error]: ${
-                    message ?? failedStepMessage
-                }`;
+        if (therifydetails) {
+            const therifyDetails = JSON.parse(therifydetails);
+            const result = await accounts.billing.handleReimbursementSubmission(
+                {
+                    memberId: therifyDetails.memberId,
+                    providerProfileId: therifyDetails.providerProfileId,
+                    practiceId: therifyDetails.practiceId,
+                    dateOfSession: dateOfSession.toISOString(),
+                    submissionId,
+                }
+            );
+            if (result.isErr()) {
+                let errorMessage = 'Could not handle form submission';
+                result.mapErr(([errorStep, error]) => {
+                    const message = (error as Error)?.message;
+                    const failedStepMessage = `Failed on step: ${errorStep}`;
+                    errorMessage = `[handleInvoicePayment error]: ${
+                        message ?? failedStepMessage
+                    }`;
+                });
+                throw new Error(`${errorMessage} - ${submissionId}`);
+            }
+        } else {
+            await accounts.billing.handleRawReimbursementSubmission({
+                dateOfSession,
+                submissionId,
+                memberEmail: clientemail,
+                provider: {
+                    firstName: providername.first,
+                    lastName: providername.last,
+                    email: provideremail,
+                    practiceName,
+                },
             });
-            throw new Error(errorMessage);
         }
 
         return { success: true };

--- a/src/lib/modules/webhooks/services/jotform/schema/reimbursementRequest.ts
+++ b/src/lib/modules/webhooks/services/jotform/schema/reimbursementRequest.ts
@@ -8,6 +8,10 @@ export const schema = baseFormSubmission.extend({
         day: z.string(),
         year: z.string(),
     }),
+    clientemail: z.string(),
+    providername: z.object({ first: z.string(), last: z.string() }),
+    provideremail: z.string(),
+    practice: z.string(),
 });
 
 export type ReimbursementRequest = z.infer<typeof schema>;

--- a/src/lib/shared/components/features/pages/PracticeClientListPage/PracticeClientListPage.tsx
+++ b/src/lib/shared/components/features/pages/PracticeClientListPage/PracticeClientListPage.tsx
@@ -34,9 +34,7 @@ import { ConnectionStatus } from '@prisma/client';
 import { getCoveredSessionsMessage } from '@/lib/modules/providers/components/Clients/utils';
 
 const REIMBURSEMENT_REQUEST_URL =
-    process.env.NEXT_PUBLIC_VERCEL_ENV === 'production'
-        ? ('https://hipaa.jotform.com/221371005584146' as const)
-        : ('https://form.jotform.com/230950700793153' as const);
+    'https://hipaa.jotform.com/221371005584146' as const;
 
 type ProfileConnectionRequest =
     PracticeProfileConnectionRequests.Type['profileConnectionRequests'][number]['connectionRequests'][number];

--- a/src/lib/shared/components/features/pages/ProviderClientListPage/ProviderClientListPage.tsx
+++ b/src/lib/shared/components/features/pages/ProviderClientListPage/ProviderClientListPage.tsx
@@ -17,7 +17,7 @@ import { useRouter } from 'next/router';
 import { URL_PATHS } from '@/lib/sitemap';
 
 const REIMBURSEMENT_REQUEST_URL =
-    'https://hipaa.jotform.com/221371005584146?' as const;
+    'https://hipaa.jotform.com/221371005584146' as const;
 
 interface ProviderClientListPageProps {
     baseConnectionRequests: ConnectionRequest.Type[];


### PR DESCRIPTION
# Description
Previously when the `therifydetails` input was empty on a Reimbursement form submission, the webhook would throw an `SyntaxError: Unexpected end of JSON input` error. This update adds logic to handle submissions with empty `therifydetails` by trying to find a member and provider relation. The webhook only throws now if no member can be found for the `clientemail` field or if parsing data off of the submission fails.

# Closes issue(s)

# How to test / repro

# Screenshots

# Changes include

-   [ ] Bugfix (non-breaking change that solves an issue)
-   [ ] New feature (non-breaking change that adds functionality)
-   [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Checklist

-   [ ] I have tested this code
-   [ ] I have updated the Readme

# Other comments
Manually tested with localtunnel