### PR TITLE
feat: member plan management

### DIFF
--- a/src/lib/modules/accounts/features/billing/create-stripe-billing-portal-session/index.ts
+++ b/src/lib/modules/accounts/features/billing/create-stripe-billing-portal-session/index.ts
@@ -1,0 +1,5 @@
+export { schema as inputSchema } from './input';
+export { schema as outputSchema } from './output';
+export type { Input } from './input';
+export type { Output } from './output';
+export { ROUTE as TRPC_ROUTE } from './trpc';

--- a/src/lib/modules/accounts/features/billing/create-stripe-billing-portal-session/input.ts
+++ b/src/lib/modules/accounts/features/billing/create-stripe-billing-portal-session/input.ts
@@ -1,0 +1,21 @@
+import * as z from 'zod';
+
+export const schema = z.object({
+    userId: z.string(),
+    returnUrl: z.string(),
+});
+
+export type Input = z.infer<typeof schema>;
+
+export const validate = (value: unknown): Input => {
+    return schema.parse(value);
+};
+
+export const isValid = (value: unknown): value is Input => {
+    try {
+        validate(value);
+        return true;
+    } catch {
+        return false;
+    }
+};

--- a/src/lib/modules/accounts/features/billing/create-stripe-billing-portal-session/output.ts
+++ b/src/lib/modules/accounts/features/billing/create-stripe-billing-portal-session/output.ts
@@ -1,0 +1,27 @@
+import * as z from 'zod';
+import { PlanSchema } from '@/lib/shared/schema';
+
+export const schema = z.union([
+    z.object({
+        billingPortalUrl: z.string(),
+        errors: z.array(z.string()),
+    }),
+    z.object({
+        billingPortalUrl: z.literal(null),
+        errors: z.array(z.string()),
+    }),
+]);
+export type Output = z.infer<typeof schema>;
+
+export const validate = (value: unknown): Output => {
+    return schema.parse(value);
+};
+
+export const isValid = (value: unknown): value is Output => {
+    try {
+        validate(value);
+        return true;
+    } catch {
+        return false;
+    }
+};

--- a/src/lib/modules/accounts/features/billing/create-stripe-billing-portal-session/trpc.ts
+++ b/src/lib/modules/accounts/features/billing/create-stripe-billing-portal-session/trpc.ts
@@ -1,0 +1,1 @@
+export const ROUTE = 'billing.create-stripe-billing-portal-session' as const;

--- a/src/lib/modules/accounts/features/billing/index.ts
+++ b/src/lib/modules/accounts/features/billing/index.ts
@@ -1,6 +1,7 @@
 export * as CreateCoachingSessionInvoice from './create-coaching-session-checkout';
 export * as GetProviderSessionInvoicesByMemberId from './get-provider-session-invoices-by-member-id';
 export * as CreateStripeConnectLoginUrl from './create-stripe-connect-login-url';
+export * as CreateStripeBillingPortalSession from './create-stripe-billing-portal-session';
 export * as HandleGroupPracticePlanPayment from './handle-group-practice-plan-payment';
 export * as HandlePlanChange from './handle-plan-change';
 export * as HandleStripeConnectOnboarding from './handle-stripe-connect-onboarding';

--- a/src/lib/modules/accounts/routes/resolvers/create-stripe-billing-portal-session/index.ts
+++ b/src/lib/modules/accounts/routes/resolvers/create-stripe-billing-portal-session/index.ts
@@ -1,0 +1,1 @@
+export { resolve as createStripeBillingPortalSessionResolver } from './resolver';

--- a/src/lib/modules/accounts/routes/resolvers/create-stripe-billing-portal-session/resolver.ts
+++ b/src/lib/modules/accounts/routes/resolvers/create-stripe-billing-portal-session/resolver.ts
@@ -1,0 +1,31 @@
+import { Context } from '@/lib/server/context';
+import { CreateStripeBillingPortalSession } from '@/lib/modules/accounts/features/billing';
+import { ProcedureResolver } from '@trpc/server/dist/declarations/src/internals/procedure';
+
+export const resolve: ProcedureResolver<
+    Context,
+    CreateStripeBillingPortalSession.Input,
+    CreateStripeBillingPortalSession.Output
+> = async function ({
+    input,
+    ctx,
+}): Promise<CreateStripeBillingPortalSession.Output> {
+    try {
+        const { billingPortalUrl } =
+            await ctx.accounts.billing.createStripeBillingPortalSession(input);
+        return {
+            billingPortalUrl,
+            errors: [],
+        };
+    } catch (error) {
+        let errorMessage =
+            'Creating Stripe billing portal session failed with an unknown error.';
+        if (error instanceof Error) {
+            errorMessage = error.message;
+        }
+        return {
+            billingPortalUrl: null,
+            errors: [errorMessage],
+        };
+    }
+};

--- a/src/lib/modules/accounts/routes/resolvers/index.ts
+++ b/src/lib/modules/accounts/routes/resolvers/index.ts
@@ -14,3 +14,4 @@ export { createCoachingSessionInvoiceResolver } from './create-coaching-session-
 export { voidCoachingSessionInvoiceResolver } from './void-coaching-session-invoice';
 export { registerAccountOwnerResolver } from './register-account-owner';
 export { getAccountByOwnerIdResolver } from './get-account-by-owner-id';
+export { createStripeBillingPortalSessionResolver } from './create-stripe-billing-portal-session';

--- a/src/lib/modules/accounts/routes/router.ts
+++ b/src/lib/modules/accounts/routes/router.ts
@@ -33,6 +33,7 @@ import {
     registerAccountOwnerResolver,
     getAccountByOwnerIdResolver,
     voidCoachingSessionInvoiceResolver,
+    createStripeBillingPortalSessionResolver,
 } from './resolvers';
 import { Context } from '../../../server/context';
 import {
@@ -40,6 +41,7 @@ import {
     CreateStripeConnectLoginUrl,
     CreateCoachingSessionInvoice,
     VoidCoachingSessionInvoice,
+    CreateStripeBillingPortalSession,
 } from '../features/billing';
 import { GetAccountByOwnerId } from '../features';
 
@@ -124,4 +126,9 @@ export const router = trpc
         input: SendEmailVerification.inputSchema,
         output: SendEmailVerification.outputSchema,
         resolve: sendEmailVerificationResolver,
+    })
+    .mutation(CreateStripeBillingPortalSession.TRPC_ROUTE, {
+        input: CreateStripeBillingPortalSession.inputSchema,
+        output: CreateStripeBillingPortalSession.outputSchema,
+        resolve: createStripeBillingPortalSessionResolver,
     });

--- a/src/lib/modules/accounts/service/billing/billingFactory.ts
+++ b/src/lib/modules/accounts/service/billing/billingFactory.ts
@@ -13,6 +13,7 @@ import { HandleMembershipPlanPayment } from './handle-membership-plan-payment';
 import { GetProviderSessionInvoicesByMemberId } from './get-provider-session-invoices-by-member-id';
 import { VoidCoachingSessionInvoice } from './void-coaching-session-invoice';
 import { HandleRawReimbursementSubmission } from './handle-raw-reimbursement-submission';
+import { CreateStripeBillingPortalSession } from './create-stripe-billing-portal-session';
 
 export const factory = (context: AccountsServiceParams) => ({
     handleCoachingSessionPayment: HandleCoachingSessionPayment.factory(context),
@@ -34,4 +35,6 @@ export const factory = (context: AccountsServiceParams) => ({
         HandleReimbursementSubmission.factory(context),
     handleRawReimbursementSubmission:
         HandleRawReimbursementSubmission.factory(context),
+    createStripeBillingPortalSession:
+        CreateStripeBillingPortalSession.factory(context),
 });

--- a/src/lib/modules/accounts/service/billing/create-stripe-billing-portal-session/createStripeBillingPortalSession.ts
+++ b/src/lib/modules/accounts/service/billing/create-stripe-billing-portal-session/createStripeBillingPortalSession.ts
@@ -1,0 +1,30 @@
+import { CreateStripeBillingPortalSession } from '@/lib/modules/accounts/features/billing';
+import { AccountsServiceParams } from '../../params';
+
+export const factory =
+    ({ prisma, stripe }: AccountsServiceParams) =>
+    async ({
+        userId,
+        returnUrl,
+    }: CreateStripeBillingPortalSession.Input): Promise<{
+        billingPortalUrl: string;
+    }> => {
+        const { stripeCustomerId } = await prisma.user.findFirstOrThrow({
+            where: {
+                id: userId,
+            },
+            select: {
+                stripeCustomerId: true,
+            },
+        });
+        if (!stripeCustomerId) {
+            throw new Error('User does not have a stripe customer id');
+        }
+        const { billingPortalUrl } = await stripe.createBillingPortalSession({
+            customerId: stripeCustomerId,
+            returnUrl,
+        });
+        return {
+            billingPortalUrl,
+        };
+    };

--- a/src/lib/modules/accounts/service/billing/create-stripe-billing-portal-session/index.ts
+++ b/src/lib/modules/accounts/service/billing/create-stripe-billing-portal-session/index.ts
@@ -1,0 +1,1 @@
+export * as CreateStripeBillingPortalSession from './createStripeBillingPortalSession';

--- a/src/lib/shared/vendors/stripe/client/create-billing-portal-session/createBillingPortalSession.ts
+++ b/src/lib/shared/vendors/stripe/client/create-billing-portal-session/createBillingPortalSession.ts
@@ -1,0 +1,15 @@
+import { StripeVendorFactoryParams } from '../types';
+import { Input, Output } from './schema';
+
+export interface CreateBillingPortalSessionFactoryParams
+    extends StripeVendorFactoryParams {}
+
+export const factory =
+    ({ stripe }: CreateBillingPortalSessionFactoryParams) =>
+    async ({ customerId, returnUrl: return_url }: Input): Promise<Output> => {
+        const link = await stripe.billingPortal.sessions.create({
+            customer: customerId,
+            return_url,
+        });
+        return { billingPortalUrl: link.url };
+    };

--- a/src/lib/shared/vendors/stripe/client/create-billing-portal-session/index.ts
+++ b/src/lib/shared/vendors/stripe/client/create-billing-portal-session/index.ts
@@ -1,0 +1,1 @@
+export * as CreateBillingPortalSession from './createBillingPortalSession';

--- a/src/lib/shared/vendors/stripe/client/create-billing-portal-session/schema/index.ts
+++ b/src/lib/shared/vendors/stripe/client/create-billing-portal-session/schema/index.ts
@@ -1,0 +1,4 @@
+export { schema as inputSchema } from './input';
+export type { Input } from './input';
+export { schema as outputSchema } from './output';
+export type { Output } from './output';

--- a/src/lib/shared/vendors/stripe/client/create-billing-portal-session/schema/input.ts
+++ b/src/lib/shared/vendors/stripe/client/create-billing-portal-session/schema/input.ts
@@ -1,0 +1,21 @@
+import * as z from 'zod';
+
+export const schema = z.object({
+    customerId: z.string(),
+    returnUrl: z.string(),
+});
+
+export type Input = z.infer<typeof schema>;
+
+export const validate = (value: unknown): Input => {
+    return schema.parse(value);
+};
+
+export const isValid = (value: unknown): value is Input => {
+    try {
+        validate(value);
+        return true;
+    } catch {
+        return false;
+    }
+};

--- a/src/lib/shared/vendors/stripe/client/create-billing-portal-session/schema/output.ts
+++ b/src/lib/shared/vendors/stripe/client/create-billing-portal-session/schema/output.ts
@@ -1,0 +1,20 @@
+import * as z from 'zod';
+
+export const schema = z.object({
+    billingPortalUrl: z.string(),
+});
+
+export type Output = z.infer<typeof schema>;
+
+export const validate = (value: unknown): Output => {
+    return schema.parse(value);
+};
+
+export const isValid = (value: unknown): value is Output => {
+    try {
+        validate(value);
+        return true;
+    } catch {
+        return false;
+    }
+};

--- a/src/lib/shared/vendors/stripe/index.ts
+++ b/src/lib/shared/vendors/stripe/index.ts
@@ -18,6 +18,7 @@ import { ArchivePrice } from './client/archive-price';
 import { CreateInvoice } from './client/create-invoice';
 import { SendInvoice } from './client/send-invoice';
 import { VoidInvoice } from './client/void-invoice';
+import { CreateBillingPortalSession } from './client/create-billing-portal-session';
 
 export * from './types';
 export * as StripeUtils from './utils';
@@ -34,6 +35,9 @@ export const vendorStripe = withStripeConfiguration((CONFIG) => {
             stripe,
         }),
         createAccountLink: CreateAccountLink.factory({
+            stripe,
+        }),
+        createBillingPortalSession: CreateBillingPortalSession.factory({
             stripe,
         }),
         createStripeConnectLoginLink: CreateStripeConnectLoginLink.factory({

--- a/src/pages/members/account/billing.tsx
+++ b/src/pages/members/account/billing.tsx
@@ -21,7 +21,6 @@ import {
     CenteredContainer,
     Badge,
     Divider,
-    Caption,
     H5,
 } from '@/lib/shared/components/ui';
 import { PlanStatus } from '@prisma/client';
@@ -121,52 +120,6 @@ export default function BillingPage({
                             </>
                         )}
 
-                    {!user?.isAccountAdmin && (
-                        <>
-                            <Divider />
-                            <H3>Billing and Payments</H3>
-                            <Paragraph>
-                                We partner with{' '}
-                                <Link
-                                    href="https://stripe.com/"
-                                    target="_blank"
-                                    style={{
-                                        color: theme.palette.text.primary,
-                                    }}
-                                >
-                                    Stripe
-                                </Link>{' '}
-                                for simplified billing. You can edit billing
-                                settings and pay invoices in Stripe&apos;s
-                                customer portal.
-                            </Paragraph>
-
-                            {stripeCustomerPortalUrl ? (
-                                <Link
-                                    href={stripeCustomerPortalUrl}
-                                    target="_blank"
-                                    style={{ textDecoration: 'none' }}
-                                >
-                                    <Button endIcon={<ArrowIcon />}>
-                                        Launch Stripe Customer Portal
-                                    </Button>
-                                </Link>
-                            ) : (
-                                <Alert
-                                    icon={
-                                        <CenteredContainer>
-                                            <WarningRounded />
-                                        </CenteredContainer>
-                                    }
-                                    title="Stripe Billing Issue"
-                                    type="error"
-                                    message="Stripe customer portal URL is not configured. Please reach
-                    out to Therify support."
-                                />
-                            )}
-                        </>
-                    )}
-
                     {user?.plan && (
                         <>
                             <Divider />
@@ -188,65 +141,121 @@ export default function BillingPage({
                                         {getPlanStatusText(user.plan.status)}
                                     </Badge>
                                 </Box>
-                                <Paragraph>
-                                    Period start:{' '}
-                                    {format(
-                                        new Date(user.plan.startDate),
-                                        'MMMM do, yyyy'
-                                    )}
-                                </Paragraph>
-                                <Paragraph>
-                                    Period end:{' '}
-                                    {format(
-                                        new Date(user.plan.endDate),
-                                        'MMMM do, yyyy'
-                                    )}
-                                </Paragraph>
-                                {accountDetails && (
+                                {user.plan.status !== PlanStatus.canceled && (
                                     <>
-                                        {accountDetails.totalSeats > 1 && (
-                                            <Paragraph>
-                                                Usage:{' '}
-                                                {`${
-                                                    accountDetails.claimedSeats
-                                                } ${
-                                                    accountDetails.claimedSeats ===
-                                                    1
-                                                        ? 'seat'
-                                                        : 'seats'
-                                                } claimed of ${
-                                                    accountDetails.totalSeats
-                                                } total ${
-                                                    accountDetails.totalSeats ===
-                                                    1
-                                                        ? 'seat'
-                                                        : 'seats'
-                                                }`}
-                                            </Paragraph>
-                                        )}
-
                                         <Paragraph>
-                                            Covered Sessions{' '}
-                                            {accountDetails.totalSeats > 1 &&
-                                                'per seat '}
-                                            {getBillingCycleDisplayText(
-                                                user.plan.startDate,
-                                                user.plan.endDate
+                                            Period start:{' '}
+                                            {format(
+                                                new Date(user.plan.startDate),
+                                                'MMMM do, yyyy'
                                             )}
-                                            : {accountDetails.coveredSessions}
                                         </Paragraph>
+                                        <Paragraph>
+                                            Period end:{' '}
+                                            {format(
+                                                new Date(user.plan.endDate),
+                                                'MMMM do, yyyy'
+                                            )}
+                                        </Paragraph>
+                                        {accountDetails && (
+                                            <>
+                                                {accountDetails.totalSeats >
+                                                    1 && (
+                                                    <Paragraph>
+                                                        Usage:{' '}
+                                                        {`${
+                                                            accountDetails.claimedSeats
+                                                        } ${
+                                                            accountDetails.claimedSeats ===
+                                                            1
+                                                                ? 'seat'
+                                                                : 'seats'
+                                                        } claimed of ${
+                                                            accountDetails.totalSeats
+                                                        } total ${
+                                                            accountDetails.totalSeats ===
+                                                            1
+                                                                ? 'seat'
+                                                                : 'seats'
+                                                        }`}
+                                                    </Paragraph>
+                                                )}
+
+                                                <Paragraph>
+                                                    Covered Sessions{' '}
+                                                    {accountDetails.totalSeats >
+                                                        1 && 'per seat '}
+                                                    {getBillingCycleDisplayText(
+                                                        user.plan.startDate,
+                                                        user.plan.endDate
+                                                    )}
+                                                    :{' '}
+                                                    {
+                                                        accountDetails.coveredSessions
+                                                    }
+                                                </Paragraph>
+                                            </>
+                                        )}
                                     </>
                                 )}
                             </Box>
                         </>
                     )}
+
+                    <Divider />
+                    <H3>
+                        {user?.isAccountAdmin
+                            ? 'Invoices, Billing Methods, and Plan Cancelation'
+                            : 'Billing & Payments'}
+                    </H3>
+                    <Paragraph>
+                        We partner with{' '}
+                        <Link
+                            href="https://stripe.com/"
+                            target="_blank"
+                            style={{
+                                color: theme.palette.text.primary,
+                            }}
+                        >
+                            Stripe
+                        </Link>{' '}
+                        for simplified billing.{' '}
+                        {user?.isAccountAdmin
+                            ? "You can edit billing settings, cancel/renew your subscription, and pay invoices in Stripe's customer portal."
+                            : "You can edit billing settings and pay invoices in Stripe's customer portal."}
+                    </Paragraph>
+
+                    {stripeCustomerPortalUrl ? (
+                        <Link
+                            href={stripeCustomerPortalUrl}
+                            target="_blank"
+                            style={{ textDecoration: 'none' }}
+                        >
+                            <Button endIcon={<ArrowIcon />}>
+                                Launch Stripe Customer Portal
+                            </Button>
+                        </Link>
+                    ) : (
+                        <Alert
+                            icon={
+                                <CenteredContainer>
+                                    <WarningRounded />
+                                </CenteredContainer>
+                            }
+                            title="Stripe Billing Issue"
+                            type="error"
+                            message="Stripe customer portal URL is not configured. Please reach
+                    out to Therify support."
+                        />
+                    )}
+
                     {user?.isAccountAdmin && user.plan && (
                         <Box width="100%" marginTop={4}>
                             <Divider />
                             <H4>Request to change your plan</H4>
                             <Paragraph>
-                                You may submit a request to update or cancel
-                                your plan by launching and submitting a plan
+                                Need more seats or sessions? You may submit a
+                                request to update your plan by submitting a plan
                                 change request. Plan changes are usually
                                 processed within 2-3 business days (excluding
                                 holidays).
@@ -283,7 +292,7 @@ export default function BillingPage({
                                         );
                                 }}
                             >
-                                Launch Plan Change Form
+                                Request a Plan Change
                             </Button>
                         </Box>
                     )}

--- a/src/pages/members/account/billing.tsx
+++ b/src/pages/members/account/billing.tsx
@@ -265,7 +265,7 @@ export default function BillingPage({
                     </Paragraph>
 
                     <Button
-                        isDisabled={isBillingPortalSessionLoading}
+                        disabled={isBillingPortalSessionLoading}
                         isLoading={isBillingPortalSessionLoading}
                         onClick={() =>
                             createBillingPortalSession({


### PR DESCRIPTION
# Description
Adds Stripe billing portal access to dtc members. Also creates billing portal sessions so members no longer need email links from Stripe to log in.

# Closes issue(s)

# How to test / repro
1. Login as a DTC member. 
2. go to the billing page.
3. Click the "Launch Stripe Customer Portal" button

# Screenshots
![image](https://github.com/Therify/directory/assets/25045075/0a672814-508e-4440-9619-8249a63b71aa)

# Changes include

-   [ ] Bugfix (non-breaking change that solves an issue)
-   [x] New feature (non-breaking change that adds functionality)
-   [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Checklist

-   [ ] I have tested this code
-   [ ] I have updated the Readme

# Other comments
