### PR TITLE
chore: add launchdarkly vendor

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
         "jest": "^29.3.1",
         "jest-environment-jsdom": "^29.3.1",
         "jest-mock-extended": "2.0.4",
+        "launchdarkly-node-server-sdk": "^7.0.1",
         "launchdarkly-react-client-sdk": "^3.0.4",
         "mailing-core": "^0.9.10",
         "micro": "^10.0.1",

--- a/src/lib/shared/types/feature-flags/featureFlags.ts
+++ b/src/lib/shared/types/feature-flags/featureFlags.ts
@@ -1,11 +1,27 @@
 import * as z from 'zod';
 
+export const SERVER_FLAGS = {
+    DID_FLAGS_LOAD: 'did-flags-load',
+    HAS_STRIPE_CONNECT_ACCESS: 'has-stripe-connect-access',
+    USE_IFRAME_REIMBURSEMENT_REQUEST: 'use-iframe-reimbursement-request',
+    CAN_ACCESS_CLIENT_DETAILS_PAGE: 'can-access-client-details-page',
+    BANNER_CONTENT: 'banner-content',
+} as const;
+
+export const CLIENT_FLAGS = {
+    DID_FLAGS_LOAD: 'didFlagsLoad',
+    HAS_STRIPE_CONNECT_ACCESS: 'hasStripeConnectAccess',
+    USE_IFRAME_REIMBURSEMENT_REQUEST: 'useIframeReimbursementRequest',
+    CAN_ACCESS_CLIENT_DETAILS_PAGE: 'canAccessClientDetailsPage',
+    BANNER_CONTENT: 'bannerContent',
+} as const;
+
 export const schema = z.object({
-    didFlagsLoad: z.boolean(),
-    hasStripeConnectAccess: z.boolean(),
-    useIframeReimbursementRequest: z.boolean(),
-    canAccessClientDetailsPage: z.boolean(),
-    bannerContent: z.object({
+    [CLIENT_FLAGS.DID_FLAGS_LOAD]: z.boolean(),
+    [CLIENT_FLAGS.HAS_STRIPE_CONNECT_ACCESS]: z.boolean(),
+    [CLIENT_FLAGS.USE_IFRAME_REIMBURSEMENT_REQUEST]: z.boolean(),
+    [CLIENT_FLAGS.CAN_ACCESS_CLIENT_DETAILS_PAGE]: z.boolean(),
+    [CLIENT_FLAGS.BANNER_CONTENT]: z.object({
         message: z.string().optional(),
         color: z.string().optional(),
         linkUrl: z.string().optional(),
@@ -17,13 +33,13 @@ export type Type = z.infer<typeof schema>;
 type FeatureFlags = Type;
 
 export const defaultFlags: FeatureFlags = {
-    // `didFlagsLoad` should always be true from the server,
+    // `didFlagsLoad` should always be true from LaunchDarkly,
     // so if we see false in the client, it means we're fully falling back to default flags
-    didFlagsLoad: false,
-    hasStripeConnectAccess: false,
-    useIframeReimbursementRequest: false,
-    canAccessClientDetailsPage: false,
-    bannerContent: {},
+    [CLIENT_FLAGS.DID_FLAGS_LOAD]: false,
+    [CLIENT_FLAGS.HAS_STRIPE_CONNECT_ACCESS]: false,
+    [CLIENT_FLAGS.USE_IFRAME_REIMBURSEMENT_REQUEST]: false,
+    [CLIENT_FLAGS.CAN_ACCESS_CLIENT_DETAILS_PAGE]: false,
+    [CLIENT_FLAGS.BANNER_CONTENT]: {},
 };
 
 export const isValid = (flags: unknown): boolean => {

--- a/src/lib/shared/vendors/launchdarkly/configuration.ts
+++ b/src/lib/shared/vendors/launchdarkly/configuration.ts
@@ -1,0 +1,19 @@
+import { generateWithConfig } from '@/lib/shared/utils';
+import { get } from 'env-var';
+
+const LAUNCHDARKLY_SDK_KEY = 'LAUNCHDARKLY_SDK_KEY' as const;
+
+export interface LaunchDarklyConfiguration {
+    LAUNCHDARKLY_SDK_KEY: string;
+}
+
+export const getLaunchDarklyConfiguration = (
+    overrides: Partial<LaunchDarklyConfiguration> = {}
+): LaunchDarklyConfiguration => ({
+    LAUNCHDARKLY_SDK_KEY: get(LAUNCHDARKLY_SDK_KEY).required().asString(),
+    ...overrides,
+});
+
+export const withLaunchDarklyConfiguration = generateWithConfig(
+    getLaunchDarklyConfiguration
+);

--- a/src/lib/shared/vendors/launchdarkly/index.ts
+++ b/src/lib/shared/vendors/launchdarkly/index.ts
@@ -1,6 +1,6 @@
 import { init, LDClient } from 'launchdarkly-node-server-sdk';
 import { withLaunchDarklyConfiguration } from './configuration';
-import { GetFlagForContext } from './methods';
+import { GetFlagForContext, CreateContextFromUser } from './methods';
 const globalLaunchDarklyClient = global as unknown as {
     launchdarklyClient: LDClient;
 };
@@ -13,6 +13,7 @@ export const launchDarklyVendor = withLaunchDarklyConfiguration((CONFIG) => {
     }
     const client = globalLaunchDarklyClient.launchdarklyClient;
     return {
+        createContextFromUser: CreateContextFromUser.method,
         getFlagForContext: GetFlagForContext.factory(client),
     };
 });

--- a/src/lib/shared/vendors/launchdarkly/index.ts
+++ b/src/lib/shared/vendors/launchdarkly/index.ts
@@ -1,9 +1,17 @@
-import * as ld from 'launchdarkly-node-server-sdk';
+import { init, LDClient } from 'launchdarkly-node-server-sdk';
 import { withLaunchDarklyConfiguration } from './configuration';
 import { GetFlagForContext } from './methods';
+const globalLaunchDarklyClient = global as unknown as {
+    launchdarklyClient: LDClient;
+};
 
 export const launchDarklyVendor = withLaunchDarklyConfiguration((CONFIG) => {
-    const client = ld.init(CONFIG.LAUNCHDARKLY_SDK_KEY);
+    if (!globalLaunchDarklyClient.launchdarklyClient) {
+        globalLaunchDarklyClient.launchdarklyClient = init(
+            CONFIG.LAUNCHDARKLY_SDK_KEY
+        );
+    }
+    const client = globalLaunchDarklyClient.launchdarklyClient;
     return {
         getFlagForContext: GetFlagForContext.factory(client),
     };

--- a/src/lib/shared/vendors/launchdarkly/index.ts
+++ b/src/lib/shared/vendors/launchdarkly/index.ts
@@ -1,0 +1,10 @@
+import * as ld from 'launchdarkly-node-server-sdk';
+import { withLaunchDarklyConfiguration } from './configuration';
+import { GetFlagForContext } from './methods';
+
+export const launchDarklyVendor = withLaunchDarklyConfiguration((CONFIG) => {
+    const client = ld.init(CONFIG.LAUNCHDARKLY_SDK_KEY);
+    return {
+        getFlagForContext: GetFlagForContext.factory(client),
+    };
+});

--- a/src/lib/shared/vendors/launchdarkly/methods/create-context-from-user/createContextFromUser.ts
+++ b/src/lib/shared/vendors/launchdarkly/methods/create-context-from-user/createContextFromUser.ts
@@ -1,0 +1,8 @@
+import { TherifyUser } from '@/lib/shared/types';
+
+export const method = (user: TherifyUser.TherifyUser) => {
+    return {
+        key: user.userId,
+        email: user.emailAddress,
+    };
+};

--- a/src/lib/shared/vendors/launchdarkly/methods/create-context-from-user/index.ts
+++ b/src/lib/shared/vendors/launchdarkly/methods/create-context-from-user/index.ts
@@ -1,0 +1,1 @@
+export * as CreateContextFromUser from './createContextFromUser';

--- a/src/lib/shared/vendors/launchdarkly/methods/get-flag-for-context/getFlagForContext.ts
+++ b/src/lib/shared/vendors/launchdarkly/methods/get-flag-for-context/getFlagForContext.ts
@@ -1,0 +1,6 @@
+import { LDClient, LDContext } from 'launchdarkly-node-server-sdk';
+
+export const factory =
+    (client: LDClient) => async (flag: string, context: LDContext) => {
+        return await client.variation(flag, context, false);
+    };

--- a/src/lib/shared/vendors/launchdarkly/methods/get-flag-for-context/index.ts
+++ b/src/lib/shared/vendors/launchdarkly/methods/get-flag-for-context/index.ts
@@ -1,0 +1,1 @@
+export * as GetFlagForContext from './getFlagForContext';

--- a/src/lib/shared/vendors/launchdarkly/methods/index.ts
+++ b/src/lib/shared/vendors/launchdarkly/methods/index.ts
@@ -1,1 +1,2 @@
+export * from './create-context-from-user';
 export * from './get-flag-for-context';

--- a/src/lib/shared/vendors/launchdarkly/methods/index.ts
+++ b/src/lib/shared/vendors/launchdarkly/methods/index.ts
@@ -1,0 +1,1 @@
+export * from './get-flag-for-context';

--- a/yarn.lock
+++ b/yarn.lock
@@ -5210,7 +5210,7 @@ async-retry@^1.3.3:
   dependencies:
     retry "0.13.1"
 
-async@^3.2.3:
+async@^3.2.3, async@^3.2.4:
   version "3.2.4"
   resolved "https://registry.yarnpkg.com/async/-/async-3.2.4.tgz#2d22e00f8cddeb5fde5dd33522b56d1cf569a81c"
   integrity sha512-iAB+JbDEGXhyIUavoDl9WP/Jj106Kz9DEn1DPgYw5ruDn0e3Wgi3sKFm55sASdGBNOQB8F59d9qQ7deqrHA8wQ==
@@ -6035,6 +6035,11 @@ clone-deep@^4.0.1:
     is-plain-object "^2.0.4"
     kind-of "^6.0.2"
     shallow-clone "^3.0.0"
+
+clone@2.x:
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/clone/-/clone-2.1.2.tgz#1b7f4b9f591f1e8f83670401600345a02887435f"
+  integrity sha512-3Pe/CF1Nn94hyhIYpjtiLhdCoEoz0DqQ+988E9gmeEdQZlojxnOb74wctFyuwWQHzqyf9X7C7MG8juUpqBJT8w==
 
 cloudinary-core@^2.10.2:
   version "2.13.0"
@@ -10237,6 +10242,11 @@ language-tags@=1.0.5:
   dependencies:
     language-subtag-registry "~0.3.2"
 
+launchdarkly-eventsource@1.4.4:
+  version "1.4.4"
+  resolved "https://registry.yarnpkg.com/launchdarkly-eventsource/-/launchdarkly-eventsource-1.4.4.tgz#fa595af8602e487c61520787170376c6a1104459"
+  integrity sha512-GL+r2Y3WccJlhFyL2buNKel+9VaMnYpbE/FfCkOST5jSNSFodahlxtGyrE8o7R+Qhobyq0Ree4a7iafJDQi9VQ==
+
 launchdarkly-js-client-sdk@^3.1.2:
   version "3.1.2"
   resolved "https://registry.yarnpkg.com/launchdarkly-js-client-sdk/-/launchdarkly-js-client-sdk-3.1.2.tgz#2c4114f2ca8c9a314cbee1bb932fc64a82b63c2d"
@@ -10253,6 +10263,19 @@ launchdarkly-js-sdk-common@5.0.3:
     base64-js "^1.3.0"
     fast-deep-equal "^2.0.1"
     uuid "^8.0.0"
+
+launchdarkly-node-server-sdk@^7.0.1:
+  version "7.0.1"
+  resolved "https://registry.yarnpkg.com/launchdarkly-node-server-sdk/-/launchdarkly-node-server-sdk-7.0.1.tgz#4476a55fa4eb416ea9c3c93a4643af28b28b0efd"
+  integrity sha512-vliVBgoO3eZVBXl7LWE3hsB+8WEeyYS2Hf0BzgNx5yYrlFDHSAB2Ug+GEawgQEd9kxWESc3n5WyCn1sdMhG1xA==
+  dependencies:
+    async "^3.2.4"
+    launchdarkly-eventsource "1.4.4"
+    lru-cache "^6.0.0"
+    node-cache "^5.1.0"
+    semver "^7.3.0"
+    tunnel "0.0.6"
+    uuid "^8.3.2"
 
 launchdarkly-react-client-sdk@^3.0.4:
   version "3.0.4"
@@ -11887,6 +11910,13 @@ node-addon-api@^5.0.0:
   version "5.1.0"
   resolved "https://registry.yarnpkg.com/node-addon-api/-/node-addon-api-5.1.0.tgz#49da1ca055e109a23d537e9de43c09cca21eb762"
   integrity sha512-eh0GgfEkpnoWDq+VY8OyvYhFEzBk6jIYbRKdIlyTiAXIVJ8PyBaKb0rp7oDtoddbdoHWhq8wwr+XZ81F1rpNdA==
+
+node-cache@^5.1.0:
+  version "5.1.2"
+  resolved "https://registry.yarnpkg.com/node-cache/-/node-cache-5.1.2.tgz#f264dc2ccad0a780e76253a694e9fd0ed19c398d"
+  integrity sha512-t1QzWwnk4sjLWaQAS8CHgOJ+RAfmHpxFWmc36IWTiWHQfs0w5JDMBS1b1ZxQteo0vVVuWJvIUKHDkkeK7vIGCg==
+  dependencies:
+    clone "2.x"
 
 node-dir@^0.1.10, node-dir@^0.1.17:
   version "0.1.17"
@@ -13742,6 +13772,13 @@ semver@^6.0.0, semver@^6.1.1, semver@^6.1.2, semver@^6.3.0:
   resolved "https://registry.yarnpkg.com/semver/-/semver-6.3.0.tgz#ee0a64c8af5e8ceea67687b133761e1becbd1d3d"
   integrity sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==
 
+semver@^7.3.0:
+  version "7.5.1"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-7.5.1.tgz#c90c4d631cf74720e46b21c1d37ea07edfab91ec"
+  integrity sha512-Wvss5ivl8TMRZXXESstBA4uR5iXgEN/VC5/sOcuXdVLzcdkz4HWetIoRfG5gb5X+ij/G9rw9YoGn3QoQ8OCSpw==
+  dependencies:
+    lru-cache "^6.0.0"
+
 semver@~7.0.0:
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/semver/-/semver-7.0.0.tgz#5f3ca35761e47e05b206c6daff2cf814f0316b8e"
@@ -14828,6 +14865,11 @@ tsutils@^3.21.0:
   dependencies:
     tslib "^1.8.1"
 
+tunnel@0.0.6:
+  version "0.0.6"
+  resolved "https://registry.yarnpkg.com/tunnel/-/tunnel-0.0.6.tgz#72f1314b34a5b192db012324df2cc587ca47f92c"
+  integrity sha512-1h/Lnq9yajKY2PEbBadPXj3VxsDDu844OnaAo52UVmIzIvwwtBPIuNvkjuzBlTWpfJyUbG3ez0KSBibQkj4ojg==
+
 type-check@^0.4.0, type-check@~0.4.0:
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/type-check/-/type-check-0.4.0.tgz#07b8203bfa7056c0657050e3ccd2c37730bab8f1"
@@ -15255,7 +15297,7 @@ uuid-browser@^3.1.0:
   resolved "https://registry.yarnpkg.com/uuid-browser/-/uuid-browser-3.1.0.tgz#0f05a40aef74f9e5951e20efbf44b11871e56410"
   integrity sha512-dsNgbLaTrd6l3MMxTtouOCFw4CBFc/3a+GgYA2YyrJvyQ1u6q4pcu3ktLoUZ/VN/Aw9WsauazbgsgdfVWgAKQg==
 
-uuid@^8.0.0:
+uuid@^8.0.0, uuid@^8.3.2:
   version "8.3.2"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-8.3.2.tgz#80d5b5ced271bb9af6c445f21a1a04c606cefbe2"
   integrity sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==


### PR DESCRIPTION
# Description
Integrates LaunchDarkly's Node SDK to facilitate server-side feature flagging.

# Closes issue(s)
https://www.notion.so/Add-Server-Side-Feature-Flags-c827b0e9586844baba6dacb8a5282f78?pvs=4

# How to test / repro
Add this code snippet to any server side function with access to a `TherifyUser` object
``` 
const hasAccess = await launchDarklyVendor.getFlagForContext(
    FeatureFlags.SERVER_FLAGS.DID_FLAGS_LOAD,
    launchDarklyVendor.createContextFromUser(user)
);
console.log({ hasAccess });
```
# Screenshots
NA
# Changes include

-   [ ] Bugfix (non-breaking change that solves an issue)
-   [x] New feature (non-breaking change that adds functionality)
-   [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Checklist

-   [ ] I have tested this code
-   [ ] I have updated the Readme

# Other comments
