### PR TITLE
feat: feature flag DTC registration

### DIFF
--- a/src/lib/modules/accounts/routes/resolvers/register-account-owner/resolver.ts
+++ b/src/lib/modules/accounts/routes/resolvers/register-account-owner/resolver.ts
@@ -28,9 +28,14 @@ export const resolve: ProcedureResolver<
             errors: [],
         };
     } catch (error) {
+        let errorMessage = 'Failed to register with an unknown error.';
+        if (error instanceof Error) {
+            errorMessage = error.message;
+        }
+
         return {
             wasSuccessful: false,
-            errors: [],
+            errors: [errorMessage],
         };
     }
 };

--- a/src/lib/modules/accounts/routes/resolvers/register-dtc-member/resolver.ts
+++ b/src/lib/modules/accounts/routes/resolvers/register-dtc-member/resolver.ts
@@ -26,9 +26,14 @@ export const resolve: ProcedureResolver<
             errors: [],
         };
     } catch (error) {
+        let errorMessage = 'Failed to register with an unknown error.';
+        if (error instanceof Error) {
+            errorMessage = error.message;
+        }
+
         return {
             wasSuccessful: false,
-            errors: [],
+            errors: [errorMessage],
         };
     }
 };

--- a/src/lib/modules/accounts/routes/resolvers/register-member/resolver.ts
+++ b/src/lib/modules/accounts/routes/resolvers/register-member/resolver.ts
@@ -26,9 +26,14 @@ export const resolve: ProcedureResolver<
             errors: [],
         };
     } catch (error) {
+        let errorMessage = 'Failed to register with an unknown error.';
+        if (error instanceof Error) {
+            errorMessage = error.message;
+        }
+
         return {
             wasSuccessful: false,
-            errors: [],
+            errors: [errorMessage],
         };
     }
 };

--- a/src/lib/modules/accounts/service/register-dtc-member/registerDTCMember.ts
+++ b/src/lib/modules/accounts/service/register-dtc-member/registerDTCMember.ts
@@ -9,6 +9,7 @@ import {
     assignAuth0Role,
     createStripeCustomer,
     updateUserEntity,
+    checkRegistrationOpen,
 } from './transaction';
 
 export const registerDTCMember = TransactionV2.generateTransaction<
@@ -19,6 +20,7 @@ export const registerDTCMember = TransactionV2.generateTransaction<
     inputSchema: INPUT_SCHEMA,
     outputsSchema: OUTPUT_SCHEMA,
     transactions: {
+        [TRANSACTION_STEPS.CHECK_REGISTRATION_OPEN]: checkRegistrationOpen,
         [TRANSACTION_STEPS.CREATE_AUTH0_USER]: createAuth0User,
         [TRANSACTION_STEPS.ASSIGN_AUTH0_ROLE]: assignAuth0Role,
         [TRANSACTION_STEPS.CREATE_THERIFY_USER_ENTRY]: createTherifyUserEntity,

--- a/src/lib/modules/accounts/service/register-dtc-member/transaction/checkRegistrationOpen.ts
+++ b/src/lib/modules/accounts/service/register-dtc-member/transaction/checkRegistrationOpen.ts
@@ -1,0 +1,19 @@
+import { FeatureFlags } from '@/lib/shared/types';
+import { RegisterDTCMemberTransaction } from './definition';
+
+export const checkRegistrationOpen: RegisterDTCMemberTransaction['CHECK_REGISTRATION_OPEN'] =
+    {
+        async commit({}, { launchDarkly }, {}) {
+            const isOpen = await launchDarkly.getFlagForContext(
+                FeatureFlags.SERVER_FLAGS.IS_DTC_REGISTRATION_OPEN,
+                {
+                    key: 'DTC_MEMBER_REGISTRATION_OPEN_EVALUATION',
+                }
+            );
+            if (!isOpen) {
+                throw new Error('Registration is not open at this time');
+            }
+            return { isOpen };
+        },
+        async rollback() {},
+    };

--- a/src/lib/modules/accounts/service/register-dtc-member/transaction/definition.ts
+++ b/src/lib/modules/accounts/service/register-dtc-member/transaction/definition.ts
@@ -4,8 +4,10 @@ import { prisma } from '@/lib/prisma';
 import { TransactionV2 } from '@/lib/shared/utils';
 import { vendorAuth0 } from '@/lib/shared/vendors/auth0';
 import { vendorStripe } from '@/lib/shared/vendors/stripe';
+import { vendorLaunchDarkly } from '@/lib/shared/vendors/launchdarkly';
 
 export const TRANSACTION_STEPS = {
+    CHECK_REGISTRATION_OPEN: 'CHECK_REGISTRATION_OPEN',
     CREATE_THERIFY_USER_ENTRY: 'CREATE_THERIFY_USER_ENTRY',
     CREATE_AUTH0_USER: 'CREATE_AUTH0_USER',
     ASSIGN_AUTH0_ROLE: 'ASSIGN_AUTH0_ROLE',
@@ -15,6 +17,9 @@ export const TRANSACTION_STEPS = {
 
 export const INPUT_SCHEMA = RegisterDTCMember.inputSchema;
 export const OUTPUT_SCHEMA = {
+    [TRANSACTION_STEPS.CHECK_REGISTRATION_OPEN]: z.object({
+        isOpen: z.boolean(),
+    }),
     [TRANSACTION_STEPS.CREATE_THERIFY_USER_ENTRY]: z.object({
         therifyUserId: z.string(),
     }),
@@ -31,6 +36,7 @@ export const CONTEXT = {
     orm: prisma,
     auth0: vendorAuth0,
     stripe: vendorStripe,
+    launchDarkly: vendorLaunchDarkly,
 } as const;
 
 export type RegisterDTCMemberTransaction = TransactionV2.TransactionDefinition<

--- a/src/lib/modules/accounts/service/register-dtc-member/transaction/index.ts
+++ b/src/lib/modules/accounts/service/register-dtc-member/transaction/index.ts
@@ -4,3 +4,4 @@ export * from './assignAuth0Role';
 export * from './createTherifyUserEntity';
 export * from './createStripeCustomer';
 export * from './updateUserEntity';
+export * from './checkRegistrationOpen';

--- a/src/lib/shared/types/feature-flags/featureFlags.ts
+++ b/src/lib/shared/types/feature-flags/featureFlags.ts
@@ -6,6 +6,7 @@ export const SERVER_FLAGS = {
     USE_IFRAME_REIMBURSEMENT_REQUEST: 'use-iframe-reimbursement-request',
     CAN_ACCESS_CLIENT_DETAILS_PAGE: 'can-access-client-details-page',
     BANNER_CONTENT: 'banner-content',
+    IS_DTC_REGISTRATION_OPEN: 'is-dtc-registration-open',
 } as const;
 
 export const CLIENT_FLAGS = {
@@ -14,6 +15,7 @@ export const CLIENT_FLAGS = {
     USE_IFRAME_REIMBURSEMENT_REQUEST: 'useIframeReimbursementRequest',
     CAN_ACCESS_CLIENT_DETAILS_PAGE: 'canAccessClientDetailsPage',
     BANNER_CONTENT: 'bannerContent',
+    IS_DTC_REGISTRATION_OPEN: 'isDtcRegistrationOpen',
 } as const;
 
 export const schema = z.object({
@@ -27,6 +29,7 @@ export const schema = z.object({
         linkUrl: z.string().optional(),
         linkText: z.string().optional(),
     }),
+    [CLIENT_FLAGS.IS_DTC_REGISTRATION_OPEN]: z.boolean(),
 });
 
 export type Type = z.infer<typeof schema>;
@@ -40,6 +43,7 @@ export const defaultFlags: FeatureFlags = {
     [CLIENT_FLAGS.USE_IFRAME_REIMBURSEMENT_REQUEST]: false,
     [CLIENT_FLAGS.CAN_ACCESS_CLIENT_DETAILS_PAGE]: false,
     [CLIENT_FLAGS.BANNER_CONTENT]: {},
+    [CLIENT_FLAGS.IS_DTC_REGISTRATION_OPEN]: false,
 };
 
 export const isValid = (flags: unknown): boolean => {

--- a/src/lib/shared/utils/transaction/transaction.v2.ts
+++ b/src/lib/shared/utils/transaction/transaction.v2.ts
@@ -102,6 +102,7 @@ export function generateTransaction<
                         );
                     }
                 }
+                throw error;
             }
         }
         return results;

--- a/src/lib/shared/vendors/launchdarkly/index.ts
+++ b/src/lib/shared/vendors/launchdarkly/index.ts
@@ -1,11 +1,15 @@
 import { init, LDClient } from 'launchdarkly-node-server-sdk';
 import { withLaunchDarklyConfiguration } from './configuration';
-import { GetFlagForContext, CreateContextFromUser } from './methods';
+import {
+    GetFlagForUser,
+    GetFlagForContext,
+    CreateContextFromUser,
+} from './methods';
 const globalLaunchDarklyClient = global as unknown as {
     launchdarklyClient: LDClient;
 };
 
-export const launchDarklyVendor = withLaunchDarklyConfiguration((CONFIG) => {
+export const vendorLaunchDarkly = withLaunchDarklyConfiguration((CONFIG) => {
     if (!globalLaunchDarklyClient.launchdarklyClient) {
         globalLaunchDarklyClient.launchdarklyClient = init(
             CONFIG.LAUNCHDARKLY_SDK_KEY
@@ -15,5 +19,8 @@ export const launchDarklyVendor = withLaunchDarklyConfiguration((CONFIG) => {
     return {
         createContextFromUser: CreateContextFromUser.method,
         getFlagForContext: GetFlagForContext.factory(client),
+        getFlagForUser: GetFlagForUser.factory(client),
     };
 });
+
+export type VendorLaunchDarkly = typeof vendorLaunchDarkly;

--- a/src/lib/shared/vendors/launchdarkly/methods/create-context-from-user/createContextFromUser.ts
+++ b/src/lib/shared/vendors/launchdarkly/methods/create-context-from-user/createContextFromUser.ts
@@ -1,6 +1,7 @@
 import { TherifyUser } from '@/lib/shared/types';
+import { LDContext } from 'launchdarkly-node-server-sdk';
 
-export const method = (user: TherifyUser.TherifyUser) => {
+export const method = (user: TherifyUser.TherifyUser): LDContext => {
     return {
         key: user.userId,
         email: user.emailAddress,

--- a/src/lib/shared/vendors/launchdarkly/methods/get-flag-for-user/getFlagForUser.ts
+++ b/src/lib/shared/vendors/launchdarkly/methods/get-flag-for-user/getFlagForUser.ts
@@ -1,0 +1,13 @@
+import { TherifyUser } from '@/lib/shared/types';
+import { LDClient } from 'launchdarkly-node-server-sdk';
+import { CreateContextFromUser } from '../create-context-from-user';
+
+export const factory =
+    (client: LDClient) =>
+    async (flag: string, user: TherifyUser.TherifyUser) => {
+        return await client.variation(
+            flag,
+            CreateContextFromUser.method(user),
+            false
+        );
+    };

--- a/src/lib/shared/vendors/launchdarkly/methods/get-flag-for-user/index.ts
+++ b/src/lib/shared/vendors/launchdarkly/methods/get-flag-for-user/index.ts
@@ -1,0 +1,1 @@
+export * as GetFlagForUser from './getFlagForUser';

--- a/src/lib/shared/vendors/launchdarkly/methods/index.ts
+++ b/src/lib/shared/vendors/launchdarkly/methods/index.ts
@@ -1,2 +1,3 @@
 export * from './create-context-from-user';
 export * from './get-flag-for-context';
+export * from './get-flag-for-user';

--- a/src/pages/accounts/register/index.tsx
+++ b/src/pages/accounts/register/index.tsx
@@ -13,6 +13,7 @@ import { AccountOwnerRegistrationFlow } from '@/lib/modules/registration/compone
 export default function AccountOwnerRegistrationPage() {
     const router = useRouter();
     const [registrationError, setRegistrationError] = useState<string>();
+    const [isRegistrationComplete, setIsRegistrationComplete] = useState(false);
     const { clearRegistrationStorage } = useRegistrationStorage();
     const handleError = (errorMessage: string) => {
         setRegistrationError(errorMessage);
@@ -22,6 +23,7 @@ export default function AccountOwnerRegistrationPage() {
         onSuccess(response, { emailAddress }) {
             if (response.wasSuccessful) {
                 clearRegistrationStorage();
+                setIsRegistrationComplete(true);
                 router.push(
                     `${
                         URL_PATHS.MEMBERS.REGISTER_SUCCESS
@@ -32,10 +34,12 @@ export default function AccountOwnerRegistrationPage() {
 
                 return;
             }
+            setIsRegistrationComplete(false);
             const [error] = response.errors ?? [];
             handleError(error ?? 'Could not create user.');
         },
         onError(error) {
+            setIsRegistrationComplete(false);
             setRegistrationError(error.message);
         },
     });
@@ -59,7 +63,7 @@ export default function AccountOwnerRegistrationPage() {
                     errorMessage={registrationError}
                     clearErrorMessage={() => setRegistrationError(undefined)}
                     isRegisteringAccountOwner={mutation.isLoading}
-                    isRegistrationComplete={mutation.isSuccess}
+                    isRegistrationComplete={isRegistrationComplete}
                     role={ROLES.ACCOUNT_OWNER}
                 />
             </InnerContent>

--- a/src/pages/members/register/index.tsx
+++ b/src/pages/members/register/index.tsx
@@ -26,6 +26,7 @@ export default function MemberRegistrationPage(props: Props) {
     const { registrationCode, account, hasSeatsAvailable = false } = props;
     const router = useRouter();
     const [registrationError, setRegistrationError] = useState<string>();
+    const [isRegistrationComplete, setIsRegistrationComplete] = useState(false);
     const { clearRegistrationStorage } = useRegistrationStorage();
     const handleError = (errorMessage: string) => {
         setRegistrationError(errorMessage);
@@ -35,6 +36,7 @@ export default function MemberRegistrationPage(props: Props) {
         onSuccess(response, { emailAddress }) {
             if (response.wasSuccessful) {
                 clearRegistrationStorage();
+                setIsRegistrationComplete(true);
                 router.push(
                     `${
                         URL_PATHS.MEMBERS.REGISTER_SUCCESS
@@ -45,10 +47,12 @@ export default function MemberRegistrationPage(props: Props) {
 
                 return;
             }
+            setIsRegistrationComplete(false);
             const [error] = response.errors ?? [];
             handleError(error ?? 'Could not create user.');
         },
         onError(error) {
+            setIsRegistrationComplete(false);
             setRegistrationError(error.message);
         },
     });
@@ -71,7 +75,7 @@ export default function MemberRegistrationPage(props: Props) {
                     errorMessage={registrationError}
                     clearErrorMessage={() => setRegistrationError(undefined)}
                     isRegisteringMember={mutation.isLoading}
-                    isRegistrationComplete={mutation.isSuccess}
+                    isRegistrationComplete={isRegistrationComplete}
                     role={ROLES.MEMBER}
                     account={account}
                     hasSeatsAvailable={hasSeatsAvailable}


### PR DESCRIPTION
# Description
Hides DTC Registration behind `is-dtc-registration-open` feature flag

## Bugs found
### V2 Transaction bug
During this work I found a bug with the V2 Transaction. When a step errors, the rollback functions would run, but then instead of exiting, the transaction would continue attempting to execute the remaining steps. This was recognized when the added feature flag check failed as expected, but then the user would get registered anyway. 

### Solution
After a step throws and the rollback steps are executed, the V2 Transaction will throw the original error so that the invoker can handle the error as needed. Once this was introduced, a new issue was noticed in the registration UI flow.

### Member registration error message bug
First, when the V2 transaction finally did throw an error as expected, there was no error message being passed back from the resolver. Second, after this was solved, when an error message was returned from the registration resolver, the alert component would show it in the UI as expected. However, if the user cleared the error message, the UI would start showing the loading UI again, preventing the user from resubmitting the form.

### Solution
Step 1 was simply to pass an error message back from the registration resolver. 
For the second issue, the `isRegistrationComplete` prop in the registration form UI was being given the mutation's completion status as a value. This caused the issue because even when there was an error message returned from the resolver, the mutation was still technically completed successfully. The solution was to add an `isRegistrationComplete` state to the page component and manually update it `true`/`false` based on the data passed back from a successful mutation invocation. This solution was mirrored across all V2 registration (Account owner, DTC member, and Enterprise member registrations) and the error clearing behavior seems to work as expected.


# Closes issue(s)
[Notion Ticket](https://www.notion.so/Protect-DTC-Registration-Page-Behind-Feature-Flag-fe7ea2d45ab04413901d94673c0029db?pvs=4)
# How to test / repro

# Screenshots

# Changes include

-   [x] Bugfix (non-breaking change that solves an issue)
-   [x] New feature (non-breaking change that adds functionality)
-   [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Checklist

-   [x] I have tested this code
-   [ ] I have updated the Readme

# Other comments
Manually tested all registration paths
Updated Transactions V2 unit tests