### PR TITLE
feat: show unread chat notification badges

### DIFF
--- a/src/lib/modules/messaging/components/Chat/Chat.tsx
+++ b/src/lib/modules/messaging/components/Chat/Chat.tsx
@@ -1,12 +1,9 @@
 import '@stream-io/stream-chat-css/dist/css/index.css';
 import './style.module.css';
-
-import { StreamChat } from 'stream-chat';
 import {
     Channel,
     ChannelList,
     ChannelHeader,
-    Chat,
     MessageInput,
     MessageList,
     Thread,
@@ -25,8 +22,6 @@ interface ChatComponentProps {
     allowSessionInvoicing?: boolean;
 }
 
-const chatClient = StreamChat.getInstance('7ryxym6g8a33');
-
 export function ChatComponent({
     userIdentifier,
     accessToken,
@@ -37,46 +32,38 @@ export function ChatComponent({
     const isSmallScreen = useMediaQuery((theme: Theme) =>
         theme.breakpoints.down('md')
     );
-    if (typeof window !== 'undefined') {
-        chatClient.connectUser(
-            { id: userIdentifier, name: displayName || userIdentifier },
-            accessToken
-        );
-    }
     const shouldDisplayDrawer = isSmallScreen && drawerOpen;
     return (
         <StyledChatContainer drawerOpen={shouldDisplayDrawer}>
-            <Chat client={chatClient} theme="str-chat__theme-square">
-                <ChannelList filters={{ members: { $in: [userIdentifier] } }} />
-                {shouldDisplayDrawer && (
-                    <DrawerBackdrop
-                        drawerOpen={drawerOpen}
-                        onClick={() => setDrawerOpen(false)}
-                    />
-                )}
-                <Channel>
-                    <Window>
-                        <HeaderContainer>
-                            <ChannelHeader
-                                MenuIcon={() => (
-                                    <IconButton
-                                        className="MuiButtonBase-root MuiButton-root MuiButton-outlined MuiButton-outlinedInfo MuiButton-sizeMedium MuiButton-outlinedSizeSmall MuiButton-disableElevation MuiButton-root MuiButton-outlined MuiButton-outlinedInfo MuiButton-sizeMedium MuiButton-outlinedSizeSmall MuiButton-disableElevation css-1q53vy0-MuiButtonBase-root-MuiButton-root"
-                                        onClick={() => setDrawerOpen(true)}
-                                    >
-                                        <ChevronLeft />
-                                    </IconButton>
-                                )}
-                            />
-                            {allowSessionInvoicing && (
-                                <ChatActions userIdentifier={userIdentifier} />
+            <ChannelList filters={{ members: { $in: [userIdentifier] } }} />
+            {shouldDisplayDrawer && (
+                <DrawerBackdrop
+                    drawerOpen={drawerOpen}
+                    onClick={() => setDrawerOpen(false)}
+                />
+            )}
+            <Channel>
+                <Window>
+                    <HeaderContainer>
+                        <ChannelHeader
+                            MenuIcon={() => (
+                                <IconButton
+                                    className="MuiButtonBase-root MuiButton-root MuiButton-outlined MuiButton-outlinedInfo MuiButton-sizeMedium MuiButton-outlinedSizeSmall MuiButton-disableElevation MuiButton-root MuiButton-outlined MuiButton-outlinedInfo MuiButton-sizeMedium MuiButton-outlinedSizeSmall MuiButton-disableElevation css-1q53vy0-MuiButtonBase-root-MuiButton-root"
+                                    onClick={() => setDrawerOpen(true)}
+                                >
+                                    <ChevronLeft />
+                                </IconButton>
                             )}
-                        </HeaderContainer>
-                        <MessageList />
-                        <MessageInput />
-                    </Window>
-                    <Thread />
-                </Channel>
-            </Chat>
+                        />
+                        {allowSessionInvoicing && (
+                            <ChatActions userIdentifier={userIdentifier} />
+                        )}
+                    </HeaderContainer>
+                    <MessageList />
+                    <MessageInput />
+                </Window>
+                <Thread />
+            </Channel>
         </StyledChatContainer>
     );
 }

--- a/src/lib/modules/messaging/hooks/use-chat/index.ts
+++ b/src/lib/modules/messaging/hooks/use-chat/index.ts
@@ -1,1 +1,2 @@
 export * from './useChat';
+export * from './useChatClient';

--- a/src/lib/modules/messaging/hooks/use-chat/useChatClient.tsx
+++ b/src/lib/modules/messaging/hooks/use-chat/useChatClient.tsx
@@ -20,10 +20,18 @@ export const useChatClient = (user?: TherifyUser.TherifyUser) => {
             const accessToken = user.chatAccessToken!;
             chatClient
                 .connectUser(
-                    { id: userIdentifier, name: displayName || userIdentifier },
+                    {
+                        id: userIdentifier,
+                        name: displayName || userIdentifier,
+                    },
                     accessToken
                 )
-                .then(() => {
+                .then((registerResult) => {
+                    if (registerResult) {
+                        setChatUnreadMessagesCount(
+                            registerResult.me?.total_unread_count ?? 0
+                        );
+                    }
                     setIsChatConnected(true);
                 })
                 .catch((e) => {
@@ -38,7 +46,7 @@ export const useChatClient = (user?: TherifyUser.TherifyUser) => {
         user?.hasChatEnabled,
         user?.userId,
     ]);
-    //TODO: fetch initial unread count on load
+
     useEffect(() => {
         if (user?.hasChatEnabled && user?.userId && isChatConnected) {
             const { unsubscribe } = chatClient.on((event) => {
@@ -46,9 +54,6 @@ export const useChatClient = (user?: TherifyUser.TherifyUser) => {
                     event.total_unread_count !== undefined &&
                     !isNaN(parseInt(event.total_unread_count?.toString() ?? ''))
                 ) {
-                    console.log(
-                        `unread messages count is now: ${event.total_unread_count}`
-                    );
                     setChatUnreadMessagesCount(event.total_unread_count);
                 }
             });

--- a/src/lib/modules/messaging/hooks/use-chat/useChatClient.tsx
+++ b/src/lib/modules/messaging/hooks/use-chat/useChatClient.tsx
@@ -1,0 +1,71 @@
+import { TherifyUser } from '@/lib/shared/types';
+import { adaptUserIdentifier } from '@/lib/shared/vendors/stream-chat/adapt-user-identifier';
+import { ReactNode, useEffect, useMemo, useState } from 'react';
+import { StreamChat } from 'stream-chat';
+import { Chat } from 'stream-chat-react';
+
+const chatClient = StreamChat.getInstance('7ryxym6g8a33');
+
+export const useChatClient = (user?: TherifyUser.TherifyUser) => {
+    const [isChatConnected, setIsChatConnected] = useState(false);
+    const [unreadChatMessagesCount, setChatUnreadMessagesCount] = useState(0);
+    useEffect(() => {
+        if (typeof window === 'undefined') return;
+
+        if (!isChatConnected && user?.hasChatEnabled && user?.userId) {
+            const userIdentifier = adaptUserIdentifier.makeStreamChatSafe(
+                user.userId
+            );
+            const displayName = user.givenName;
+            const accessToken = user.chatAccessToken!;
+            chatClient
+                .connectUser(
+                    { id: userIdentifier, name: displayName || userIdentifier },
+                    accessToken
+                )
+                .then(() => {
+                    setIsChatConnected(true);
+                })
+                .catch((e) => {
+                    console.error(e);
+                    setIsChatConnected(false);
+                });
+        }
+    }, [
+        isChatConnected,
+        user?.chatAccessToken,
+        user?.givenName,
+        user?.hasChatEnabled,
+        user?.userId,
+    ]);
+    //TODO: fetch initial unread count on load
+    useEffect(() => {
+        if (user?.hasChatEnabled && user?.userId && isChatConnected) {
+            const { unsubscribe } = chatClient.on((event) => {
+                if (
+                    event.total_unread_count !== undefined &&
+                    !isNaN(parseInt(event.total_unread_count?.toString() ?? ''))
+                ) {
+                    console.log(
+                        `unread messages count is now: ${event.total_unread_count}`
+                    );
+                    setChatUnreadMessagesCount(event.total_unread_count);
+                }
+            });
+            return () => unsubscribe();
+        }
+    }, [isChatConnected, user?.hasChatEnabled, user?.userId]);
+
+    const ChatProvider = useMemo(
+        () =>
+            function MemoizedChat({ children }: { children?: ReactNode }) {
+                return (
+                    <Chat client={chatClient} theme="str-chat__theme-square">
+                        {children}
+                    </Chat>
+                );
+            },
+        []
+    );
+    return { ChatProvider, unreadChatMessagesCount, isChatConnected };
+};

--- a/src/lib/shared/components/features/account/MemberExpiredPlanPage/MemberExpiredPlanPage.spec.tsx
+++ b/src/lib/shared/components/features/account/MemberExpiredPlanPage/MemberExpiredPlanPage.spec.tsx
@@ -3,6 +3,7 @@ import { Mocks } from '@/lib/shared/types';
 import { useInAppNotificationDrawer } from '@/lib/modules/notifications/components/hooks';
 import { MemberExpiredPlanPage } from './MemberExpiredPlanPage';
 import { format } from 'date-fns';
+import { ReactNode } from 'react';
 
 jest.mock('@/lib/modules/notifications/components/hooks', () => {
     return {
@@ -13,6 +14,17 @@ jest.mock('@/lib/modules/notifications/components/hooks', () => {
 jest.mock('next/router', () => {
     return {
         useRouter: () => ({ pathname: '/test', push: jest.fn() }),
+    };
+});
+
+jest.mock('@/lib/modules/messaging/hooks', () => {
+    return {
+        useChatClient: () => ({
+            ChatProvider: ({ children }: { children?: ReactNode }) => (
+                <>{children}</>
+            ),
+            unreadChatMessagesCount: 0,
+        }),
     };
 });
 

--- a/src/lib/shared/components/features/pages/MemberNavigationPage/MemberNavigationPage.tsx
+++ b/src/lib/shared/components/features/pages/MemberNavigationPage/MemberNavigationPage.tsx
@@ -3,6 +3,8 @@ import {
     getMemberMobileMenu,
     getMemberMenu,
 } from '@/lib/sitemap/menus/member-menu';
+import { useChatClient } from '@/lib/modules/messaging/hooks';
+import { URL_PATHS } from '@/lib/sitemap';
 import { TherifyUser } from '@/lib/shared/types';
 import { useRouter } from 'next/router';
 import {
@@ -26,15 +28,25 @@ export function MemberNavigationPage(props: MemberNavigationPageProps) {
     const router = useRouter();
     const mainMenu = getMemberMenu(props.user?.hasChatEnabled ?? false);
     const mobileMenu = getMemberMobileMenu(props.user?.hasChatEnabled ?? false);
+    const { ChatProvider, unreadChatMessagesCount } = useChatClient(props.user);
 
     return (
-        <TopNavigationPage
-            {...props}
-            onNavigate={router.push}
-            primaryMenu={mainMenu}
-            secondaryMenu={[...MEMBER_SECONDARY_MENU]}
-            mobileMenu={mobileMenu}
-            isLoadingUser={false}
-        />
+        <ChatProvider>
+            <TopNavigationPage
+                {...props}
+                onNavigate={router.push}
+                primaryMenu={mainMenu}
+                secondaryMenu={[...MEMBER_SECONDARY_MENU]}
+                mobileMenu={mobileMenu}
+                isLoadingUser={false}
+                chatNotifications={
+                    unreadChatMessagesCount > 0
+                        ? {
+                              [URL_PATHS.MEMBERS.CHAT]: unreadChatMessagesCount,
+                          }
+                        : undefined
+                }
+            />
+        </ChatProvider>
     );
 }

--- a/src/lib/shared/components/features/pages/SideNavigationPage/SideNavigationPage.tsx
+++ b/src/lib/shared/components/features/pages/SideNavigationPage/SideNavigationPage.tsx
@@ -55,13 +55,21 @@ export const SideNavigationPage = ({
     const {
         drawer: notificationDrawer,
         notifications,
-        unreadCount,
+        unreadCount: unreadNotificationsCount,
         clearActionlessNotifications,
         handleAction,
         getNotificationsMapForMenu,
     } = useInAppNotificationDrawer();
-    const notificationsMap = getNotificationsMapForMenu(
+    const inAppNotificationsMap = getNotificationsMapForMenu(
         hasAccess ? primaryMenu : []
+    );
+    const notificationMap = {
+        ...inAppNotificationsMap,
+        ...(chatNotifications ?? {}),
+    };
+    const unreadMessagesCount = Object.values(chatNotifications ?? {}).reduce(
+        (acc, count) => acc + count,
+        0
     );
     return (
         <SideNavigationLayout
@@ -82,7 +90,8 @@ export const SideNavigationPage = ({
                     menu={secondaryMenu}
                     currentPath={currentPath}
                     onNavigate={onNavigate}
-                    notificationCount={unreadCount}
+                    unreadMessagesCount={unreadMessagesCount}
+                    notificationCount={unreadNotificationsCount}
                     onShowNotifications={notificationDrawer.open}
                     user={user}
                     isLoadingUser={isLoadingUser}
@@ -97,10 +106,7 @@ export const SideNavigationPage = ({
                     navigationMenu={hasAccess ? primaryMenu : []}
                     onNavigate={onNavigate}
                     actionLink={actionLink}
-                    notificationMap={{
-                        ...notificationsMap,
-                        ...(chatNotifications ?? {}),
-                    }}
+                    notificationMap={notificationMap}
                 />
             }
         >
@@ -111,9 +117,7 @@ export const SideNavigationPage = ({
                 isOpen={isMobileMenuOpen}
                 onClose={() => setIsMobileMenuOpen(false)}
                 navigationMenu={hasAccess ? mobileMenu : secondaryMenu}
-                notificationsMap={getNotificationsMapForMenu(
-                    hasAccess ? mobileMenu : secondaryMenu
-                )}
+                notificationsMap={notificationMap}
                 onNavigate={(path) => {
                     onNavigate(path);
                     setIsMobileMenuOpen(false);

--- a/src/lib/shared/components/features/pages/SideNavigationPage/SideNavigationPage.tsx
+++ b/src/lib/shared/components/features/pages/SideNavigationPage/SideNavigationPage.tsx
@@ -30,6 +30,7 @@ export interface SideNavigationPageProps {
     user?: TherifyUser.TherifyUser;
     actionLink?: NavigationLink;
     isLoadingUser?: boolean;
+    chatNotifications?: { [pathToChat: string]: number };
     children?: React.ReactNode;
 }
 /**
@@ -44,6 +45,7 @@ export const SideNavigationPage = ({
     user,
     actionLink,
     isLoadingUser = false,
+    chatNotifications,
     children,
 }: SideNavigationPageProps) => {
     const { hasAccess } = usePlanMonitoring(user);
@@ -58,6 +60,9 @@ export const SideNavigationPage = ({
         handleAction,
         getNotificationsMapForMenu,
     } = useInAppNotificationDrawer();
+    const notificationsMap = getNotificationsMapForMenu(
+        hasAccess ? primaryMenu : []
+    );
     return (
         <SideNavigationLayout
             bannerSlot={
@@ -92,9 +97,10 @@ export const SideNavigationPage = ({
                     navigationMenu={hasAccess ? primaryMenu : []}
                     onNavigate={onNavigate}
                     actionLink={actionLink}
-                    notificationMap={getNotificationsMapForMenu(
-                        hasAccess ? primaryMenu : []
-                    )}
+                    notificationMap={{
+                        ...notificationsMap,
+                        ...(chatNotifications ?? {}),
+                    }}
                 />
             }
         >

--- a/src/lib/shared/components/features/pages/TopNavigationPage/TopNavigationPage.tsx
+++ b/src/lib/shared/components/features/pages/TopNavigationPage/TopNavigationPage.tsx
@@ -60,6 +60,10 @@ export const TopNavigationPage = ({
         ...getNotificationsMapForMenu(hasAccess ? mobileMenu : secondaryMenu),
         ...chatNotifications,
     };
+    const unreadMessagesCount = Object.values(chatNotifications ?? {}).reduce(
+        (acc, count) => acc + count,
+        0
+    );
     return (
         <TopNavigationLayout
             bannerSlot={
@@ -83,6 +87,7 @@ export const TopNavigationPage = ({
                         onNavigate={onNavigate}
                         onShowNotifications={notificationDrawer.open}
                         notificationCount={unreadCount}
+                        unreadMessagesCount={unreadMessagesCount}
                         toggleMobileMenu={() =>
                             setIsMobileMenuOpen(!isMobileMenuOpen)
                         }

--- a/src/lib/shared/components/features/pages/TopNavigationPage/TopNavigationPage.tsx
+++ b/src/lib/shared/components/features/pages/TopNavigationPage/TopNavigationPage.tsx
@@ -26,6 +26,7 @@ export interface TopNavigationPageProps {
     onNavigate: (path: string) => void;
     user: TherifyUser.TherifyUser | null;
     isLoadingUser: boolean;
+    chatNotifications?: { [pathToChat: string]: number };
     children?: React.ReactNode;
 }
 /**
@@ -39,6 +40,7 @@ export const TopNavigationPage = ({
     onNavigate,
     user,
     isLoadingUser,
+    chatNotifications,
     children,
 }: TopNavigationPageProps) => {
     const { hasAccess } = usePlanMonitoring(user);
@@ -54,6 +56,10 @@ export const TopNavigationPage = ({
         getNotificationsMapForMenu,
     } = useInAppNotificationDrawer();
 
+    const notificationsMap = {
+        ...getNotificationsMapForMenu(hasAccess ? mobileMenu : secondaryMenu),
+        ...chatNotifications,
+    };
     return (
         <TopNavigationLayout
             bannerSlot={
@@ -80,6 +86,7 @@ export const TopNavigationPage = ({
                         toggleMobileMenu={() =>
                             setIsMobileMenuOpen(!isMobileMenuOpen)
                         }
+                        notificationsMap={notificationsMap}
                         user={user}
                         isLoadingUser={isLoadingUser}
                     />
@@ -94,9 +101,7 @@ export const TopNavigationPage = ({
                     isOpen={isMobileMenuOpen}
                     onClose={() => setIsMobileMenuOpen(false)}
                     navigationMenu={hasAccess ? mobileMenu : secondaryMenu}
-                    notificationsMap={getNotificationsMapForMenu(
-                        hasAccess ? mobileMenu : secondaryMenu
-                    )}
+                    notificationsMap={notificationsMap}
                     onNavigate={(path) => {
                         onNavigate(path);
                         setIsMobileMenuOpen(false);
@@ -154,10 +159,6 @@ export const TopNavigationPage = ({
                         clearActionlessNotifications();
                     }}
                     onNotificationClicked={handleAction}
-                    onClearNotifications={() => {
-                        //TODO: clear notifications
-                        console.log('clearing notifications');
-                    }}
                 />
             )}
         </TopNavigationLayout>

--- a/src/lib/shared/components/ui/IconButtonWithBadge/IconButtonWithBadge.tsx
+++ b/src/lib/shared/components/ui/IconButtonWithBadge/IconButtonWithBadge.tsx
@@ -3,7 +3,7 @@ import { styled } from '@mui/material/styles';
 import { ReactNode } from 'react';
 import { IconButton, BUTTON_TYPE } from '../Button';
 
-interface IconWithBadgeProps {
+interface IconButtonWithBadgeProps {
     icon: ReactNode;
     onClick?: () => void;
     badgeCount?: number;
@@ -12,16 +12,15 @@ interface IconWithBadgeProps {
     showZero?: boolean;
 }
 
-export const IconWithBadge = ({
+export const IconButtonWithBadge = ({
     icon,
     onClick,
     badgeCount,
     maxValue,
     showZero,
     ...props
-}: IconWithBadgeProps) => {
+}: IconButtonWithBadgeProps) => {
     return (
-        // TODO: Move button out
         <IconButton
             aria-label={props['aria-label']}
             type={BUTTON_TYPE.TEXT}

--- a/src/lib/shared/components/ui/IconButtonWithBadge/index.ts
+++ b/src/lib/shared/components/ui/IconButtonWithBadge/index.ts
@@ -1,0 +1,1 @@
+export { IconButtonWithBadge } from './IconButtonWithBadge';

--- a/src/lib/shared/components/ui/IconWithBadge/index.ts
+++ b/src/lib/shared/components/ui/IconWithBadge/index.ts
@@ -1,1 +1,0 @@
-export { IconWithBadge } from './IconWithBadge';

--- a/src/lib/shared/components/ui/Navigation/NavigationDrawer/NavigationDrawer.tsx
+++ b/src/lib/shared/components/ui/Navigation/NavigationDrawer/NavigationDrawer.tsx
@@ -36,7 +36,6 @@ export const NavigationDrawer = ({
     onNavigate,
     children,
 }: NavigationDrawerProps) => {
-    const theme = useTheme();
     return (
         <Drawer anchor="right" open={isOpen} onClose={onClose}>
             <MenuHeader>

--- a/src/lib/shared/components/ui/Navigation/SecondaryNavigationControls/SecondaryNavigationControls.tsx
+++ b/src/lib/shared/components/ui/Navigation/SecondaryNavigationControls/SecondaryNavigationControls.tsx
@@ -4,8 +4,8 @@ import {
 } from '@mui/icons-material';
 import { Box } from '@mui/material';
 import { useTheme } from '@mui/material/styles';
-import { IconWithBadge } from '../../IconWithBadge';
-import { BUTTON_TYPE, IconButton, Button } from '../../Button';
+import { IconButtonWithBadge } from '../../IconButtonWithBadge';
+import { BUTTON_TYPE, Button } from '../../Button';
 import { FloatingMenu } from '../FloatingMenu';
 import { Avatar } from '../../Avatar';
 import { NavigationLink, URL_PATHS } from '@/lib/sitemap';
@@ -14,6 +14,7 @@ import { TherifyUser } from '@/lib/shared/types/therify-user';
 interface SecondaryNavigationControlsProps {
     onShowNotifications?: () => void;
     notificationCount?: number;
+    unreadMessagesCount?: number;
     isMobileWidth: boolean;
     toggleMobileMenu: () => void;
     currentPath: string;
@@ -33,6 +34,7 @@ export const TEST_IDS = {
 export const SecondaryNavigationControls = ({
     onShowNotifications,
     notificationCount,
+    unreadMessagesCount,
     isMobileWidth,
     toggleMobileMenu,
     currentPath,
@@ -61,7 +63,7 @@ export const SecondaryNavigationControls = ({
             )}
 
             {user && (
-                <IconWithBadge
+                <IconButtonWithBadge
                     data-testid={TEST_IDS.NOTIFICATIONS_ICON}
                     onClick={onShowNotifications}
                     aria-label={`${notificationCount ?? 0} Notifications`}
@@ -72,17 +74,12 @@ export const SecondaryNavigationControls = ({
 
             <Box paddingLeft={2}>
                 {isMobileWidth ? (
-                    <IconButton
+                    <IconButtonWithBadge
                         data-testid={TEST_IDS.MENU_ICON}
-                        color="info"
-                        type={BUTTON_TYPE.TEXT}
                         onClick={toggleMobileMenu}
-                        style={{
-                            color: theme.palette.text.primary,
-                        }}
-                    >
-                        <MenuIcon fontSize="large" />
-                    </IconButton>
+                        badgeCount={unreadMessagesCount}
+                        icon={<MenuIcon fontSize="large" />}
+                    />
                 ) : (
                     <DesktopControls
                         user={user}

--- a/src/lib/shared/components/ui/Navigation/SecondaryTopBar/SecondaryTopBar.tsx
+++ b/src/lib/shared/components/ui/Navigation/SecondaryTopBar/SecondaryTopBar.tsx
@@ -12,6 +12,7 @@ export const SecondaryTopBar = ({
     onNavigate,
     onShowNotifications,
     notificationCount,
+    unreadMessagesCount,
     toggleMobileMenu,
     isLoadingUser,
 }: {
@@ -19,6 +20,7 @@ export const SecondaryTopBar = ({
     currentPath: string;
     menu: NavigationLink[];
     notificationCount?: number;
+    unreadMessagesCount?: number;
     toggleMobileMenu: () => void;
     onNavigate: (path: string) => void;
     onShowNotifications?: () => void;
@@ -33,6 +35,7 @@ export const SecondaryTopBar = ({
                     <SecondaryNavigationControls
                         onShowNotifications={onShowNotifications}
                         notificationCount={notificationCount}
+                        unreadMessagesCount={unreadMessagesCount}
                         isMobileWidth={isMobileWidth}
                         toggleMobileMenu={toggleMobileMenu}
                         currentPath={currentPath}

--- a/src/lib/shared/components/ui/Navigation/TopNavigationBar/TopNavigationBar.tsx
+++ b/src/lib/shared/components/ui/Navigation/TopNavigationBar/TopNavigationBar.tsx
@@ -19,6 +19,7 @@ export interface TopNavigationBarProps {
     isLoadingUser: boolean;
     withTherifyWebsiteLink?: boolean;
     notificationsMap?: Record<string, number>;
+    unreadMessagesCount?: number;
 }
 export const TEST_IDS = {
     DESKTOP_MENU: 'desktop-menu',
@@ -31,6 +32,7 @@ export const TopNavigationBar = ({
     secondaryMenu,
     onShowNotifications,
     notificationCount,
+    unreadMessagesCount,
     toggleMobileMenu,
     onNavigate,
     user,
@@ -82,6 +84,7 @@ export const TopNavigationBar = ({
                 <SecondaryNavigationControls
                     onShowNotifications={onShowNotifications}
                     notificationCount={notificationCount}
+                    unreadMessagesCount={unreadMessagesCount}
                     isMobileWidth={isMobileWidth}
                     toggleMobileMenu={toggleMobileMenu}
                     currentPath={currentPath}

--- a/src/lib/shared/components/ui/Navigation/TopNavigationBar/TopNavigationBar.tsx
+++ b/src/lib/shared/components/ui/Navigation/TopNavigationBar/TopNavigationBar.tsx
@@ -1,6 +1,6 @@
 import { TherifyUser } from '@/lib/shared/types/therify-user';
 import { NavigationLink } from '@/lib/sitemap';
-import { useMediaQuery } from '@mui/material';
+import { Avatar, useMediaQuery } from '@mui/material';
 import { styled, useTheme } from '@mui/material/styles';
 import Link from 'next/link';
 import { TopBar } from '../../TopBar';
@@ -18,6 +18,7 @@ export interface TopNavigationBarProps {
     user?: TherifyUser.TherifyUser;
     isLoadingUser: boolean;
     withTherifyWebsiteLink?: boolean;
+    notificationsMap?: Record<string, number>;
 }
 export const TEST_IDS = {
     DESKTOP_MENU: 'desktop-menu',
@@ -34,6 +35,7 @@ export const TopNavigationBar = ({
     onNavigate,
     user,
     isLoadingUser,
+    notificationsMap,
     withTherifyWebsiteLink,
 }: TopNavigationBarProps) => {
     const theme = useTheme();
@@ -63,6 +65,12 @@ export const TopNavigationBar = ({
                                         <ActiveTab
                                             data-testid={TEST_IDS.ACTIVE_TAB}
                                         />
+                                    )}
+                                    {(notificationsMap?.[link.path] ?? 0) >
+                                        0 && (
+                                        <NotificationCount>
+                                            {notificationsMap?.[link.path]}
+                                        </NotificationCount>
                                     )}
                                 </Link>
                             </LinkItem>
@@ -102,6 +110,8 @@ const LinkItem = styled('li')(({ theme }) => ({
     '& a': {
         position: 'relative',
         ...theme.typography.body1,
+        display: 'flex',
+        alignItems: 'center',
         fontWeight: 500,
         margin: 0,
         padding: theme.spacing(4, 5),
@@ -116,6 +126,15 @@ const LinkItem = styled('li')(({ theme }) => ({
             },
         },
     },
+}));
+
+const NotificationCount = styled(Avatar)(({ theme }) => ({
+    backgroundColor: theme.palette.error.main,
+    color: theme.palette.error.contrastText,
+    fontSize: '.75rem',
+    height: theme.spacing(6),
+    width: theme.spacing(6),
+    marginLeft: theme.spacing(2),
 }));
 
 const ActiveTab = styled('span')(({ theme }) => ({

--- a/src/lib/shared/components/ui/index.ts
+++ b/src/lib/shared/components/ui/index.ts
@@ -19,7 +19,7 @@ export type { BannerProps } from './Banner';
 export { BlockQuote, BLOCK_QUOTE_SIZE } from './BlockQuote';
 export { CallToActionCard } from './CallToActionCard';
 export { Carousel } from './Carousel';
-export { IconWithBadge } from './IconWithBadge';
+export { IconButtonWithBadge } from './IconButtonWithBadge';
 export { Button, BUTTON_SIZE, BUTTON_TYPE, IconButton } from './Button';
 export type { ButtonProps } from './Button';
 export { Card, TEST_IDS as CARD_TEST_IDS } from './Card';


### PR DESCRIPTION
# Description
This work moves StreamChat's `Chat` provider to the layout page level and passes unread message information into the navigation components. This allows the navigation layout to render unread message notifications for the messaging route.

# Closes issue(s)

# How to test / repro

# Screenshots
### Member Moble
![image](https://github.com/Therify/directory/assets/25045075/9ebebc3f-e1bc-423f-8b53-7e469f646754)
![image](https://github.com/Therify/directory/assets/25045075/906f78f6-6089-4b41-bb1f-7c0ccb9695be)

### Member desktop
![image](https://github.com/Therify/directory/assets/25045075/63c514e4-e435-4c30-b59b-0b073643219e)

### Coach mobile
![image](https://github.com/Therify/directory/assets/25045075/8d13924a-0d3e-4fc4-8e2a-0290df83c6f0)
![image](https://github.com/Therify/directory/assets/25045075/e5297f88-5868-4a65-a7a6-60eca68b498a)


### Coach Desktop
![image](https://github.com/Therify/directory/assets/25045075/39dd3c38-6388-47c4-bed4-6a3688ad4828)
 

# Changes include

-   [ ] Bugfix (non-breaking change that solves an issue)
-   [x] New feature (non-breaking change that adds functionality)
-   [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Checklist

-   [ ] I have tested this code
-   [ ] I have updated the Readme

# Other comments
