### PR TITLE
feat: add streamchat webhook handler

### DIFF
--- a/src/lib/modules/webhooks/services/stream-chat/errors/UnknownStreamChatEvent.ts
+++ b/src/lib/modules/webhooks/services/stream-chat/errors/UnknownStreamChatEvent.ts
@@ -1,0 +1,5 @@
+export class UnknownStreamChatEventTypeError extends Error {
+    constructor(eventType: string) {
+        super(`Unknown Stream Chat event type: ${eventType}`);
+    }
+}

--- a/src/lib/modules/webhooks/services/stream-chat/errors/index.ts
+++ b/src/lib/modules/webhooks/services/stream-chat/errors/index.ts
@@ -1,0 +1,1 @@
+export * from './UnknownStreamChatEvent';

--- a/src/lib/modules/webhooks/services/stream-chat/event-handlers/handleEvent.ts
+++ b/src/lib/modules/webhooks/services/stream-chat/event-handlers/handleEvent.ts
@@ -1,0 +1,29 @@
+import { StreamChatWebhookParams } from '../webhookParams';
+import { handleMessagesFactory } from './messages';
+import { NewMessageEvent } from '../schema';
+import { UnknownStreamChatEventTypeError } from '../errors';
+
+interface HandleEventParams {
+    type: string;
+    event: unknown;
+}
+export const handleEventFactory =
+    (context: StreamChatWebhookParams) =>
+    ({ type, event }: HandleEventParams) => {
+        const messageHandlers = handleMessagesFactory(context);
+        switch (type) {
+            case 'message.new':
+                return messageHandlers.newMessage(
+                    NewMessageEvent.schema.parse(event)
+                );
+            default:
+                handleUnknownEvent(type);
+        }
+    };
+
+const handleUnknownEvent = (type: string) => {
+    console.log(`Unexpected event type: ${type}`);
+    if (process.env.NODE_ENV !== 'development') {
+        throw new UnknownStreamChatEventTypeError(type);
+    }
+};

--- a/src/lib/modules/webhooks/services/stream-chat/event-handlers/messages/index.ts
+++ b/src/lib/modules/webhooks/services/stream-chat/event-handlers/messages/index.ts
@@ -1,0 +1,6 @@
+import { StreamChatWebhookParams } from '../../webhookParams';
+import { handleNewMessageFactory } from './newMessage';
+
+export const handleMessagesFactory = (params: StreamChatWebhookParams) => ({
+    newMessage: handleNewMessageFactory(params),
+});

--- a/src/lib/modules/webhooks/services/stream-chat/event-handlers/messages/newMessage.ts
+++ b/src/lib/modules/webhooks/services/stream-chat/event-handlers/messages/newMessage.ts
@@ -1,0 +1,48 @@
+import { adaptUserIdentifier } from '@/lib/shared/vendors/stream-chat/adapt-user-identifier';
+import { NewMessageEvent } from '../../schema';
+import { StreamChatWebhookParams } from '../../webhookParams';
+
+export const handleNewMessageFactory =
+    ({ prisma, notifications }: StreamChatWebhookParams) =>
+    async (newMessageEvent: NewMessageEvent.Type) => {
+        const senderId = newMessageEvent.message.user.id;
+        const recipientUserIds = newMessageEvent.members.reduce<string[]>(
+            (ids, member) => {
+                // Filter out sender from channel members
+                if (member.user_id === senderId) return ids;
+                return [
+                    ...ids,
+                    adaptUserIdentifier.fromStreamChat(member.user_id),
+                ];
+            },
+            []
+        );
+        const users = await prisma.user.findMany({
+            where: {
+                id: {
+                    in: recipientUserIds,
+                },
+            },
+            select: {
+                id: true,
+                emailAddress: true,
+            },
+        });
+
+        const usersWithPresence = await Promise.all(
+            users.map(async (user) => {
+                const presence = await notifications.getUserPresence(user.id);
+                return {
+                    ...user,
+                    ...presence,
+                };
+            })
+        );
+
+        // TODO: if offline, send notification
+        console.log(usersWithPresence);
+
+        return {
+            success: true,
+        };
+    };

--- a/src/lib/modules/webhooks/services/stream-chat/index.ts
+++ b/src/lib/modules/webhooks/services/stream-chat/index.ts
@@ -1,0 +1,1 @@
+export * from './service';

--- a/src/lib/modules/webhooks/services/stream-chat/schema/basePushEventSchema.ts
+++ b/src/lib/modules/webhooks/services/stream-chat/schema/basePushEventSchema.ts
@@ -1,0 +1,9 @@
+import * as z from 'zod';
+
+export const schema = z
+    .object({
+        type: z.string(),
+    })
+    .passthrough();
+
+export type Type = z.infer<typeof schema>;

--- a/src/lib/modules/webhooks/services/stream-chat/schema/index.ts
+++ b/src/lib/modules/webhooks/services/stream-chat/schema/index.ts
@@ -1,0 +1,2 @@
+export * as BasePushEvent from './basePushEventSchema';
+export * as NewMessageEvent from './newMessageEventSchema';

--- a/src/lib/modules/webhooks/services/stream-chat/schema/newMessageEventSchema.ts
+++ b/src/lib/modules/webhooks/services/stream-chat/schema/newMessageEventSchema.ts
@@ -1,0 +1,30 @@
+import * as z from 'zod';
+import { schema as basePushEventSchema } from './basePushEventSchema';
+const memberUserSchema = z
+    .object({
+        user_id: z.string(),
+    })
+    .passthrough();
+
+const messageUserSchema = z.object({
+    id: z.string(),
+    role: z.string(),
+    banned: z.boolean(),
+    online: z.boolean(),
+});
+
+export const schema = basePushEventSchema.extend({
+    message: z
+        .object({
+            id: z.string(),
+            text: z.string(),
+            user: messageUserSchema,
+        })
+        .passthrough(),
+    user: messageUserSchema.passthrough(),
+    members: memberUserSchema.array(),
+    channel_type: z.string(),
+    channel_id: z.string(),
+});
+
+export type Type = z.infer<typeof schema>;

--- a/src/lib/modules/webhooks/services/stream-chat/service.ts
+++ b/src/lib/modules/webhooks/services/stream-chat/service.ts
@@ -1,0 +1,41 @@
+import { StreamChatWebhookParams } from './webhookParams';
+import { prisma } from '@/lib/prisma';
+import { vendorStreamChat } from '@/lib/shared/vendors/stream-chat';
+import { BasePushEvent } from './schema';
+import { handleEventFactory } from './event-handlers/handleEvent';
+import { notificationsService } from '@/lib/modules/notifications/service';
+
+export const STREAM_CHAT_WEBHOOK_IDENTIFIER = 'STREAM_CHAT_WEBHOOK';
+
+const webhookContext: StreamChatWebhookParams = {
+    prisma,
+    notifications: notificationsService,
+};
+
+interface StreamChatWebhookServiceParams {
+    requestBody: string;
+    signature: string;
+}
+
+export const streamChatWebhookService = {
+    handleEvent: ({
+        requestBody,
+        signature,
+    }: StreamChatWebhookServiceParams) => {
+        const isValidSignature = vendorStreamChat.verifyWebhookSignature({
+            signature,
+            requestBody,
+        });
+
+        if (!isValidSignature) {
+            throw new Error('Invalid Stream Chat event signature.');
+        }
+
+        const rawEvent = JSON.parse(requestBody);
+        const event = BasePushEvent.schema.parse(rawEvent);
+
+        return handleEventFactory(webhookContext)({ type: event.type, event });
+    },
+};
+
+export type StreamChatWebhookServiceV1 = typeof streamChatWebhookService;

--- a/src/lib/modules/webhooks/services/stream-chat/webhookParams.ts
+++ b/src/lib/modules/webhooks/services/stream-chat/webhookParams.ts
@@ -1,0 +1,8 @@
+import { PrismaClient } from '@prisma/client';
+import { AccountsService } from '../../../accounts/service';
+import { NotificationsService } from '@/lib/modules/notifications/service';
+
+export interface StreamChatWebhookParams {
+    prisma: PrismaClient;
+    notifications: NotificationsService;
+}

--- a/src/lib/shared/vendors/stream-chat/index.ts
+++ b/src/lib/shared/vendors/stream-chat/index.ts
@@ -5,6 +5,7 @@ import { CreateToken } from './create-token';
 import { DeleteUser } from './delete-user';
 import { SendSystemMessageToChannel } from './send-system-message-to-channel';
 import { UpsertUser } from './upsert-user';
+import { VerifyWebhookSignature } from './verify-webhook-signature';
 
 export const vendorStreamChat = withStreamChatConfiguration((CONFIG) => {
     const streamChat = new StreamChat(
@@ -25,6 +26,9 @@ export const vendorStreamChat = withStreamChatConfiguration((CONFIG) => {
             streamChat,
         }),
         sendSystemMessageToChannel: SendSystemMessageToChannel.factory({
+            streamChat,
+        }),
+        verifyWebhookSignature: VerifyWebhookSignature.factory({
             streamChat,
         }),
     };

--- a/src/lib/shared/vendors/stream-chat/verify-webhook-signature/index.ts
+++ b/src/lib/shared/vendors/stream-chat/verify-webhook-signature/index.ts
@@ -1,0 +1,1 @@
+export * as VerifyWebhookSignature from './verifyWebhookSignature';

--- a/src/lib/shared/vendors/stream-chat/verify-webhook-signature/schema/index.ts
+++ b/src/lib/shared/vendors/stream-chat/verify-webhook-signature/schema/index.ts
@@ -1,0 +1,2 @@
+export { schema as inputSchema } from './input';
+export type { Input } from './input';

--- a/src/lib/shared/vendors/stream-chat/verify-webhook-signature/schema/input.ts
+++ b/src/lib/shared/vendors/stream-chat/verify-webhook-signature/schema/input.ts
@@ -1,0 +1,21 @@
+import * as z from 'zod';
+
+export const schema = z.object({
+    signature: z.string(),
+    requestBody: z.string(),
+});
+
+export type Input = z.infer<typeof schema>;
+
+export const validate = (value: unknown): Input => {
+    return schema.parse(value);
+};
+
+export const isValid = (value: unknown): value is Input => {
+    try {
+        validate(value);
+        return true;
+    } catch {
+        return false;
+    }
+};

--- a/src/lib/shared/vendors/stream-chat/verify-webhook-signature/verifyWebhookSignature.ts
+++ b/src/lib/shared/vendors/stream-chat/verify-webhook-signature/verifyWebhookSignature.ts
@@ -1,0 +1,15 @@
+import { StreamChatParams } from '../params';
+import { Input } from './schema';
+
+interface VerifyWebhookSignatureParams extends StreamChatParams {}
+
+export const factory = ({ streamChat }: VerifyWebhookSignatureParams) => {
+    return function upsertUser({ requestBody, signature }: Input): boolean {
+        try {
+            return streamChat.verifyWebhook(requestBody, signature);
+        } catch (error) {
+            console.error(error);
+            return false;
+        }
+    };
+};

--- a/src/pages/api/webhooks/stream-chat.ts
+++ b/src/pages/api/webhooks/stream-chat.ts
@@ -1,0 +1,28 @@
+import { NextApiRequest, NextApiResponse } from 'next/types';
+import { buffer } from 'micro';
+import { streamChatWebhookService } from '@/lib/modules/webhooks/services/stream-chat';
+
+export const config = { api: { bodyParser: false } };
+
+const handler = async (req: NextApiRequest, res: NextApiResponse) => {
+    if (req.method !== 'POST') {
+        res.setHeader('Allow', 'POST');
+        res.status(405).end('Method Not Allowed');
+        return;
+    }
+    const signature = req.headers['x-signature'] as string;
+    const rawBody = await buffer(req);
+
+    try {
+        const result = await streamChatWebhookService.handleEvent({
+            requestBody: rawBody.toString(),
+            signature,
+        });
+        res.send({ received: !!result?.success });
+    } catch (error) {
+        console.error(error);
+        return res.status(500).send(`Webhook Error: ${error}`);
+    }
+};
+
+export default handler;


### PR DESCRIPTION
# Description
Adds Stream Chat webhook listener for the `message.new` event.
- Handles event and validates signature
- Identifies `message.new` events and routes to handler
- Extracts Therify users from event and pulls recipient presence from our Notifications Service

*Follow up work needed to handle notification when users are offline.

# Closes issue(s)

# How to test / repro
Spin up local tunnel (`yarn localtunnel`)
Set your tunnel URL in the Steam Chat dashboard
Send a message to an offline user and watch the console.

# Screenshots
### Console output:
![image](https://github.com/Therify/directory/assets/25045075/c238acad-ea67-43cb-946d-bb4ec527c686)

# Changes include

-   [ ] Bugfix (non-breaking change that solves an issue)
-   [x] New feature (non-breaking change that adds functionality)
-   [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Checklist

-   [ ] I have tested this code
-   [ ] I have updated the Readme

# Other comments
Needs follow-up notification work to be production ready.