### PR TITLE
refactor: hook-form controller over register fn

### DIFF
--- a/src/lib/shared/components/ui/FormElements/FormRenderer/FormRenderer.spec.tsx
+++ b/src/lib/shared/components/ui/FormElements/FormRenderer/FormRenderer.spec.tsx
@@ -424,6 +424,30 @@ describe('FormRenderer', () => {
             expect(getByText(errorMessage)).toBeVisible();
             expect(submitButton).toBeDisabled();
         });
+
+        it('disables field when form is submitting', () => {
+            const mockInputConfig = getMockInputConfig({
+                id: 'test',
+                type: 'input',
+                label: 'First Name',
+                helperText: 'Enter your first name',
+                placeholder: 'John',
+                statePath: 'firstName',
+            });
+            const { getByPlaceholderText } = renderWithTheme(
+                <FormRenderer
+                    isSubmitting
+                    validationSchema={mockSchema}
+                    config={mockInputConfig}
+                    validationMode={'onChange'}
+                    onSubmit={(values) => console.log('submit', values)}
+                />
+            );
+            const inputDetails = mockInputConfig.sections[0].fields[0];
+            expect(
+                getByPlaceholderText(inputDetails.placeholder!)
+            ).toBeDisabled();
+        });
     });
 
     describe('password field', () => {
@@ -492,6 +516,21 @@ describe('FormRenderer', () => {
             expect(input).toHaveValue(password);
             expect(getByText(errorMessage)).toBeVisible();
             expect(submitButton).toBeDisabled();
+        });
+
+        it('disables field when form is submitting', () => {
+            const { getByPlaceholderText } = renderWithTheme(
+                <FormRenderer
+                    validationSchema={mockSchema}
+                    config={mockPasswordConfig}
+                    validationMode={'onChange'}
+                    onSubmit={jest.fn()}
+                    isSubmitting
+                />
+            );
+            const password = '12345678';
+            const input = getByPlaceholderText(inputDetails.placeholder!);
+            expect(input).toBeDisabled();
         });
     });
 
@@ -563,6 +602,21 @@ describe('FormRenderer', () => {
             expect(getByText(errorMessage)).toBeVisible();
             expect(submitButton).toBeDisabled();
         });
+
+        it('disables field when form is submitting', () => {
+            const mockSubmit = jest.fn();
+            const { getByPlaceholderText } = renderWithTheme(
+                <FormRenderer
+                    validationSchema={mockSchema}
+                    config={mockTextareaConfig}
+                    validationMode={'onChange'}
+                    onSubmit={mockSubmit}
+                    isSubmitting
+                />
+            );
+            const input = getByPlaceholderText(textAreaDetails.placeholder!);
+            expect(input).toBeDisabled();
+        });
     });
 
     describe('select field', () => {
@@ -629,6 +683,24 @@ describe('FormRenderer', () => {
             );
             const submitButton = getByText('Submit');
             expect(submitButton).toBeDisabled();
+        });
+
+        it('disables field when form is submitting', () => {
+            const mockSubmit = jest.fn();
+            const { getByTestId } = renderWithTheme(
+                <FormRenderer
+                    validationSchema={mockSchema}
+                    config={mockSelectConfig}
+                    validationMode={'onChange'}
+                    onSubmit={mockSubmit}
+                    isSubmitting
+                />
+            );
+            const select = getByTestId(
+                SELECT_TEST_IDS.SELECT
+            ).firstElementChild;
+
+            expect(select?.getAttribute('aria-disabled')).toBe('true');
         });
     });
 });

--- a/src/lib/shared/components/ui/FormElements/FormRenderer/FormRenderer.stories.tsx
+++ b/src/lib/shared/components/ui/FormElements/FormRenderer/FormRenderer.stories.tsx
@@ -22,7 +22,9 @@ const schema = z.object({
     age: z.number().min(18, {
         message: 'Must be at least 18 years old.',
     }),
-    password: z.string(),
+    password: z.string().min(8, {
+        message: 'Password must be at least 8 characters.',
+    }),
     confirmPassword: z.string(),
     state: z.enum(states),
     description: z.string(),
@@ -133,6 +135,28 @@ export const PrefilledForm: StoryFn = () => {
                 validationMode={'onChange'}
                 isSubmitting={isLoading}
                 onSubmit={submit}
+            />
+        </div>
+    );
+};
+export const SubmittingForm: StoryFn = () => {
+    return (
+        <div style={containerStyle}>
+            <Ui
+                validationSchema={schema}
+                config={config}
+                defaultValues={{
+                    firstName: 'John',
+                    lastName: 'Doe',
+                    age: 25,
+                    password: 'password',
+                    confirmPassword: 'password',
+                    description: 'I am a not a robot',
+                    state: 'California',
+                }}
+                validationMode={'onChange'}
+                isSubmitting
+                onSubmit={console.log}
             />
         </div>
     );

--- a/src/lib/shared/components/ui/FormElements/FormRenderer/FormRenderer.tsx
+++ b/src/lib/shared/components/ui/FormElements/FormRenderer/FormRenderer.tsx
@@ -52,12 +52,10 @@ export function FormRenderer<ValidationSchema extends z.ZodTypeAny>({
     });
 
     const {
-        watch,
         formState: { isValid },
         handleSubmit,
     } = form;
-    // There is a problem where this watch call is needed to trigger validation
-    watch();
+
     return (
         <Form sx={sx}>
             <FormContent isError={!!errorMessage}>
@@ -91,6 +89,7 @@ export function FormRenderer<ValidationSchema extends z.ZodTypeAny>({
                                     key={`field-${i}`}
                                 >
                                     {getFormInput({
+                                        isLoading: !!isSubmitting,
                                         field,
                                         useFormProps: form,
                                     })}

--- a/src/lib/shared/components/ui/FormElements/FormRenderer/getFormInput.tsx
+++ b/src/lib/shared/components/ui/FormElements/FormRenderer/getFormInput.tsx
@@ -7,21 +7,23 @@ import { InputField, PasswordField, TextAreaField, SelectField } from './ui';
 interface GetFormInputProps<T extends FieldValues> {
     field: FormField<T>;
     useFormProps: UseFormReturn<T, any>;
+    isLoading: boolean;
 }
 
 export function getFormInput<T extends FieldValues>({
+    isLoading,
     field,
     useFormProps,
 }: GetFormInputProps<T>): ReactNode {
     switch (field.type) {
         case 'input':
-            return <InputField field={field} {...useFormProps} />;
+            return <InputField {...{ field, isLoading, ...useFormProps }} />;
         case 'password':
-            return <PasswordField field={field} {...useFormProps} />;
+            return <PasswordField {...{ field, isLoading, ...useFormProps }} />;
         case 'textarea':
-            return <TextAreaField field={field} {...useFormProps} />;
+            return <TextAreaField {...{ field, isLoading, ...useFormProps }} />;
         case 'select':
-            return <SelectField field={field} {...useFormProps} />;
+            return <SelectField {...{ field, isLoading, ...useFormProps }} />;
         default:
             return null;
     }

--- a/src/lib/shared/components/ui/FormElements/FormRenderer/ui/InputField.tsx
+++ b/src/lib/shared/components/ui/FormElements/FormRenderer/ui/InputField.tsx
@@ -1,34 +1,49 @@
-import { FieldValues, UseFormReturn } from 'react-hook-form';
+import { Controller, FieldValues, UseFormReturn } from 'react-hook-form';
 import { Input } from '@/lib/shared/components/ui';
 import { Input as InputType } from '../types';
 
 export function InputField<T extends FieldValues>({
-    register,
-    getFieldState,
+    control,
     field,
+    isLoading,
 }: {
     field: InputType<T>;
+    isLoading: boolean;
 } & UseFormReturn<T, any>) {
-    const { error } = getFieldState(field.statePath);
-    const { ref, ...registerProps } = register(field.statePath, {
-        ...(field.inputType === 'number' && { valueAsNumber: true }),
-    });
-
     return (
-        <Input
-            required={field.required}
-            type={field.inputType ?? 'text'}
-            id={field.id}
-            label={field.label}
-            placeholder={field.placeholder}
-            helperText={field.helperText}
-            errorMessage={error?.message}
-            autoComplete={field.autoComplete}
-            inputRef={ref}
-            {...registerProps}
-            wrapperSx={{
-                width: '100%',
-            }}
+        <Controller
+            control={control}
+            name={field.statePath}
+            render={({
+                field: { onChange, onBlur, value, name },
+                fieldState: { error },
+            }) => (
+                <Input
+                    fullWidth
+                    disabled={isLoading}
+                    required={field.required}
+                    type={field.inputType ?? 'text'}
+                    id={field.id}
+                    label={field.label}
+                    placeholder={field.placeholder}
+                    helperText={field.helperText}
+                    errorMessage={error?.message}
+                    autoComplete={field.autoComplete}
+                    onChange={(e) => {
+                        if (field.inputType === 'number') {
+                            return onChange({
+                                target: { value: parseFloat(e.target.value) },
+                            });
+                        }
+                        onChange(e);
+                    }}
+                    {...{
+                        onBlur,
+                        value,
+                        name,
+                    }}
+                />
+            )}
         />
     );
 }

--- a/src/lib/shared/components/ui/FormElements/FormRenderer/ui/PasswordField.tsx
+++ b/src/lib/shared/components/ui/FormElements/FormRenderer/ui/PasswordField.tsx
@@ -1,31 +1,40 @@
-import { FieldValues, UseFormReturn } from 'react-hook-form';
+import { Controller, FieldValues, UseFormReturn } from 'react-hook-form';
 import { PasswordInput } from '@/lib/shared/components/ui';
 import { PasswordInput as PasswordFieldType } from '../types';
 
 export function PasswordField<T extends FieldValues>({
-    register,
-    getFieldState,
     field,
+    isLoading,
+    control,
 }: {
+    isLoading: boolean;
     field: PasswordFieldType<T>;
 } & UseFormReturn<T, any>) {
-    const { error } = getFieldState(field.statePath);
-    const { ref, ...registerProps } = register(field.statePath, {});
-
     return (
-        <PasswordInput
-            allowShowPassword={field.allowShowPassword ?? true}
-            required={field.required}
-            placeholder={field.placeholder}
-            id={field.id}
-            label={field.label}
-            helperText={field.helperText}
-            errorMessage={error?.message}
-            inputRef={ref}
-            {...registerProps}
-            wrapperSx={{
-                width: '100%',
-            }}
+        <Controller
+            control={control}
+            name={field.statePath}
+            render={({
+                field: { onChange, onBlur, value, name },
+                fieldState: { error },
+            }) => (
+                <PasswordInput
+                    fullWidth
+                    disabled={isLoading}
+                    required={field.required}
+                    id={field.id}
+                    label={field.label}
+                    placeholder={field.placeholder}
+                    helperText={field.helperText}
+                    errorMessage={error?.message}
+                    {...{
+                        onChange,
+                        onBlur,
+                        value,
+                        name,
+                    }}
+                />
+            )}
         />
     );
 }

--- a/src/lib/shared/components/ui/FormElements/FormRenderer/ui/SelectField.tsx
+++ b/src/lib/shared/components/ui/FormElements/FormRenderer/ui/SelectField.tsx
@@ -1,14 +1,13 @@
-import { Path, PathValue, UseFormReturn, FieldValues } from 'react-hook-form';
+import { UseFormReturn, FieldValues, Controller } from 'react-hook-form';
 import { Select, SelectOption } from '@/lib/shared/components/ui';
 import { SelectInput } from '../types';
 
 export function SelectField<T extends FieldValues>({
-    register,
-    getFieldState,
-    watch,
-    setValue,
+    control,
     field,
+    isLoading,
 }: {
+    isLoading: boolean;
     field: SelectInput<T>;
 } & UseFormReturn<T, any>) {
     const options: SelectOption[] = field.options.map((option) => {
@@ -20,31 +19,32 @@ export function SelectField<T extends FieldValues>({
         }
         return option;
     });
-    const value = watch(field.statePath);
-    const { error } = getFieldState(field.statePath);
-    const { ref, onChange, ...registerProps } = register(field.statePath, {
-        ...(field.required && { required: 'Field is required' }),
-    });
-
     return (
-        <Select
-            required={field.required}
-            id={field.id}
-            label={field.label}
-            helperText={field.helperText}
-            errorMessage={error?.message}
-            inputRef={ref}
-            options={options}
-            value={value}
-            fullWidth
-            placeholder={field.placeholder}
-            onChange={(value) => {
-                setValue(field.statePath, value as PathValue<T, Path<T>>);
-            }}
-            {...registerProps}
-            wrapperSx={{
-                width: '100%',
-            }}
+        <Controller
+            control={control}
+            name={field.statePath}
+            render={({
+                field: { onChange, onBlur, value, name },
+                fieldState: { error },
+            }) => (
+                <Select
+                    required={field.required}
+                    id={field.id}
+                    label={field.label}
+                    helperText={field.helperText}
+                    errorMessage={error?.message}
+                    disabled={isLoading}
+                    value={value}
+                    fullWidth
+                    placeholder={field.placeholder}
+                    options={options}
+                    {...{
+                        onBlur,
+                        onChange,
+                        name,
+                    }}
+                />
+            )}
         />
     );
 }

--- a/src/lib/shared/components/ui/FormElements/FormRenderer/ui/TextAreaField.tsx
+++ b/src/lib/shared/components/ui/FormElements/FormRenderer/ui/TextAreaField.tsx
@@ -1,30 +1,41 @@
-import { UseFormReturn, FieldValues } from 'react-hook-form';
+import { UseFormReturn, FieldValues, Controller } from 'react-hook-form';
 import { Textarea } from '@/lib/shared/components/ui';
 import { TextAreaInput } from '../types';
 
 export function TextAreaField<T extends FieldValues>({
-    register,
-    getFieldState,
+    control,
     field,
+    isLoading,
 }: {
+    isLoading: boolean;
     field: TextAreaInput<T>;
 } & UseFormReturn<T, any>) {
-    const { error } = getFieldState(field.statePath);
-    const { ref, ...registerProps } = register(field.statePath, {});
-
     return (
-        <Textarea
-            required={field.required}
-            id={field.id}
-            label={field.label}
-            helperText={field.helperText}
-            placeholder={field.placeholder}
-            errorMessage={error?.message}
-            inputRef={ref}
-            {...registerProps}
-            wrapperSx={{
-                width: '100%',
-            }}
+        <Controller
+            control={control}
+            name={field.statePath}
+            render={({
+                field: { onChange, onBlur, value, name },
+                fieldState: { error },
+            }) => (
+                <Textarea
+                    id={field.id}
+                    defaultValue=""
+                    fullWidth
+                    disabled={isLoading}
+                    required={field.required}
+                    label={field.label}
+                    placeholder={field.placeholder}
+                    helperText={field.helperText}
+                    errorMessage={error?.message}
+                    {...{
+                        onChange,
+                        onBlur,
+                        value,
+                        name,
+                    }}
+                />
+            )}
         />
     );
 }


### PR DESCRIPTION
# Description
Refactors the use of the `register` function from the `useFrom` hook to use `Controller` element from react-hook-form.
Also disables input fields when form is submitting.

This solves some unexpected validation behavior. 

# Closes issue(s)

# How to test / repro

# Screenshots

# Changes include

-   [ ] Bugfix (non-breaking change that solves an issue)
-   [ ] New feature (non-breaking change that adds functionality)
-   [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Checklist

-   [x] I have tested this code
-   [ ] I have updated the Readme

# Other comments
