### PR TITLE
feat: add radio select form element

### DIFF
--- a/src/lib/shared/components/ui/FormElements/RadioSelect/RadioSelect.spec.tsx
+++ b/src/lib/shared/components/ui/FormElements/RadioSelect/RadioSelect.spec.tsx
@@ -1,0 +1,121 @@
+import { renderWithTheme } from '../../../fixtures';
+import { SelectOption } from '../Select';
+import { RadioSelect } from './RadioSelect';
+
+const question =
+    'In the 2 weeks have you had little interest or pleasure in doing things?';
+const options: SelectOption[] = [
+    {
+        id: 'not-at-all',
+        displayText: 'Not at all',
+        value: 'not-at-all',
+    },
+    {
+        id: 'several-days',
+        displayText: 'Several days',
+        value: 'several-days',
+    },
+    {
+        id: 'more-than-half-the-days',
+        displayText: 'More than half the days',
+        value: 'more-than-half-the-days',
+    },
+    {
+        id: 'nearly-every-day',
+        displayText: 'Nearly every day',
+        value: 'nearly-every-day',
+    },
+];
+
+describe('RadioSelect', () => {
+    it('should render label text', () => {
+        const mockOnChange = jest.fn();
+        const { getByText } = renderWithTheme(
+            <RadioSelect
+                id="radio-select"
+                options={options}
+                label={question}
+                onChange={mockOnChange}
+            />
+        );
+        expect(getByText(question)).toBeVisible();
+    });
+
+    it('should render options', () => {
+        const mockOnChange = jest.fn();
+        const { getByText } = renderWithTheme(
+            <RadioSelect
+                id="radio-select"
+                options={options}
+                label={question}
+                onChange={mockOnChange}
+            />
+        );
+        options.forEach((option) => {
+            expect(getByText(option.displayText)).toBeVisible();
+        });
+    });
+
+    it('should render required indicator', () => {
+        const mockOnChange = jest.fn();
+        const { getByText } = renderWithTheme(
+            <RadioSelect
+                id="radio-select"
+                options={options}
+                label={question}
+                onChange={mockOnChange}
+                required
+            />
+        );
+        expect(getByText('*')).toBeVisible();
+    });
+
+    it('should call onChange when an option is selected', () => {
+        const mockOnChange = jest.fn();
+        const { getByText } = renderWithTheme(
+            <RadioSelect
+                id="radio-select"
+                options={options}
+                label={question}
+                onChange={mockOnChange}
+            />
+        );
+        const option = getByText(options[0].displayText);
+        option.click();
+        expect(mockOnChange).toHaveBeenCalledWith(options[0].value);
+    });
+
+    it('should disable option', () => {
+        const mockOnChange = jest.fn();
+        const { getByText } = renderWithTheme(
+            <RadioSelect
+                id="radio-select"
+                options={[{ ...options[0], disabled: true }]}
+                label={question}
+                onChange={mockOnChange}
+            />
+        );
+        const option = getByText(options[0].displayText);
+        expect(option.previousSibling).toHaveAttribute('aria-disabled', 'true');
+    });
+
+    it('should disable entire input', () => {
+        const mockOnChange = jest.fn();
+        const { getByText } = renderWithTheme(
+            <RadioSelect
+                id="radio-select"
+                options={options}
+                label={question}
+                onChange={mockOnChange}
+                disabled
+            />
+        );
+        options.forEach((option) => {
+            const optionEl = getByText(option.displayText);
+            expect(optionEl.previousSibling).toHaveAttribute(
+                'aria-disabled',
+                'true'
+            );
+        });
+    });
+});

--- a/src/lib/shared/components/ui/FormElements/RadioSelect/RadioSelect.stories.tsx
+++ b/src/lib/shared/components/ui/FormElements/RadioSelect/RadioSelect.stories.tsx
@@ -1,0 +1,62 @@
+import { Meta, StoryFn } from '@storybook/react';
+import { useState } from 'react';
+import { SelectOption } from '../Select';
+import { RadioSelect as Component } from './RadioSelect';
+
+const meta: Meta<typeof Component> = {
+    title: 'Components/RadioSelect',
+    component: Component,
+};
+
+export default meta;
+
+const question =
+    'In the 2 weeks have you had little interest or pleasure in doing things?';
+const options: SelectOption[] = [
+    {
+        id: 'not-at-all',
+        displayText: 'Not at all',
+        value: 'not-at-all',
+    },
+    {
+        id: 'several-days',
+        displayText: 'Several days',
+        value: 'several-days',
+    },
+    {
+        id: 'more-than-half-the-days',
+        displayText: 'More than half the days',
+        value: 'more-than-half-the-days',
+    },
+    {
+        id: 'nearly-every-day',
+        displayText: 'Nearly every day',
+        value: 'nearly-every-day',
+    },
+];
+
+export const RadioSelect: StoryFn<typeof Component> = () => {
+    const [value, setValue] = useState<string>();
+    return (
+        <Component
+            id="radio-select"
+            label={question}
+            value={value}
+            onChange={(value) => setValue(value)}
+            options={options}
+        />
+    );
+};
+export const Disabled: StoryFn<typeof Component> = () => {
+    const [value, setValue] = useState<string>();
+    return (
+        <Component
+            id="radio-select"
+            label={question}
+            value={value}
+            onChange={(value) => setValue(value)}
+            options={options}
+            disabled
+        />
+    );
+};

--- a/src/lib/shared/components/ui/FormElements/RadioSelect/RadioSelect.tsx
+++ b/src/lib/shared/components/ui/FormElements/RadioSelect/RadioSelect.tsx
@@ -1,0 +1,90 @@
+import { Box, FormControl, InputLabel as MuiInputLabel } from '@mui/material';
+import { styled, SxProps, Theme, useTheme } from '@mui/material/styles';
+import { SelectOption } from '../Select';
+import { Radio } from '../Toggle';
+
+interface RadioSelectProps {
+    id: string;
+    options: SelectOption[];
+    onChange?: (value: string) => void;
+    value?: string;
+    label: string;
+    required?: boolean;
+    fullWidth?: boolean;
+    wrapperSx?: SxProps<Theme>;
+    labelSx?: SxProps<Theme>;
+    disabled?: boolean;
+}
+
+export const RadioSelect = ({
+    id,
+    onChange,
+    value,
+    options,
+    disabled,
+    label,
+    required,
+    fullWidth,
+    labelSx,
+    wrapperSx,
+}: RadioSelectProps) => {
+    const theme = useTheme();
+
+    return (
+        <FormControl
+            fullWidth={fullWidth}
+            sx={{ marginBottom: theme.spacing(4), ...wrapperSx }}
+        >
+            <InputLabel
+                id={`${id}-label`}
+                shrink
+                sx={{
+                    fontSize: 14,
+                    position: 'relative',
+                    color: theme.palette.grey[600],
+                    transform: 'none',
+                    ...labelSx,
+                }}
+            >
+                {label}{' '}
+                {required && (
+                    <span style={{ color: theme.palette.error.main }}>*</span>
+                )}
+            </InputLabel>
+
+            <OptionsWrapper>
+                {options.map((option) => (
+                    <Radio
+                        key={option.value}
+                        id={option.id}
+                        disabled={disabled ?? option.disabled}
+                        displayText={option.displayText}
+                        value={option.value}
+                        checked={!!value && option.value === value}
+                        onChange={() => onChange?.(option.value)}
+                    />
+                ))}
+            </OptionsWrapper>
+        </FormControl>
+    );
+};
+
+const InputLabel = styled(MuiInputLabel)(({ theme }) => ({
+    ...theme.typography.body2,
+    fontWeight: 500,
+    color: theme.palette.text.primary,
+    fontSize: '1.125rem !important',
+    '&.Mui-focused, &.MuiFormLabel-root': {
+        color: theme.palette.text.primary + ' !important',
+    },
+}));
+
+const OptionsWrapper = styled(Box)(({ theme }) => ({
+    display: 'flex',
+    flexDirection: 'column',
+    alignItems: 'flex-start',
+    marginTop: theme.spacing(6),
+    '& label span.MuiRadio-root': {
+        padding: theme.spacing(1, 2, 1, 0),
+    },
+}));

--- a/src/lib/shared/components/ui/FormElements/RadioSelect/index.ts
+++ b/src/lib/shared/components/ui/FormElements/RadioSelect/index.ts
@@ -1,0 +1,1 @@
+export * from './RadioSelect';

--- a/src/lib/shared/components/ui/FormElements/index.ts
+++ b/src/lib/shared/components/ui/FormElements/index.ts
@@ -10,6 +10,7 @@ export {
     Radio,
     TOGGLE_TYPE,
 } from './Toggle';
+export { RadioSelect } from './RadioSelect';
 export * from './formTypography';
 export type { ToggleProps, ToggleType } from './Toggle';
 export * as FormValidation from './form-validation';


### PR DESCRIPTION
# Description
Adds `RadioSelect` form element to shared UI library

# Closes issue(s)
[Radio Select Form Element](https://www.notion.so/Radio-Select-Form-Element-41ab0d7cbef34129bb780846818b2cd5?pvs=4)

# How to test / repro
`yarn storybook`

View `Components > RadioSelect`

# Screenshots
![image](https://github.com/Therify/directory/assets/25045075/05d2ee91-eb86-4993-b080-5b5c35a3a6da)



# Changes include

-   [ ] Bugfix (non-breaking change that solves an issue)
-   [x] New feature (non-breaking change that adds functionality)
-   [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Checklist

-   [x] I have tested this code
-   [ ] I have updated the Readme

# Other comments
