### PR TITLE
feat: add radio select to form renderer

### DIFF
--- a/src/lib/shared/components/ui/FormElements/FormRenderer/FormRenderer.stories.tsx
+++ b/src/lib/shared/components/ui/FormElements/FormRenderer/FormRenderer.stories.tsx
@@ -47,7 +47,7 @@ const schema = z
         dateOfBirth: z.date().max(new Date(), {
             message: 'Date of birth must be in the past.',
         }),
-        radio: z.enum(numbers),
+        favoriteNumber: z.enum(numbers),
     })
     .refine((data) => data.password === data.confirmPassword, {
         message: 'Passwords do not match.',
@@ -152,7 +152,7 @@ export const PrefilledForm: StoryFn = () => {
                     confirmPassword: 'password',
                     description: 'I am a not a robot',
                     state: 'California',
-                    radio: 'One',
+                    favoriteNumber: 'One',
                 }}
                 validationMode={'onChange'}
                 isSubmitting={isLoading}
@@ -175,7 +175,7 @@ export const SubmittingForm: StoryFn = () => {
                     confirmPassword: 'password',
                     description: 'I am a not a robot',
                     state: 'California',
-                    radio: 'One',
+                    favoriteNumber: 'One',
                 }}
                 validationMode={'onChange'}
                 isSubmitting
@@ -280,7 +280,7 @@ const config: FormConfig<z.infer<typeof schema>> = {
                     label: 'Which of these numbers is your favorite?',
                     helperText: 'Select an option',
                     fullWidth: true,
-                    statePath: 'radio',
+                    statePath: 'favoriteNumber',
                     options: [...numbers],
                 },
             ],

--- a/src/lib/shared/components/ui/FormElements/FormRenderer/FormRenderer.stories.tsx
+++ b/src/lib/shared/components/ui/FormElements/FormRenderer/FormRenderer.stories.tsx
@@ -276,7 +276,7 @@ const config: FormConfig<z.infer<typeof schema>> = {
                 {
                     id: 'radio',
                     required: false,
-                    type: 'radio',
+                    type: 'radio-select',
                     label: 'Which of these numbers is your favorite?',
                     helperText: 'Select an option',
                     fullWidth: true,

--- a/src/lib/shared/components/ui/FormElements/FormRenderer/FormRenderer.stories.tsx
+++ b/src/lib/shared/components/ui/FormElements/FormRenderer/FormRenderer.stories.tsx
@@ -12,6 +12,7 @@ export default {
 } as Meta;
 
 const states = ['California', 'New York', 'Tennessee'] as const;
+const numbers = ['One', 'Two', 'Three', 'Four'] as const;
 const schema = z
     .object({
         firstName: z.string().nonempty({
@@ -46,6 +47,7 @@ const schema = z
         dateOfBirth: z.date().max(new Date(), {
             message: 'Date of birth must be in the past.',
         }),
+        radio: z.enum(numbers),
     })
     .refine((data) => data.password === data.confirmPassword, {
         message: 'Passwords do not match.',
@@ -150,6 +152,7 @@ export const PrefilledForm: StoryFn = () => {
                     confirmPassword: 'password',
                     description: 'I am a not a robot',
                     state: 'California',
+                    radio: 'One',
                 }}
                 validationMode={'onChange'}
                 isSubmitting={isLoading}
@@ -172,6 +175,7 @@ export const SubmittingForm: StoryFn = () => {
                     confirmPassword: 'password',
                     description: 'I am a not a robot',
                     state: 'California',
+                    radio: 'One',
                 }}
                 validationMode={'onChange'}
                 isSubmitting
@@ -268,6 +272,16 @@ const config: FormConfig<z.infer<typeof schema>> = {
                     fullWidth: true,
                     label: 'I agree to the terms and conditions',
                     statePath: 'iAgree',
+                },
+                {
+                    id: 'radio',
+                    required: false,
+                    type: 'radio',
+                    label: 'Which of these numbers is your favorite?',
+                    helperText: 'Select an option',
+                    fullWidth: true,
+                    statePath: 'radio',
+                    options: [...numbers],
                 },
             ],
         },

--- a/src/lib/shared/components/ui/FormElements/FormRenderer/__tests__/RadioSelectField.spec.tsx
+++ b/src/lib/shared/components/ui/FormElements/FormRenderer/__tests__/RadioSelectField.spec.tsx
@@ -1,0 +1,105 @@
+import userEvent from '@testing-library/user-event';
+import { z } from 'zod';
+import { FormRenderer } from '../FormRenderer';
+import { RadioSelectInput } from '../types';
+import { renderWithTheme } from '../../../../fixtures';
+import { getMockInputConfig } from '../__mocks__/getMockInputConfig';
+import { sleep } from '@/lib/shared/utils';
+
+describe('Select field', () => {
+    const user = userEvent.setup();
+    const mockSchema = z.object({
+        yesOrNo: z.enum(['Yes', 'No']),
+    });
+    const radioSelectConfig: RadioSelectInput<z.infer<typeof mockSchema>> = {
+        id: 'yesOrNo',
+        type: 'radio-select',
+        label: 'Select yes or no',
+        statePath: 'yesOrNo',
+        options: ['Yes', 'No'],
+    };
+    const mockRadioSelectConfig = getMockInputConfig(radioSelectConfig);
+    const radioSelectDetails = mockRadioSelectConfig.sections[0].fields[0] as RadioSelectInput<
+        z.infer<typeof mockSchema>
+    >;
+
+    it('renders radio select', () => {
+        const { getByText } = renderWithTheme(
+            <FormRenderer
+                validationSchema={mockSchema}
+                config={mockRadioSelectConfig}
+                validationMode={'onChange'}
+                onSubmit={console.log}
+            />
+        );
+        expect(getByText(radioSelectDetails.label)).toBeVisible();
+    });
+
+    it('captures radio select value', async () => {
+        const mockSubmit = jest.fn();
+        const { getByText } = renderWithTheme(
+            <FormRenderer
+                validationSchema={mockSchema}
+                config={mockRadioSelectConfig}
+                validationMode={'onChange'}
+                onSubmit={mockSubmit}
+            />
+        );
+        const submitButton = getByText('Submit');
+        const optionEl = getByText('Yes');
+        await userEvent.click(optionEl);
+        await user.click(submitButton);
+        expect(mockSubmit).toHaveBeenCalledWith({ yesOrNo: 'Yes' });
+    });
+
+    it('requires selection to submit', async () => {
+        const mockSubmit = jest.fn();
+        const { getByText } = renderWithTheme(
+            <FormRenderer
+                validationSchema={mockSchema}
+                config={mockRadioSelectConfig}
+                validationMode={'onChange'}
+                onSubmit={mockSubmit}
+            />
+        );
+        const submitButton = getByText('Submit');
+        expect(submitButton).toBeDisabled();
+    });
+
+    it('disables field when form is submitting', () => {
+        const mockSubmit = jest.fn();
+        const { getByText } = renderWithTheme(
+            <FormRenderer
+                validationSchema={mockSchema}
+                config={mockRadioSelectConfig}
+                validationMode={'onChange'}
+                onSubmit={mockSubmit}
+                isSubmitting
+            />
+        );
+        radioSelectDetails.options.forEach(option => {
+            expect(getByText(option as string)).toHaveClass('Mui-disabled');
+        })
+    });
+
+    it('selects default value when given at the field level', async () => {
+            const mockSubmit = jest.fn();
+            const mockDefaultValueConfig = getMockInputConfig({
+                    ...radioSelectDetails,
+                    defaultValue: 'Yes',
+                });
+            const { getByText } = renderWithTheme(
+                <FormRenderer
+                    validationSchema={mockSchema}
+                    config={mockDefaultValueConfig}
+                    validationMode={'onChange'}
+                    onSubmit={mockSubmit}
+                />
+            );
+            // allow the default value to re-render before assertion occurs
+            await sleep(0);
+            const submitButton = getByText('Submit');
+            await user.click(submitButton);
+            expect(mockSubmit).toHaveBeenCalledWith({ yesOrNo: 'Yes' });
+        });
+});

--- a/src/lib/shared/components/ui/FormElements/FormRenderer/getFormInput.tsx
+++ b/src/lib/shared/components/ui/FormElements/FormRenderer/getFormInput.tsx
@@ -42,7 +42,7 @@ export function getFormInput<T extends FieldValues>({
             );
         case 'toggle':
             return <ToggleField {...{ field, isLoading, ...useFormProps }} />;
-        case 'radio':
+        case 'radio-select':
             return <RadioSelectField {...{ field, isLoading, ...useFormProps }} />;
         default:
             return null;

--- a/src/lib/shared/components/ui/FormElements/FormRenderer/getFormInput.tsx
+++ b/src/lib/shared/components/ui/FormElements/FormRenderer/getFormInput.tsx
@@ -10,6 +10,7 @@ import {
     DatePickerField,
     ToggleField,
 } from './ui';
+import { RadioSelectField } from './ui/RadioSelectField';
 
 interface GetFormInputProps<T extends FieldValues> {
     field: FormField<T>;
@@ -41,6 +42,8 @@ export function getFormInput<T extends FieldValues>({
             );
         case 'toggle':
             return <ToggleField {...{ field, isLoading, ...useFormProps }} />;
+        case 'radio':
+            return <RadioSelectField {...{ field, isLoading, ...useFormProps }} />;
         default:
             return null;
     }

--- a/src/lib/shared/components/ui/FormElements/FormRenderer/getFormInput.tsx
+++ b/src/lib/shared/components/ui/FormElements/FormRenderer/getFormInput.tsx
@@ -9,8 +9,8 @@ import {
     TelephoneField,
     DatePickerField,
     ToggleField,
+    RadioSelectField,
 } from './ui';
-import { RadioSelectField } from './ui/RadioSelectField';
 
 interface GetFormInputProps<T extends FieldValues> {
     field: FormField<T>;

--- a/src/lib/shared/components/ui/FormElements/FormRenderer/types.ts
+++ b/src/lib/shared/components/ui/FormElements/FormRenderer/types.ts
@@ -66,7 +66,7 @@ export type SelectInput<T extends FieldValues> = {
 } & FormFieldBase<T>;
 
 export type RadioSelectInput<T extends FieldValues> = {
-    type: 'radio';
+    type: 'radio-select';
     defaultValue?: PathValue<T, Path<T>>;
     options: string[] | SelectOption[];
 } & FormFieldBase<T>;

--- a/src/lib/shared/components/ui/FormElements/FormRenderer/types.ts
+++ b/src/lib/shared/components/ui/FormElements/FormRenderer/types.ts
@@ -20,7 +20,8 @@ export type FormField<T extends FieldValues> =
     | SelectInput<T>
     | TelephoneInput<T>
     | DatePickerInput<T>
-    | ToggleInput<T>;
+    | ToggleInput<T>
+    | RadioSelectInput<T>;
 
 interface FormFieldBase<T extends FieldValues> {
     id: string;
@@ -60,6 +61,12 @@ export type TextAreaInput<T extends FieldValues> = {
 export type SelectInput<T extends FieldValues> = {
     type: 'select';
     placeholder?: string;
+    defaultValue?: PathValue<T, Path<T>>;
+    options: string[] | SelectOption[];
+} & FormFieldBase<T>;
+
+export type RadioSelectInput<T extends FieldValues> = {
+    type: 'radio';
     defaultValue?: PathValue<T, Path<T>>;
     options: string[] | SelectOption[];
 } & FormFieldBase<T>;

--- a/src/lib/shared/components/ui/FormElements/FormRenderer/ui/RadioSelectField.tsx
+++ b/src/lib/shared/components/ui/FormElements/FormRenderer/ui/RadioSelectField.tsx
@@ -1,5 +1,5 @@
 import { UseFormReturn, FieldValues, Controller } from 'react-hook-form';
-import { RadioSelect, Select, SelectOption } from '@/lib/shared/components/ui';
+import { RadioSelect, SelectOption } from '@/lib/shared/components/ui';
 import { RadioSelectInput } from '../types';
 
 export function RadioSelectField<T extends FieldValues>({
@@ -26,7 +26,6 @@ export function RadioSelectField<T extends FieldValues>({
             defaultValue={field.defaultValue}
             render={({
                 field: { onChange, onBlur, value, name },
-                fieldState: { error },
             }) => (
                 <RadioSelect
                     required={field.required}

--- a/src/lib/shared/components/ui/FormElements/FormRenderer/ui/RadioSelectField.tsx
+++ b/src/lib/shared/components/ui/FormElements/FormRenderer/ui/RadioSelectField.tsx
@@ -1,0 +1,48 @@
+import { UseFormReturn, FieldValues, Controller } from 'react-hook-form';
+import { RadioSelect, Select, SelectOption } from '@/lib/shared/components/ui';
+import { RadioSelectInput } from '../types';
+
+export function RadioSelectField<T extends FieldValues>({
+    control,
+    field,
+    isLoading,
+}: {
+    isLoading: boolean;
+    field: RadioSelectInput<T>;
+} & UseFormReturn<T, any>) {
+    const options: SelectOption[] = field.options.map((option) => {
+        if (typeof option === 'string') {
+            return {
+                displayText: option,
+                value: option,
+            };
+        }
+        return option;
+    });
+    return (
+        <Controller
+            control={control}
+            name={field.statePath}
+            defaultValue={field.defaultValue}
+            render={({
+                field: { onChange, onBlur, value, name },
+                fieldState: { error },
+            }) => (
+                <RadioSelect
+                    required={field.required}
+                    id={field.id}
+                    label={field.label}
+                    disabled={isLoading}
+                    value={value}
+                    fullWidth
+                    options={options}
+                    {...{
+                        onBlur,
+                        onChange,
+                        name,
+                    }}
+                />
+            )}
+        />
+    );
+}

--- a/src/lib/shared/components/ui/FormElements/FormRenderer/ui/TextAreaField.tsx
+++ b/src/lib/shared/components/ui/FormElements/FormRenderer/ui/TextAreaField.tsx
@@ -2,8 +2,6 @@ import {
     UseFormReturn,
     FieldValues,
     Controller,
-    PathValue,
-    Path,
 } from 'react-hook-form';
 import { Textarea } from '@/lib/shared/components/ui';
 import { TextAreaInput } from '../types';

--- a/src/lib/shared/components/ui/FormElements/FormRenderer/ui/ToggleField.tsx
+++ b/src/lib/shared/components/ui/FormElements/FormRenderer/ui/ToggleField.tsx
@@ -16,7 +16,6 @@ export function ToggleField<T extends FieldValues>({
             name={field.statePath}
             render={({
                 field: { onChange, onBlur, value, name },
-                fieldState: { error },
             }) => (
                 <Toggle
                     type={field.toggleType ?? 'checkbox'}

--- a/src/lib/shared/components/ui/FormElements/FormRenderer/ui/index.ts
+++ b/src/lib/shared/components/ui/FormElements/FormRenderer/ui/index.ts
@@ -5,3 +5,4 @@ export * from './SelectField';
 export * from './TelephoneField';
 export * from './DatePickerField';
 export * from './ToggleField';
+export * from './RadioSelectField';


### PR DESCRIPTION
# Description
Add `RadioSelectField` to form renderer

# Closes issue(s)
[Add Radio Select FormRenderer field](https://www.notion.so/Add-Radio-Select-FormRenderer-field-a838ff8a1c2b4feca28e2fbf861ad8db?pvs=4)

# How to test / repro
Run `yarn storybook`
View `Ui/FormElements/FormRenderer`

# Screenshots
<img width="493" alt="image" src="https://github.com/Therify/directory/assets/48607329/defa095e-a72f-497a-ace9-3349375ea7fb">

# Changes include

-   [ ] Bugfix (non-breaking change that solves an issue)
-   [x] New feature (non-breaking change that adds functionality)
-   [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Checklist

-   [x] I have tested this code
-   [ ] I have updated the Readme

# Other comments
