### PR TITLE
chore: add v3 feature flag + naming improvements

### DIFF
--- a/src/lib/shared/hooks/use-feature-flags/useFeatureFlags.ts
+++ b/src/lib/shared/hooks/use-feature-flags/useFeatureFlags.ts
@@ -24,6 +24,6 @@ export const useFeatureFlags = (user: TherifyUser.TherifyUser | undefined) => {
     }, [ldClient, user]);
 
     return {
-        flags: FeatureFlags.validate(flags),
+        flags: FeatureFlags.validateClientFlags(flags),
     };
 };

--- a/src/lib/shared/types/feature-flags/featureFlags.spec.ts
+++ b/src/lib/shared/types/feature-flags/featureFlags.spec.ts
@@ -1,45 +1,50 @@
-import { validate, defaultFlags } from './featureFlags';
+import { validateClientFlags, defaultClientFlags } from './featureFlags';
 
 describe('FeatureFlags validation', () => {
     it('should return default flags when flags are undefined', () => {
-        expect(validate(undefined)).toEqual(defaultFlags);
+        expect(validateClientFlags(undefined)).toEqual(defaultClientFlags);
     });
 
     it('should return default flags when flags are null', () => {
-        expect(validate(null)).toEqual(defaultFlags);
+        expect(validateClientFlags(null)).toEqual(defaultClientFlags);
     });
 
     it('should return default flags when flags are not an object', () => {
-        expect(validate('not an object')).toEqual(defaultFlags);
+        expect(validateClientFlags('not an object')).toEqual(
+            defaultClientFlags
+        );
     });
 
     it('should return default flags when flags are an empty object', () => {
-        expect(validate({})).toEqual(defaultFlags);
+        expect(validateClientFlags({})).toEqual(defaultClientFlags);
     });
 
     it('should return flags when flags are valid', () => {
         const flags = {
-            ...defaultFlags,
+            ...defaultClientFlags,
             didFlagsLoad: true,
         };
-        expect(validate(flags)).toEqual(flags);
+        expect(validateClientFlags(flags)).toEqual(flags);
     });
 
     it('should return default flag value when individual key is invalid', () => {
         const flags = {
-            ...defaultFlags,
+            ...defaultClientFlags,
             didFlagsLoad: 'not a boolean',
         };
-        expect(validate(flags)).toEqual(defaultFlags);
+        expect(validateClientFlags(flags)).toEqual(defaultClientFlags);
     });
 
     it('should merge partially valid flags with default flags', () => {
         const flags = {
-            ...defaultFlags,
+            ...defaultClientFlags,
             didFlagsLoad: true,
         };
         expect(
-            validate({ ...flags, invalidFlag: "this shouldn't be here" })
+            validateClientFlags({
+                ...flags,
+                invalidFlag: "this shouldn't be here",
+            })
         ).toEqual(flags);
     });
 });

--- a/src/lib/shared/types/feature-flags/featureFlags.ts
+++ b/src/lib/shared/types/feature-flags/featureFlags.ts
@@ -8,6 +8,7 @@ export const SERVER_FLAGS = {
     BANNER_CONTENT: 'banner-content',
     IS_DTC_REGISTRATION_OPEN: 'is-dtc-registration-open',
     IS_COACH_SCHEDULING_ENABLED: 'is-coach-scheduling-enabled',
+    IS_V3_DIRECTORY_ENABLED: 'is-v3-directory-enabled',
 } as const;
 
 export const CLIENT_FLAGS = {
@@ -18,6 +19,7 @@ export const CLIENT_FLAGS = {
     BANNER_CONTENT: 'bannerContent',
     IS_DTC_REGISTRATION_OPEN: 'isDtcRegistrationOpen',
     IS_COACH_SCHEDULING_ENABLED: 'isCoachSchedulingEnabled',
+    IS_V3_DIRECTORY_ENABLED: 'is-v3-directory-enabled',
 } as const;
 
 export const schema = z.object({
@@ -33,6 +35,7 @@ export const schema = z.object({
     }),
     [CLIENT_FLAGS.IS_DTC_REGISTRATION_OPEN]: z.boolean(),
     [CLIENT_FLAGS.IS_COACH_SCHEDULING_ENABLED]: z.boolean(),
+    [CLIENT_FLAGS.IS_V3_DIRECTORY_ENABLED]: z.boolean(),
 });
 
 export type Type = z.infer<typeof schema>;
@@ -48,6 +51,7 @@ export const defaultFlags: FeatureFlags = {
     [CLIENT_FLAGS.BANNER_CONTENT]: {},
     [CLIENT_FLAGS.IS_DTC_REGISTRATION_OPEN]: false,
     [CLIENT_FLAGS.IS_COACH_SCHEDULING_ENABLED]: false,
+    [CLIENT_FLAGS.IS_V3_DIRECTORY_ENABLED]: false,
 };
 
 export const isValid = (flags: unknown): boolean => {

--- a/src/lib/shared/types/feature-flags/featureFlags.ts
+++ b/src/lib/shared/types/feature-flags/featureFlags.ts
@@ -82,7 +82,7 @@ const buildSafeClientFeatureFlags = (flags: unknown): ClientFeatureFlags => {
     );
 };
 
-export const validate = (flags: unknown): ClientFeatureFlags => {
+export const validateClientFlags = (flags: unknown): ClientFeatureFlags => {
     try {
         return clientFlagsSchema.parse(flags);
     } catch (error) {

--- a/src/lib/shared/types/feature-flags/featureFlags.ts
+++ b/src/lib/shared/types/feature-flags/featureFlags.ts
@@ -38,8 +38,8 @@ export const clientFlagsSchema = z.object({
     [CLIENT_FLAGS.IS_V3_DIRECTORY_ENABLED]: z.boolean(),
 });
 
-export type Type = z.infer<typeof clientFlagsSchema>;
-type ClientFeatureFlags = Type;
+export type ClientFlagsType = z.infer<typeof clientFlagsSchema>;
+type ClientFeatureFlags = ClientFlagsType;
 
 export const defaultClientFlags: ClientFeatureFlags = {
     // `didFlagsLoad` should always be true from LaunchDarkly,

--- a/src/lib/shared/types/feature-flags/featureFlags.ts
+++ b/src/lib/shared/types/feature-flags/featureFlags.ts
@@ -59,7 +59,7 @@ export const isValidClientFlags = (flags: unknown): boolean => {
     return success;
 };
 
-const isValidFlag = (key: string, value: unknown): boolean => {
+const isValidClientFlag = (key: string, value: unknown): boolean => {
     if (key in defaultClientFlags === false) return false;
     const { success } = clientFlagsSchema.safeParse({
         ...defaultClientFlags,
@@ -73,7 +73,7 @@ const buildSafeClientFeatureFlags = (flags: unknown): ClientFeatureFlags => {
 
     return Object.entries(flags).reduce<ClientFeatureFlags>(
         (safeFlags, [key, value]) => {
-            if (isValidFlag(key, value)) {
+            if (isValidClientFlag(key, value)) {
                 return { ...safeFlags, [key]: value };
             }
             return safeFlags;

--- a/src/lib/shared/types/feature-flags/featureFlags.ts
+++ b/src/lib/shared/types/feature-flags/featureFlags.ts
@@ -19,7 +19,7 @@ export const CLIENT_FLAGS = {
     BANNER_CONTENT: 'bannerContent',
     IS_DTC_REGISTRATION_OPEN: 'isDtcRegistrationOpen',
     IS_COACH_SCHEDULING_ENABLED: 'isCoachSchedulingEnabled',
-    IS_V3_DIRECTORY_ENABLED: 'is-v3-directory-enabled',
+    IS_V3_DIRECTORY_ENABLED: 'isV3DirectoryEnabled',
 } as const;
 
 export const schema = z.object({


### PR DESCRIPTION
# Description
Adds feature flag to toggle on v3 experience. Flag added as `is-v3-directory-enabled`.

Additionally, renames some schema and validation functions to better communicate they only apply to client-side flag validation. This is an oversight from when server side flags were introduced. The naming was a little confusing.

#### Affected exported `FeatureFlags` properties/methods: 
 - ~~defaultFlags~~ ->  defaultClientFlags
 - ~~schema~~ -> clientFlagsSchema
 - ~~Type~~ -> ClientFlagsType
 - ~~isValid~~ -> isValidClientFlags
 - ~~validate~~ -> validateClientFlags

# Closes issue(s)
N/A

# How to test / repro
Check feature flags loaded from LaunchDarkly

# Screenshots
![image](https://github.com/Therify/directory/assets/25045075/aeab5c9a-cfaa-4ca8-aa62-11319d01fd37)

# Changes include

-   [ ] Bugfix (non-breaking change that solves an issue)
-   [ ] New feature (non-breaking change that adds functionality)
-   [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Checklist

-   [ ] I have tested this code
-   [ ] I have updated the Readme

# Other comments
