### PR TITLE
refactor: care jumbotron state priority

### DIFF
--- a/src/lib/modules/care/components/CareJumbotron/CareJumbotron.spec.tsx
+++ b/src/lib/modules/care/components/CareJumbotron/CareJumbotron.spec.tsx
@@ -1,5 +1,5 @@
-import { renderWithTheme } from '../../../../shared/components/fixtures/renderWithTheme';
-import { CareJumbotron, CareJumbotronProps } from './CareJumbotron';
+import { renderWithTheme } from '@/lib/shared/components/fixtures/renderWithTheme';
+import { CareJumbotron } from './CareJumbotron';
 
 const routerMock = { pathname: '/test', push: jest.fn() };
 jest.mock('next/router', () => {
@@ -9,82 +9,96 @@ jest.mock('next/router', () => {
 });
 
 describe('CareJumbotron', () => {
-    it('should render', () => {
-        const { getByText } = renderWithTheme(
-        <CareJumbotron
-            isAwaitingRecommendations={false}
-            hasRecommendationsForReview={false}
-            hasCareTeam={false}
-        />
-        );
-        const header = getByText('Get matched with your first Provider!');
-        expect(header).toBeVisible();
+    describe('hasRecommendationsForReview', () => {
+        it('should render message when there are recommendations for review', () => {
+            const { getByText } = renderWithTheme(
+                <CareJumbotron
+                    hasRecommendationsForReview={true}
+                    isAwaitingRecommendations={false}
+                    hasCareTeam={false}
+                />
+            );
+            const header = getByText("You've got Provider Recommendations!");
+            expect(header).toBeVisible();
+        });
+        it('should override all other messages', () => {
+            const { getByText } = renderWithTheme(
+                <CareJumbotron
+                    hasRecommendationsForReview={true}
+                    isAwaitingRecommendations={true}
+                    hasCareTeam={true}
+                />
+            );
+            const header = getByText("You've got Provider Recommendations!");
+            expect(header).toBeVisible();
+        });
     });
-    it('should render \'has provider recommendations\' message when there are recommendations for review', () => {
-        const { getByText } = renderWithTheme(
-        <CareJumbotron
-            isAwaitingRecommendations={false}
-            hasRecommendationsForReview={true}
-            hasCareTeam={false}
-        />
-        );
-        const header = getByText('You\'ve got Provider Recommendations!');
-        expect(header).toBeVisible();
+    describe('isAwaitingRecommendations', () => {
+        it('should render message when awaiting recommendations', () => {
+            const { getByText } = renderWithTheme(
+                <CareJumbotron
+                    isAwaitingRecommendations={true}
+                    hasRecommendationsForReview={false}
+                    hasCareTeam={false}
+                />
+            );
+            const header = getByText(
+                "We're looking for providers to recommend!"
+            );
+            expect(header).toBeVisible();
+        });
+        it("should render '{name} is looking for providers' message when awaiting recommendations from a specific care navigator", () => {
+            const { getByText } = renderWithTheme(
+                <CareJumbotron
+                    isAwaitingRecommendations={true}
+                    hasRecommendationsForReview={false}
+                    hasCareTeam={false}
+                    careNavigatorName="Dr. Test"
+                />
+            );
+            const header = getByText(
+                'Dr. Test is looking for providers to recommend!'
+            );
+            expect(header).toBeVisible();
+        });
+        it("should override 'build care team' message", () => {
+            const { getByText } = renderWithTheme(
+                <CareJumbotron
+                    isAwaitingRecommendations={true}
+                    hasRecommendationsForReview={false}
+                    hasCareTeam={true}
+                />
+            );
+            const header = getByText(
+                "We're looking for providers to recommend!"
+            );
+            expect(header).toBeVisible();
+        });
     });
-    it('should render \'has provider recommendations\' message when there are recommendations for review, overriding other props', () => {
-        const { getByText } = renderWithTheme(
-        <CareJumbotron
-            isAwaitingRecommendations={true}
-            hasRecommendationsForReview={true}
-            hasCareTeam={true}
-        />
-        );
-        const header = getByText('You\'ve got Provider Recommendations!');
-        expect(header).toBeVisible();
+    describe('hasCareTeam', () => {
+        it("should render message when 'hasCareTeam' prop is true", () => {
+            const { getByText } = renderWithTheme(
+                <CareJumbotron
+                    isAwaitingRecommendations={false}
+                    hasRecommendationsForReview={false}
+                    hasCareTeam={true}
+                />
+            );
+            const header = getByText('Build your Care Team!');
+            expect(header).toBeVisible();
+        });
     });
-    it('should render \'build care team\' message when \'hasCareTeam\' prop is true', () => {
-        const { getByText } = renderWithTheme(
-        <CareJumbotron
-            isAwaitingRecommendations={false}
-            hasRecommendationsForReview={false}
-            hasCareTeam={true}
-        />
-        );
-        const header = getByText('Build your Care Team!');
-        expect(header).toBeVisible();
-    });
-    it('should render \'build care team\' message when \'hasCareTeam\' prop is true, overriding \'awaiting recommendations\' prop', () => {
-        const { getByText } = renderWithTheme(
-        <CareJumbotron
-            isAwaitingRecommendations={true}
-            hasRecommendationsForReview={false}
-            hasCareTeam={true}
-        />
-        );
-        const header = getByText('Build your Care Team!');
-        expect(header).toBeVisible();
-    });
-    it('should render \'looking for providers\' message when awaiting recommendations', () => {
-        const { getByText } = renderWithTheme(
-        <CareJumbotron
-            isAwaitingRecommendations={true}
-            hasRecommendationsForReview={false}
-            hasCareTeam={false}
-        />
-        );
-        const header = getByText('We\'re looking for providers to recommend!');
-        expect(header).toBeVisible();
-    });
-    it('should render \'{name} is looking for providers\' message when awaiting recommendations from a specific care navigator', () => {
-        const { getByText } = renderWithTheme(
-        <CareJumbotron
-            isAwaitingRecommendations={true}
-            hasRecommendationsForReview={false}
-            hasCareTeam={false}
-            careNavigatorName='Dr. Test'
-        />
-        );
-        const header = getByText('Dr. Test is looking for providers to recommend!');
-        expect(header).toBeVisible();
+    describe('default message', () => {
+        it("should default to 'Get Matched' message", () => {
+            const { getByText } = renderWithTheme(
+                <CareJumbotron
+                    isAwaitingRecommendations={false}
+                    hasRecommendationsForReview={false}
+                    hasCareTeam={false}
+                />
+            );
+            const header = getByText('Get matched with your first Provider!');
+            expect(header).toBeVisible();
+        });
     });
 });

--- a/src/lib/modules/care/components/CareJumbotron/CareJumbotron.spec.tsx
+++ b/src/lib/modules/care/components/CareJumbotron/CareJumbotron.spec.tsx
@@ -20,28 +20,6 @@ describe('CareJumbotron', () => {
         const header = getByText('Get matched with your first Provider!');
         expect(header).toBeVisible();
     });
-    it('should render \'build care team\' message when \'hasCareTeam\' prop is true', () => {
-        const { getByText } = renderWithTheme(
-        <CareJumbotron
-            isAwaitingRecommendations={false}
-            hasRecommendationsForReview={false}
-            hasCareTeam={true}
-        />
-        );
-        const header = getByText('Build your Care Team!');
-        expect(header).toBeVisible();
-    });
-    it('should render \'build care team\' message when \'hasCareTeam\' prop is true, overriding other props', () => {
-        const { getByText } = renderWithTheme(
-        <CareJumbotron
-            isAwaitingRecommendations={true}
-            hasRecommendationsForReview={true}
-            hasCareTeam={true}
-        />
-        );
-        const header = getByText('Build your Care Team!');
-        expect(header).toBeVisible();
-    });
     it('should render \'has provider recommendations\' message when there are recommendations for review', () => {
         const { getByText } = renderWithTheme(
         <CareJumbotron
@@ -53,15 +31,37 @@ describe('CareJumbotron', () => {
         const header = getByText('You\'ve got Provider Recommendations!');
         expect(header).toBeVisible();
     });
-    it('should render \'has provider recommendations\' message when there are recommendations for review, overriding \'awaitingRecommendations\' prop', () => {
+    it('should render \'has provider recommendations\' message when there are recommendations for review, overriding other props', () => {
         const { getByText } = renderWithTheme(
         <CareJumbotron
             isAwaitingRecommendations={true}
             hasRecommendationsForReview={true}
-            hasCareTeam={false}
+            hasCareTeam={true}
         />
         );
         const header = getByText('You\'ve got Provider Recommendations!');
+        expect(header).toBeVisible();
+    });
+    it('should render \'build care team\' message when \'hasCareTeam\' prop is true', () => {
+        const { getByText } = renderWithTheme(
+        <CareJumbotron
+            isAwaitingRecommendations={false}
+            hasRecommendationsForReview={false}
+            hasCareTeam={true}
+        />
+        );
+        const header = getByText('Build your Care Team!');
+        expect(header).toBeVisible();
+    });
+    it('should render \'build care team\' message when \'hasCareTeam\' prop is true, overriding \'awaiting recommendations\' prop', () => {
+        const { getByText } = renderWithTheme(
+        <CareJumbotron
+            isAwaitingRecommendations={true}
+            hasRecommendationsForReview={false}
+            hasCareTeam={true}
+        />
+        );
+        const header = getByText('Build your Care Team!');
         expect(header).toBeVisible();
     });
     it('should render \'looking for providers\' message when awaiting recommendations', () => {

--- a/src/lib/modules/care/components/CareJumbotron/CareJumbotron.tsx
+++ b/src/lib/modules/care/components/CareJumbotron/CareJumbotron.tsx
@@ -71,9 +71,9 @@ export function CareJumbotron({
         },
     };
 
-    if (hasCareTeam) return <Jumbotron {...hasCareTeamProps} />;
     if (hasRecommendationsForReview)
         return <Jumbotron {...hasRecommendationsForReviewProps} />;
+    if (hasCareTeam) return <Jumbotron {...hasCareTeamProps} />;
     if (isAwaitingRecommendations)
         return <Jumbotron {...isAwaitingRecommendationsProps} />;
     return <Jumbotron {...defaultProps} />;

--- a/src/lib/modules/care/components/CareJumbotron/CareJumbotron.tsx
+++ b/src/lib/modules/care/components/CareJumbotron/CareJumbotron.tsx
@@ -73,8 +73,8 @@ export function CareJumbotron({
 
     if (hasRecommendationsForReview)
         return <Jumbotron {...hasRecommendationsForReviewProps} />;
-    if (hasCareTeam) return <Jumbotron {...hasCareTeamProps} />;
     if (isAwaitingRecommendations)
         return <Jumbotron {...isAwaitingRecommendationsProps} />;
+    if (hasCareTeam) return <Jumbotron {...hasCareTeamProps} />;
     return <Jumbotron {...defaultProps} />;
 }


### PR DESCRIPTION
# Description
Update the priority of different states passed to the `CareJumbotron`. The gist of it is that when the `hasRecommendationsForReview` prop is true, the `CareJumbotron` will display the celebration background/style, overriding any other props passed in.

# Closes issue(s)
None, just a small refactor. But related to [Care-Screen-Jumbotron](https://www.notion.so/Care-Screen-Jumbotron-4df6d765a5244e23add5f7ce022c0464?pvs=4)

# How to test / repro
Run `yarn test` and `yarn storybook`

# Screenshots
<img width="1291" alt="image" src="https://github.com/Therify/directory/assets/48607329/571d78e2-5445-44e5-a969-6b6bf233dde2">

# Changes include

-   [ ] Bugfix (non-breaking change that solves an issue)
-   [ ] New feature (non-breaking change that adds functionality)
-   [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Checklist

-   [x] I have tested this code
-   [ ] I have updated the Readme

# Other comments
