### PR TITLE
feat: add v3 settings page

### DIFF
--- a/src/lib/modules/accounts/components/settings/SettingsPage/SettingsPage.spec.tsx
+++ b/src/lib/modules/accounts/components/settings/SettingsPage/SettingsPage.spec.tsx
@@ -1,0 +1,59 @@
+import { renderWithTheme } from '@/lib/shared/components/fixtures';
+import { TherifyUser } from '@/lib/shared/types';
+import { SettingsPage, SETTINGS_TAB_IDS, TEST_IDS } from './SettingsPage';
+
+const mockUser = {} as TherifyUser.TherifyUser;
+describe('SettingsPage', () => {
+    it('should render the Account tab', () => {
+        const { getByTestId } = renderWithTheme(
+            <SettingsPage
+                user={mockUser}
+                currentTab={SETTINGS_TAB_IDS.ACCOUNT}
+                onTabChange={jest.fn()}
+            />
+        );
+        expect(getByTestId(TEST_IDS.ACCOUNT_TAB)).toBeVisible();
+    });
+    it('should render the Care Details tab', () => {
+        const { getByTestId } = renderWithTheme(
+            <SettingsPage
+                user={mockUser}
+                currentTab={SETTINGS_TAB_IDS.CARE_DETAILS}
+                onTabChange={jest.fn()}
+            />
+        );
+        expect(getByTestId(TEST_IDS.CARE_DETAILS_TAB)).toBeVisible();
+    });
+    it('should render the Billing and Payments tab', () => {
+        const { getByTestId } = renderWithTheme(
+            <SettingsPage
+                user={mockUser}
+                currentTab={SETTINGS_TAB_IDS.BILLING}
+                onTabChange={jest.fn()}
+            />
+        );
+        expect(getByTestId(TEST_IDS.BILLING_TAB)).toBeVisible();
+    });
+    it('should render the Email Notifications tab', () => {
+        const { getByTestId } = renderWithTheme(
+            <SettingsPage
+                user={mockUser}
+                currentTab={SETTINGS_TAB_IDS.NOTIFICATIONS}
+                onTabChange={jest.fn()}
+            />
+        );
+        expect(getByTestId(TEST_IDS.NOTIFICATIONS_TAB)).toBeVisible();
+    });
+    it('calls onTabChange when a tab is clicked', () => {
+        const onTabChange = jest.fn();
+        const { getByText } = renderWithTheme(
+            <SettingsPage
+                user={mockUser}
+                currentTab={SETTINGS_TAB_IDS.NOTIFICATIONS}
+                onTabChange={onTabChange}
+            />
+        );
+        getByText('Care Details').click();
+        expect(onTabChange).toHaveBeenCalledWith(SETTINGS_TAB_IDS.CARE_DETAILS);
+    });
+});

--- a/src/lib/modules/accounts/components/settings/SettingsPage/SettingsPage.stories.tsx
+++ b/src/lib/modules/accounts/components/settings/SettingsPage/SettingsPage.stories.tsx
@@ -1,0 +1,39 @@
+import { TherifyUser } from '@/lib/shared/types';
+import { Role } from '@prisma/client';
+import { Meta, StoryFn } from '@storybook/react';
+import { useState } from 'react';
+import {
+    SettingsPage as Component,
+    SettingsTabId,
+    SETTINGS_TAB_IDS,
+} from './SettingsPage';
+
+const meta: Meta<typeof Component> = {
+    title: 'UI/SettingsPage',
+    component: Component,
+};
+
+export default meta;
+
+const user = {
+    userId: '123',
+    emailAddress: 'test@therify.co',
+    givenName: 'Test',
+    surname: 'User',
+    roles: [Role.member],
+    hasChatEnabled: false,
+    createdAt: new Date().toISOString(),
+} as TherifyUser.TherifyUser;
+
+export const Default: StoryFn<typeof Component> = () => {
+    const [currentTab, setCurrentTab] = useState<SettingsTabId>(
+        SETTINGS_TAB_IDS.ACCOUNT
+    );
+    return (
+        <Component
+            user={user}
+            currentTab={currentTab}
+            onTabChange={setCurrentTab}
+        />
+    );
+};

--- a/src/lib/modules/accounts/components/settings/SettingsPage/SettingsPage.tsx
+++ b/src/lib/modules/accounts/components/settings/SettingsPage/SettingsPage.tsx
@@ -1,0 +1,76 @@
+import {
+    H3,
+    PageContentContainer,
+    Tabs,
+    TabOption,
+} from '@/lib/shared/components/ui';
+import { TherifyUser } from '@/lib/shared/types';
+import { styled } from '@mui/material/styles';
+
+export const SETTINGS_TAB_IDS = {
+    ACCOUNT: 'account',
+    CARE_DETAILS: 'care-details',
+    BILLING: 'billing',
+    NOTIFICATIONS: 'notifications',
+} as const;
+export type SettingsTabId =
+    (typeof SETTINGS_TAB_IDS)[keyof typeof SETTINGS_TAB_IDS];
+interface SettingsPageProps {
+    user: TherifyUser.TherifyUser;
+    currentTab: SettingsTabId;
+    onTabChange: (tabId: SettingsTabId) => void;
+}
+const tabs: TabOption[] = [
+    { id: SETTINGS_TAB_IDS.ACCOUNT, tabLabel: 'Account' },
+    { id: SETTINGS_TAB_IDS.CARE_DETAILS, tabLabel: 'Care Details' },
+    { id: SETTINGS_TAB_IDS.BILLING, tabLabel: 'Billing & Payments' },
+    { id: SETTINGS_TAB_IDS.NOTIFICATIONS, tabLabel: 'Email Notifications' },
+];
+
+export const TEST_IDS = {
+    ACCOUNT_TAB: 'account',
+    CARE_DETAILS_TAB: 'care-details',
+    BILLING_TAB: 'billing',
+    NOTIFICATIONS_TAB: 'notifications',
+} as const;
+export const SettingsPage = ({
+    user,
+    currentTab,
+    onTabChange,
+}: SettingsPageProps) => {
+    return (
+        <PageContentContainer padding={8} paddingTop={10} maxWidth={1448}>
+            <H3 marginBottom={10}>Settings</H3>
+            <Tabs
+                v3
+                selectedTab={currentTab}
+                onTabChange={(tabId) => onTabChange(tabId as SettingsTabId)}
+                ariaLabel="Settings tabs"
+                withBottomBorder
+                tabs={tabs}
+            />
+            {currentTab === SETTINGS_TAB_IDS.ACCOUNT && (
+                <TabContent data-testid={TEST_IDS.ACCOUNT_TAB}>
+                    {/* TODO: Add Account view */}
+                </TabContent>
+            )}
+            {currentTab === SETTINGS_TAB_IDS.CARE_DETAILS && (
+                <TabContent data-testid={TEST_IDS.CARE_DETAILS_TAB}>
+                    {/* TODO: Add Care Details view */}
+                </TabContent>
+            )}
+            {currentTab === SETTINGS_TAB_IDS.BILLING && (
+                <TabContent data-testid={TEST_IDS.BILLING_TAB}>
+                    {/* TODO: Add Billing & Payments view */}
+                </TabContent>
+            )}
+            {currentTab === SETTINGS_TAB_IDS.NOTIFICATIONS && (
+                <TabContent data-testid={TEST_IDS.NOTIFICATIONS_TAB}>
+                    {/* TODO: Add Email Notifications view */}
+                </TabContent>
+            )}
+        </PageContentContainer>
+    );
+};
+
+const TabContent = styled('div')();

--- a/src/lib/modules/accounts/components/settings/SettingsPage/index.ts
+++ b/src/lib/modules/accounts/components/settings/SettingsPage/index.ts
@@ -1,0 +1,1 @@
+export * from './SettingsPage';

--- a/src/lib/modules/accounts/components/settings/SettingsPage/index.ts
+++ b/src/lib/modules/accounts/components/settings/SettingsPage/index.ts
@@ -1,1 +1,2 @@
 export * from './SettingsPage';
+export * as SettingsPageUtils from './utils';

--- a/src/lib/modules/accounts/components/settings/SettingsPage/utils/getSettingsTabView.spec.ts
+++ b/src/lib/modules/accounts/components/settings/SettingsPage/utils/getSettingsTabView.spec.ts
@@ -1,0 +1,25 @@
+import { getSettingsTabView } from './getSettingsTabView';
+import { SETTINGS_TAB_IDS } from '../SettingsPage';
+
+describe('getSettingsTabView', () => {
+    it('returns the view if it is a valid view', () => {
+        expect(getSettingsTabView(SETTINGS_TAB_IDS.CARE_DETAILS)).toEqual(
+            SETTINGS_TAB_IDS.CARE_DETAILS
+        );
+        expect(getSettingsTabView(SETTINGS_TAB_IDS.BILLING)).toEqual(
+            SETTINGS_TAB_IDS.BILLING
+        );
+        expect(getSettingsTabView(SETTINGS_TAB_IDS.NOTIFICATIONS)).toEqual(
+            SETTINGS_TAB_IDS.NOTIFICATIONS
+        );
+        expect(getSettingsTabView(SETTINGS_TAB_IDS.ACCOUNT)).toEqual(
+            SETTINGS_TAB_IDS.ACCOUNT
+        );
+    });
+
+    it('returns the default view if the view is not valid', () => {
+        expect(getSettingsTabView('not-a-valid-view')).toEqual(
+            SETTINGS_TAB_IDS.ACCOUNT
+        );
+    });
+});

--- a/src/lib/modules/accounts/components/settings/SettingsPage/utils/getSettingsTabView.ts
+++ b/src/lib/modules/accounts/components/settings/SettingsPage/utils/getSettingsTabView.ts
@@ -1,0 +1,15 @@
+import { SETTINGS_TAB_IDS } from '../SettingsPage';
+
+export const getSettingsTabView = (view: string | undefined) => {
+    switch (view) {
+        case SETTINGS_TAB_IDS.CARE_DETAILS:
+            return SETTINGS_TAB_IDS.CARE_DETAILS;
+        case SETTINGS_TAB_IDS.BILLING:
+            return SETTINGS_TAB_IDS.BILLING;
+        case SETTINGS_TAB_IDS.NOTIFICATIONS:
+            return SETTINGS_TAB_IDS.NOTIFICATIONS;
+        case SETTINGS_TAB_IDS.ACCOUNT:
+        default:
+            return SETTINGS_TAB_IDS.ACCOUNT;
+    }
+};

--- a/src/lib/modules/accounts/components/settings/SettingsPage/utils/index.ts
+++ b/src/lib/modules/accounts/components/settings/SettingsPage/utils/index.ts
@@ -1,0 +1,1 @@
+export * from './getSettingsTabView';

--- a/src/lib/modules/accounts/components/settings/index.ts
+++ b/src/lib/modules/accounts/components/settings/index.ts
@@ -1,1 +1,5 @@
-export { SettingsPage, SETTINGS_TAB_IDS } from './SettingsPage';
+export {
+    SettingsPage,
+    SETTINGS_TAB_IDS,
+    SettingsPageUtils,
+} from './SettingsPage';

--- a/src/lib/modules/accounts/components/settings/index.ts
+++ b/src/lib/modules/accounts/components/settings/index.ts
@@ -1,0 +1,1 @@
+export { SettingsPage, SETTINGS_TAB_IDS } from './SettingsPage';

--- a/src/lib/shared/components/ui/Tabs/index.tsx
+++ b/src/lib/shared/components/ui/Tabs/index.tsx
@@ -15,6 +15,7 @@ interface TabProps {
     ariaLabel?: string;
     tabs: TabOption[];
     withBottomBorder?: boolean;
+    v3?: boolean;
 }
 
 export const TEST_IDS = {
@@ -27,6 +28,7 @@ export const Tabs = ({
     ariaLabel,
     tabs,
     withBottomBorder,
+    v3,
 }: TabProps) => {
     const theme = useTheme();
     const handleChange = (_: React.SyntheticEvent, newTabId: string) => {
@@ -41,6 +43,13 @@ export const Tabs = ({
             // TODO: Handle maxwidths for scrolling once breakpoints are implemented
             variant="scrollable"
             scrollButtons="auto"
+            sx={{
+                ...(v3 && {
+                    '& .MuiTabs-indicator': {
+                        backgroundColor: theme.palette.text.primary,
+                    },
+                }),
+            }}
         >
             {tabs.map(({ id, tabLabel, disabled, icon }) => (
                 <MuiTab
@@ -55,10 +64,16 @@ export const Tabs = ({
                         ) : undefined
                     }
                     iconPosition="end"
-                    style={{
+                    sx={{
                         padding: theme.spacing(4, 6),
                         lineHeight: 1,
                         textTransform: 'none',
+                        ...(v3 && {
+                            color: theme.palette.grey[500],
+                            '&.Mui-selected': {
+                                color: theme.palette.text.primary,
+                            },
+                        }),
                     }}
                 />
             ))}

--- a/src/pages/members/account/settings/[view].tsx
+++ b/src/pages/members/account/settings/[view].tsx
@@ -6,7 +6,7 @@ import { RBAC } from '@/lib/shared/utils';
 import { withPageAuthRequired } from '@auth0/nextjs-auth0';
 import {
     SettingsPage,
-    SETTINGS_TAB_IDS,
+    SettingsPageUtils,
 } from '@/lib/modules/accounts/components/settings';
 import { useFeatureFlags } from '@/lib/shared/hooks';
 import { membersService } from '@/lib/modules/members/service';
@@ -23,7 +23,9 @@ export default function ClientDetailsPage({
 }: MemberTherifyUserPageProps) {
     const { flags } = useFeatureFlags(user);
     const router = useRouter();
-
+    const view = Array.isArray(router.query.view)
+        ? router.query.view[0]
+        : router.query.view;
     useEffect(() => {
         if (flags.didFlagsLoad && !flags.isV3DirectoryEnabled) {
             router.push(URL_PATHS.PROVIDERS.COACH.CLIENTS);
@@ -38,7 +40,7 @@ export default function ClientDetailsPage({
         >
             <SettingsPage
                 user={user}
-                currentTab={getSettingsView(router.query.view)}
+                currentTab={SettingsPageUtils.getSettingsTabView(view)}
                 onTabChange={(tabId) =>
                     router.push(
                         `${URL_PATHS.MEMBERS.ACCOUNT.SETTINGS.ROOT}/${tabId}`
@@ -48,18 +50,3 @@ export default function ClientDetailsPage({
         </MemberNavigationPage>
     );
 }
-
-const getSettingsView = (view: string | string[] | undefined) => {
-    const currentView = Array.isArray(view) ? view[0] : view;
-    switch (currentView) {
-        case SETTINGS_TAB_IDS.CARE_DETAILS:
-            return SETTINGS_TAB_IDS.CARE_DETAILS;
-        case SETTINGS_TAB_IDS.BILLING:
-            return SETTINGS_TAB_IDS.BILLING;
-        case SETTINGS_TAB_IDS.NOTIFICATIONS:
-            return SETTINGS_TAB_IDS.NOTIFICATIONS;
-        case SETTINGS_TAB_IDS.ACCOUNT:
-        default:
-            return SETTINGS_TAB_IDS.ACCOUNT;
-    }
-};

--- a/src/pages/members/account/settings/[view].tsx
+++ b/src/pages/members/account/settings/[view].tsx
@@ -1,0 +1,65 @@
+import { useEffect } from 'react';
+import { useRouter } from 'next/router';
+import { MemberNavigationPage } from '@/lib/shared/components/features/pages';
+import { URL_PATHS } from '@/lib/sitemap';
+import { RBAC } from '@/lib/shared/utils';
+import { withPageAuthRequired } from '@auth0/nextjs-auth0';
+import {
+    SettingsPage,
+    SETTINGS_TAB_IDS,
+} from '@/lib/modules/accounts/components/settings';
+import { useFeatureFlags } from '@/lib/shared/hooks';
+import { membersService } from '@/lib/modules/members/service';
+import { MemberTherifyUserPageProps } from '@/lib/modules/members/service/get-therify-user-props';
+
+export const getServerSideProps = RBAC.requireMemberAuth(
+    withPageAuthRequired({
+        getServerSideProps: membersService.getTherifyUserPageProps,
+    })
+);
+
+export default function ClientDetailsPage({
+    user,
+}: MemberTherifyUserPageProps) {
+    const { flags } = useFeatureFlags(user);
+    const router = useRouter();
+
+    useEffect(() => {
+        if (flags.didFlagsLoad && !flags.isV3DirectoryEnabled) {
+            router.push(URL_PATHS.PROVIDERS.COACH.CLIENTS);
+        }
+    }, [flags.isV3DirectoryEnabled, flags.didFlagsLoad, router]);
+
+    if (!user || !flags.isV3DirectoryEnabled) return null;
+    return (
+        <MemberNavigationPage
+            currentPath={URL_PATHS.MEMBERS.ACCOUNT.SETTINGS.ROOT}
+            user={user}
+        >
+            <SettingsPage
+                user={user}
+                currentTab={getSettingsView(router.query.view)}
+                onTabChange={(tabId) =>
+                    router.push(
+                        `${URL_PATHS.MEMBERS.ACCOUNT.SETTINGS.ROOT}/${tabId}`
+                    )
+                }
+            />
+        </MemberNavigationPage>
+    );
+}
+
+const getSettingsView = (view: string | string[] | undefined) => {
+    const currentView = Array.isArray(view) ? view[0] : view;
+    switch (currentView) {
+        case SETTINGS_TAB_IDS.CARE_DETAILS:
+            return SETTINGS_TAB_IDS.CARE_DETAILS;
+        case SETTINGS_TAB_IDS.BILLING:
+            return SETTINGS_TAB_IDS.BILLING;
+        case SETTINGS_TAB_IDS.NOTIFICATIONS:
+            return SETTINGS_TAB_IDS.NOTIFICATIONS;
+        case SETTINGS_TAB_IDS.ACCOUNT:
+        default:
+            return SETTINGS_TAB_IDS.ACCOUNT;
+    }
+};


### PR DESCRIPTION
# Description
- Adds page to display `SettingsPage`
- Adds `SettingsPage` component

# Closes issue(s)
[Setting Tabs Page](https://www.notion.so/Settings-Tabs-Page-f5d22e0da7574d88b89e7ff767d8f28e?pvs=4)

# How to test / repro
Storybook 
# Screenshots
#### StoryBook
![image](https://github.com/Therify/directory/assets/25045075/6b4e2071-76c1-4895-9661-44e5b6bbbb72)

#### Directory Page
![image](https://github.com/Therify/directory/assets/25045075/d9dee72b-048e-4a12-bf96-a0057aaf8035)

# Changes include

-   [ ] Bugfix (non-breaking change that solves an issue)
-   [x] New feature (non-breaking change that adds functionality)
-   [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Checklist

-   [x] I have tested this code
-   [ ] I have updated the Readme

# Other comments
