### PR TITLE
feat: add v3 account settings view

### DIFF
--- a/src/lib/modules/accounts/components/settings/SettingsPage/SettingsPage.spec.tsx
+++ b/src/lib/modules/accounts/components/settings/SettingsPage/SettingsPage.spec.tsx
@@ -10,6 +10,9 @@ describe('SettingsPage', () => {
                 user={mockUser}
                 currentTab={SETTINGS_TAB_IDS.ACCOUNT}
                 onTabChange={jest.fn()}
+                onUpdateUserDetails={jest.fn()}
+                onImageUploadSuccess={jest.fn()}
+                onImageUploadError={jest.fn()}
             />
         );
         expect(getByTestId(TEST_IDS.ACCOUNT_TAB)).toBeVisible();
@@ -20,6 +23,9 @@ describe('SettingsPage', () => {
                 user={mockUser}
                 currentTab={SETTINGS_TAB_IDS.CARE_DETAILS}
                 onTabChange={jest.fn()}
+                onUpdateUserDetails={jest.fn()}
+                onImageUploadSuccess={jest.fn()}
+                onImageUploadError={jest.fn()}
             />
         );
         expect(getByTestId(TEST_IDS.CARE_DETAILS_TAB)).toBeVisible();
@@ -30,6 +36,9 @@ describe('SettingsPage', () => {
                 user={mockUser}
                 currentTab={SETTINGS_TAB_IDS.BILLING}
                 onTabChange={jest.fn()}
+                onUpdateUserDetails={jest.fn()}
+                onImageUploadSuccess={jest.fn()}
+                onImageUploadError={jest.fn()}
             />
         );
         expect(getByTestId(TEST_IDS.BILLING_TAB)).toBeVisible();
@@ -40,6 +49,9 @@ describe('SettingsPage', () => {
                 user={mockUser}
                 currentTab={SETTINGS_TAB_IDS.NOTIFICATIONS}
                 onTabChange={jest.fn()}
+                onUpdateUserDetails={jest.fn()}
+                onImageUploadSuccess={jest.fn()}
+                onImageUploadError={jest.fn()}
             />
         );
         expect(getByTestId(TEST_IDS.NOTIFICATIONS_TAB)).toBeVisible();
@@ -51,6 +63,9 @@ describe('SettingsPage', () => {
                 user={mockUser}
                 currentTab={SETTINGS_TAB_IDS.NOTIFICATIONS}
                 onTabChange={onTabChange}
+                onUpdateUserDetails={jest.fn()}
+                onImageUploadSuccess={jest.fn()}
+                onImageUploadError={jest.fn()}
             />
         );
         getByText('Care Details').click();

--- a/src/lib/modules/accounts/components/settings/SettingsPage/SettingsPage.spec.tsx
+++ b/src/lib/modules/accounts/components/settings/SettingsPage/SettingsPage.spec.tsx
@@ -3,6 +3,12 @@ import { TherifyUser } from '@/lib/shared/types';
 import { SettingsPage, SETTINGS_TAB_IDS, TEST_IDS } from './SettingsPage';
 
 const mockUser = {} as TherifyUser.TherifyUser;
+
+const mockUseCloudinaryWidget = jest.fn();
+jest.mock('@/lib/modules/media/components/hooks/userCloudinaryWidget', () => ({
+    useCloudinaryWidget: (args: unknown) => mockUseCloudinaryWidget(args),
+}));
+
 describe('SettingsPage', () => {
     it('should render the Account tab', () => {
         const { getByTestId } = renderWithTheme(

--- a/src/lib/modules/accounts/components/settings/SettingsPage/SettingsPage.stories.tsx
+++ b/src/lib/modules/accounts/components/settings/SettingsPage/SettingsPage.stories.tsx
@@ -35,6 +35,8 @@ export const Default: StoryFn<typeof Component> = () => {
             currentTab={currentTab}
             onTabChange={setCurrentTab}
             onUpdateUserDetails={console.log}
+            onImageUploadSuccess={console.log}
+            onImageUploadError={console.log}
         />
     );
 };

--- a/src/lib/modules/accounts/components/settings/SettingsPage/SettingsPage.stories.tsx
+++ b/src/lib/modules/accounts/components/settings/SettingsPage/SettingsPage.stories.tsx
@@ -34,6 +34,7 @@ export const Default: StoryFn<typeof Component> = () => {
             user={user}
             currentTab={currentTab}
             onTabChange={setCurrentTab}
+            onUpdateUserDetails={console.log}
         />
     );
 };

--- a/src/lib/modules/accounts/components/settings/SettingsPage/SettingsPage.tsx
+++ b/src/lib/modules/accounts/components/settings/SettingsPage/SettingsPage.tsx
@@ -1,4 +1,4 @@
-import { DeepPartial } from 'react-hook-form';
+import { DeepPartial, UseFormReset } from 'react-hook-form';
 import {
     H3,
     PageContentContainer,
@@ -22,7 +22,10 @@ interface SettingsPageProps {
     user: TherifyUser.TherifyUser;
     currentTab: SettingsTabId;
     onTabChange: (tabId: SettingsTabId) => void;
-    onUpdateUserDetails: (data: AccountForm) => void;
+    onUpdateUserDetails: (
+        data: AccountForm,
+        reset: UseFormReset<AccountForm>
+    ) => void;
     onImageUploadError: AccountViewProps['onImageUploadError'];
     onImageUploadSuccess: AccountViewProps['onImageUploadSuccess'];
     defaultAccountDetails?: DeepPartial<AccountForm>;
@@ -65,7 +68,6 @@ export const SettingsPage = ({
                             onImageUploadError={() => {}}
                             onImageUploadSuccess={() => {}}
                             imageUrl={user?.avatarUrl}
-                            user={user}
                             onUpdateUserDetails={onUpdateUserDetails}
                             defaultAccountDetails={defaultAccountDetails}
                         />

--- a/src/lib/modules/accounts/components/settings/SettingsPage/SettingsPage.tsx
+++ b/src/lib/modules/accounts/components/settings/SettingsPage/SettingsPage.tsx
@@ -1,3 +1,4 @@
+import { DeepPartial } from 'react-hook-form';
 import {
     H3,
     PageContentContainer,
@@ -7,7 +8,7 @@ import {
 import { TherifyUser } from '@/lib/shared/types';
 import Box from '@mui/material/Box';
 import { styled } from '@mui/material/styles';
-import { AccountView, AccountForm } from './views';
+import { AccountView, AccountForm, AccountViewProps } from './views';
 
 export const SETTINGS_TAB_IDS = {
     ACCOUNT: 'account',
@@ -22,6 +23,9 @@ interface SettingsPageProps {
     currentTab: SettingsTabId;
     onTabChange: (tabId: SettingsTabId) => void;
     onUpdateUserDetails: (data: AccountForm) => void;
+    onImageUploadError: AccountViewProps['onImageUploadError'];
+    onImageUploadSuccess: AccountViewProps['onImageUploadSuccess'];
+    defaultAccountDetails?: DeepPartial<AccountForm>;
 }
 const tabs: TabOption[] = [
     { id: SETTINGS_TAB_IDS.ACCOUNT, tabLabel: 'Account' },
@@ -41,6 +45,7 @@ export const SettingsPage = ({
     currentTab,
     onTabChange,
     onUpdateUserDetails,
+    defaultAccountDetails,
 }: SettingsPageProps) => {
     return (
         <PageContainer>
@@ -62,6 +67,7 @@ export const SettingsPage = ({
                             imageUrl={user?.avatarUrl}
                             user={user}
                             onUpdateUserDetails={onUpdateUserDetails}
+                            defaultAccountDetails={defaultAccountDetails}
                         />
                     </TabContent>
                 )}

--- a/src/lib/modules/accounts/components/settings/SettingsPage/SettingsPage.tsx
+++ b/src/lib/modules/accounts/components/settings/SettingsPage/SettingsPage.tsx
@@ -48,6 +48,8 @@ export const SettingsPage = ({
     currentTab,
     onTabChange,
     onUpdateUserDetails,
+    onImageUploadError,
+    onImageUploadSuccess,
     defaultAccountDetails,
 }: SettingsPageProps) => {
     return (
@@ -65,8 +67,8 @@ export const SettingsPage = ({
                 {currentTab === SETTINGS_TAB_IDS.ACCOUNT && (
                     <TabContent data-testid={TEST_IDS.ACCOUNT_TAB}>
                         <AccountView
-                            onImageUploadError={() => {}}
-                            onImageUploadSuccess={() => {}}
+                            onImageUploadError={onImageUploadError}
+                            onImageUploadSuccess={onImageUploadSuccess}
                             imageUrl={user?.avatarUrl}
                             onUpdateUserDetails={onUpdateUserDetails}
                             defaultAccountDetails={defaultAccountDetails}

--- a/src/lib/modules/accounts/components/settings/SettingsPage/SettingsPage.tsx
+++ b/src/lib/modules/accounts/components/settings/SettingsPage/SettingsPage.tsx
@@ -5,7 +5,9 @@ import {
     TabOption,
 } from '@/lib/shared/components/ui';
 import { TherifyUser } from '@/lib/shared/types';
+import Box from '@mui/material/Box';
 import { styled } from '@mui/material/styles';
+import { AccountView, AccountForm } from './views';
 
 export const SETTINGS_TAB_IDS = {
     ACCOUNT: 'account',
@@ -19,6 +21,7 @@ interface SettingsPageProps {
     user: TherifyUser.TherifyUser;
     currentTab: SettingsTabId;
     onTabChange: (tabId: SettingsTabId) => void;
+    onUpdateUserDetails: (data: AccountForm) => void;
 }
 const tabs: TabOption[] = [
     { id: SETTINGS_TAB_IDS.ACCOUNT, tabLabel: 'Account' },
@@ -37,40 +40,66 @@ export const SettingsPage = ({
     user,
     currentTab,
     onTabChange,
+    onUpdateUserDetails,
 }: SettingsPageProps) => {
     return (
-        <PageContentContainer padding={8} paddingTop={10} maxWidth={1448}>
-            <H3 marginBottom={10}>Settings</H3>
-            <Tabs
-                v3
-                selectedTab={currentTab}
-                onTabChange={(tabId) => onTabChange(tabId as SettingsTabId)}
-                ariaLabel="Settings tabs"
-                withBottomBorder
-                tabs={tabs}
-            />
-            {currentTab === SETTINGS_TAB_IDS.ACCOUNT && (
-                <TabContent data-testid={TEST_IDS.ACCOUNT_TAB}>
-                    {/* TODO: Add Account view */}
-                </TabContent>
-            )}
-            {currentTab === SETTINGS_TAB_IDS.CARE_DETAILS && (
-                <TabContent data-testid={TEST_IDS.CARE_DETAILS_TAB}>
-                    {/* TODO: Add Care Details view */}
-                </TabContent>
-            )}
-            {currentTab === SETTINGS_TAB_IDS.BILLING && (
-                <TabContent data-testid={TEST_IDS.BILLING_TAB}>
-                    {/* TODO: Add Billing & Payments view */}
-                </TabContent>
-            )}
-            {currentTab === SETTINGS_TAB_IDS.NOTIFICATIONS && (
-                <TabContent data-testid={TEST_IDS.NOTIFICATIONS_TAB}>
-                    {/* TODO: Add Email Notifications view */}
-                </TabContent>
-            )}
-        </PageContentContainer>
+        <PageContainer>
+            <InnerContainer>
+                <H3 marginBottom={10}>Settings</H3>
+                <Tabs
+                    v3
+                    selectedTab={currentTab}
+                    onTabChange={(tabId) => onTabChange(tabId as SettingsTabId)}
+                    ariaLabel="Settings tabs"
+                    withBottomBorder
+                    tabs={tabs}
+                />
+                {currentTab === SETTINGS_TAB_IDS.ACCOUNT && (
+                    <TabContent data-testid={TEST_IDS.ACCOUNT_TAB}>
+                        <AccountView
+                            onImageUploadError={() => {}}
+                            onImageUploadSuccess={() => {}}
+                            imageUrl={user?.avatarUrl}
+                            user={user}
+                            onUpdateUserDetails={onUpdateUserDetails}
+                        />
+                    </TabContent>
+                )}
+                {currentTab === SETTINGS_TAB_IDS.CARE_DETAILS && (
+                    <TabContent data-testid={TEST_IDS.CARE_DETAILS_TAB}>
+                        {/* TODO: Add Care Details view */}
+                    </TabContent>
+                )}
+                {currentTab === SETTINGS_TAB_IDS.BILLING && (
+                    <TabContent data-testid={TEST_IDS.BILLING_TAB}>
+                        {/* TODO: Add Billing & Payments view */}
+                    </TabContent>
+                )}
+                {currentTab === SETTINGS_TAB_IDS.NOTIFICATIONS && (
+                    <TabContent data-testid={TEST_IDS.NOTIFICATIONS_TAB}>
+                        {/* TODO: Add Email Notifications view */}
+                    </TabContent>
+                )}
+            </InnerContainer>
+        </PageContainer>
     );
 };
 
-const TabContent = styled('div')();
+const TabContent = styled('div')(({ theme }) => ({
+    padding: theme.spacing(10, 0),
+}));
+
+const PageContainer = styled(PageContentContainer)(({ theme }) => ({
+    padding: theme.spacing(8),
+    paddingTop: theme.spacing(10),
+    height: '100%',
+    width: '100%',
+    overflow: 'auto',
+    maxWidth: '100% !important',
+}));
+
+const InnerContainer = styled(Box)({
+    width: '100%',
+    maxWidth: '1448px',
+    margin: 'auto',
+});

--- a/src/lib/modules/accounts/components/settings/SettingsPage/views/AccountView/AccountView.spec.tsx
+++ b/src/lib/modules/accounts/components/settings/SettingsPage/views/AccountView/AccountView.spec.tsx
@@ -2,16 +2,13 @@ import { renderWithTheme } from '@/lib/shared/components/fixtures';
 import { Gender, UNITED_STATES, Ethnicity } from '@/lib/shared/types';
 import { TEST_IDS as AVATAR_TEST_IDS } from '@/lib/shared/components/ui/Avatar';
 import userEvent from '@testing-library/user-event';
-import { TherifyUser } from '@/lib/shared/types';
 import { AccountView } from './AccountView';
 import { AccountForm } from './form';
-import { sleep } from '@/lib/shared/utils';
+
 const mockUseCloudinaryWidget = jest.fn();
 jest.mock('@/lib/modules/media/components/hooks/userCloudinaryWidget', () => ({
     useCloudinaryWidget: (args: unknown) => mockUseCloudinaryWidget(args),
 }));
-
-const mockUser = {} as TherifyUser.TherifyUser;
 
 describe('SettingsPage > Account View', () => {
     const user = userEvent.setup();
@@ -23,7 +20,6 @@ describe('SettingsPage > Account View', () => {
             const onImageUploadSuccess = jest.fn();
             renderWithTheme(
                 <AccountView
-                    user={mockUser}
                     onUpdateUserDetails={jest.fn()}
                     onImageUploadSuccess={onImageUploadSuccess}
                     onImageUploadError={jest.fn()}
@@ -45,7 +41,6 @@ describe('SettingsPage > Account View', () => {
             const onImageUploadError = jest.fn();
             renderWithTheme(
                 <AccountView
-                    user={mockUser}
                     onUpdateUserDetails={jest.fn()}
                     onImageUploadSuccess={jest.fn()}
                     onImageUploadError={onImageUploadError}
@@ -64,7 +59,6 @@ describe('SettingsPage > Account View', () => {
             const mockImageUrl = 'test-url';
             const { getByTestId } = renderWithTheme(
                 <AccountView
-                    user={mockUser}
                     onUpdateUserDetails={jest.fn()}
                     onImageUploadSuccess={jest.fn()}
                     onImageUploadError={jest.fn()}
@@ -77,11 +71,6 @@ describe('SettingsPage > Account View', () => {
     });
 
     describe('Account Details Form', () => {
-        const mockAccountDetails = {
-            givenName: 'Test',
-            surname: 'User',
-            emailAddress: 'test@therify.co',
-        } as TherifyUser.TherifyUser;
         const mockUserDetails: AccountForm = {
             accountDetails: {
                 givenName: 'Updated',
@@ -104,7 +93,6 @@ describe('SettingsPage > Account View', () => {
         it('prefills the form', () => {
             const { getByLabelText } = renderWithTheme(
                 <AccountView
-                    user={mockAccountDetails}
                     onUpdateUserDetails={jest.fn()}
                     onImageUploadSuccess={jest.fn()}
                     onImageUploadError={jest.fn()}
@@ -152,7 +140,6 @@ describe('SettingsPage > Account View', () => {
             const onUpdateUserDetails = jest.fn();
             const { getByLabelText, getByText } = renderWithTheme(
                 <AccountView
-                    user={mockUser}
                     onUpdateUserDetails={onUpdateUserDetails}
                     onImageUploadSuccess={jest.fn()}
                     onImageUploadError={jest.fn()}
@@ -199,7 +186,11 @@ describe('SettingsPage > Account View', () => {
                 getByText(mockUserDetails.personalDetails.ethnicity)
             );
             await user.click(getByText('Save Changes'));
-            expect(onUpdateUserDetails).toHaveBeenCalledWith(mockUserDetails);
+            const updatedDataArg = onUpdateUserDetails.mock.calls[0][0];
+            const resetFormArg = onUpdateUserDetails.mock.calls[0][1];
+            expect(onUpdateUserDetails).toHaveBeenCalledTimes(1);
+            expect(updatedDataArg).toEqual(mockUserDetails);
+            expect(resetFormArg).toBeInstanceOf(Function);
         });
     });
 });

--- a/src/lib/modules/accounts/components/settings/SettingsPage/views/AccountView/AccountView.spec.tsx
+++ b/src/lib/modules/accounts/components/settings/SettingsPage/views/AccountView/AccountView.spec.tsx
@@ -191,6 +191,6 @@ describe('SettingsPage > Account View', () => {
             expect(onUpdateUserDetails).toHaveBeenCalledTimes(1);
             expect(updatedDataArg).toEqual(mockUserDetails);
             expect(resetFormArg).toBeInstanceOf(Function);
-        });
+        }, 10000);
     });
 });

--- a/src/lib/modules/accounts/components/settings/SettingsPage/views/AccountView/AccountView.spec.tsx
+++ b/src/lib/modules/accounts/components/settings/SettingsPage/views/AccountView/AccountView.spec.tsx
@@ -1,0 +1,205 @@
+import { renderWithTheme } from '@/lib/shared/components/fixtures';
+import { Gender, UNITED_STATES, Ethnicity } from '@/lib/shared/types';
+import { TEST_IDS as AVATAR_TEST_IDS } from '@/lib/shared/components/ui/Avatar';
+import userEvent from '@testing-library/user-event';
+import { TherifyUser } from '@/lib/shared/types';
+import { AccountView } from './AccountView';
+import { AccountForm } from './form';
+import { sleep } from '@/lib/shared/utils';
+const mockUseCloudinaryWidget = jest.fn();
+jest.mock('@/lib/modules/media/components/hooks/userCloudinaryWidget', () => ({
+    useCloudinaryWidget: (args: unknown) => mockUseCloudinaryWidget(args),
+}));
+
+const mockUser = {} as TherifyUser.TherifyUser;
+
+describe('SettingsPage > Account View', () => {
+    const user = userEvent.setup();
+    beforeEach(() => {
+        mockUseCloudinaryWidget.mockClear();
+    });
+    describe('Image upload', () => {
+        it('calls onImageUploadSuccess when the upload is successful', async () => {
+            const onImageUploadSuccess = jest.fn();
+            renderWithTheme(
+                <AccountView
+                    user={mockUser}
+                    onUpdateUserDetails={jest.fn()}
+                    onImageUploadSuccess={onImageUploadSuccess}
+                    onImageUploadError={jest.fn()}
+                />
+            );
+            // Get the onUploadResult callback passed to the cloudinary widget
+            // and simulate a successful upload event
+            const cloudinaryParams = mockUseCloudinaryWidget.mock.calls[0][0];
+            const mockUploadResult = { event: 'success' };
+            cloudinaryParams.onUploadResult(null, mockUploadResult);
+
+            expect(onImageUploadSuccess).toHaveBeenCalledWith(
+                null,
+                mockUploadResult
+            );
+        });
+
+        it('calls onImageUploadError when the upload fails', async () => {
+            const onImageUploadError = jest.fn();
+            renderWithTheme(
+                <AccountView
+                    user={mockUser}
+                    onUpdateUserDetails={jest.fn()}
+                    onImageUploadSuccess={jest.fn()}
+                    onImageUploadError={onImageUploadError}
+                />
+            );
+            // Get the onUploadResult callback passed to the cloudinary widget
+            // and simulate a failed upload
+            const cloudinaryParams = mockUseCloudinaryWidget.mock.calls[0][0];
+            const mockUploadError = new Error('Upload failed');
+            cloudinaryParams.onUploadResult(mockUploadError);
+
+            expect(onImageUploadError).toHaveBeenCalledWith(mockUploadError);
+        });
+
+        it('renders the profile image', () => {
+            const mockImageUrl = 'test-url';
+            const { getByTestId } = renderWithTheme(
+                <AccountView
+                    user={mockUser}
+                    onUpdateUserDetails={jest.fn()}
+                    onImageUploadSuccess={jest.fn()}
+                    onImageUploadError={jest.fn()}
+                    imageUrl={mockImageUrl}
+                />
+            );
+            const image = getByTestId(AVATAR_TEST_IDS.AVATAR).firstElementChild;
+            expect(image?.getAttribute('src')).toBe(mockImageUrl);
+        });
+    });
+
+    describe('Account Details Form', () => {
+        const mockAccountDetails = {
+            givenName: 'Test',
+            surname: 'User',
+            emailAddress: 'test@therify.co',
+        } as TherifyUser.TherifyUser;
+        const mockUserDetails: AccountForm = {
+            accountDetails: {
+                givenName: 'Updated',
+                surname: 'User',
+                emailAddress: 'test@therify.co',
+                phoneNumber: '1234567890',
+            },
+            personalDetails: {
+                state: UNITED_STATES.STATE.ENTRIES[0],
+                gender: Gender.ENTRIES[0],
+                ethnicity: Ethnicity.ENTRIES[0],
+            },
+            emergencyDetails: {
+                contactName: 'Test User',
+                contactPhoneNumber: '1234567890',
+                contactRelationship: 'Parent',
+                homeAddress: '123 Street St',
+            },
+        };
+        it('prefills the form', () => {
+            const { getByLabelText } = renderWithTheme(
+                <AccountView
+                    user={mockAccountDetails}
+                    onUpdateUserDetails={jest.fn()}
+                    onImageUploadSuccess={jest.fn()}
+                    onImageUploadError={jest.fn()}
+                    defaultAccountDetails={mockUserDetails}
+                />
+            );
+
+            expect(getByLabelText('First Name')).toHaveValue(
+                mockUserDetails.accountDetails.givenName
+            );
+            expect(getByLabelText('Last Name')).toHaveValue(
+                mockUserDetails.accountDetails.surname
+            );
+            expect(getByLabelText('Email Address')).toHaveValue(
+                mockUserDetails.accountDetails.emailAddress
+            );
+            expect(getByLabelText('Phone Number')).toHaveValue(
+                mockUserDetails.accountDetails.phoneNumber
+            );
+            expect(getByLabelText('Emergency Contact Name')).toHaveValue(
+                mockUserDetails.emergencyDetails.contactName
+            );
+            expect(getByLabelText('Emergency Phone Number')).toHaveValue(
+                mockUserDetails.emergencyDetails.contactPhoneNumber
+            );
+            expect(getByLabelText('Emergency Contact Relation')).toHaveValue(
+                mockUserDetails.emergencyDetails.contactRelationship
+            );
+            expect(getByLabelText('Your Home Address')).toHaveValue(
+                mockUserDetails.emergencyDetails.homeAddress
+            );
+            // select.nextSibling is the hidden rendered input that holds the selected value
+            expect(getByLabelText('State').nextSibling).toHaveValue(
+                mockUserDetails.personalDetails.state
+            );
+            expect(getByLabelText('Gender').nextSibling).toHaveValue(
+                mockUserDetails.personalDetails.gender
+            );
+            expect(getByLabelText('Ethnicity').nextSibling).toHaveValue(
+                mockUserDetails.personalDetails.ethnicity
+            );
+        });
+
+        it('submits the form with the updated user details', async () => {
+            const onUpdateUserDetails = jest.fn();
+            const { getByLabelText, getByText } = renderWithTheme(
+                <AccountView
+                    user={mockUser}
+                    onUpdateUserDetails={onUpdateUserDetails}
+                    onImageUploadSuccess={jest.fn()}
+                    onImageUploadError={jest.fn()}
+                />
+            );
+            await user.type(
+                getByLabelText('First Name'),
+                mockUserDetails.accountDetails.givenName
+            );
+            await user.type(
+                getByLabelText('Last Name'),
+                mockUserDetails.accountDetails.surname
+            );
+            await user.type(
+                getByLabelText('Email Address'),
+                mockUserDetails.accountDetails.emailAddress
+            );
+            await user.type(
+                getByLabelText('Phone Number'),
+                mockUserDetails.accountDetails.phoneNumber
+            );
+            await user.type(
+                getByLabelText('Emergency Contact Name'),
+                mockUserDetails.emergencyDetails.contactName
+            );
+            await user.type(
+                getByLabelText('Emergency Phone Number'),
+                mockUserDetails.emergencyDetails.contactPhoneNumber
+            );
+            await user.type(
+                getByLabelText('Emergency Contact Relation'),
+                mockUserDetails.emergencyDetails.contactRelationship
+            );
+            await user.type(
+                getByLabelText('Your Home Address'),
+                mockUserDetails.emergencyDetails.homeAddress
+            );
+            await user.click(getByLabelText('State'));
+            await user.click(getByText(mockUserDetails.personalDetails.state));
+            await user.click(getByLabelText('Gender'));
+            await user.click(getByText(mockUserDetails.personalDetails.gender));
+            await user.click(getByLabelText('Ethnicity'));
+            await user.click(
+                getByText(mockUserDetails.personalDetails.ethnicity)
+            );
+            await user.click(getByText('Save Changes'));
+            expect(onUpdateUserDetails).toHaveBeenCalledWith(mockUserDetails);
+        });
+    });
+});

--- a/src/lib/modules/accounts/components/settings/SettingsPage/views/AccountView/AccountView.tsx
+++ b/src/lib/modules/accounts/components/settings/SettingsPage/views/AccountView/AccountView.tsx
@@ -1,7 +1,6 @@
 import { Box, Stack } from '@mui/material';
-import { DeepPartial } from 'react-hook-form';
+import { DeepPartial, UseFormReset } from 'react-hook-form';
 import { CloudinaryUploadResult } from '@/lib/modules/media/components/hooks/userCloudinaryWidget';
-import { TherifyUser } from '@/lib/shared/types';
 import {
     FormRenderer,
     Avatar,
@@ -18,16 +17,16 @@ export interface AccountViewProps {
     ) => void;
     onImageUploadError: (error: string | Error) => void;
     imageUrl?: string;
-
-    user: TherifyUser.TherifyUser;
-    onUpdateUserDetails: (user: AccountForm) => void;
+    onUpdateUserDetails: (
+        user: AccountForm,
+        reset: UseFormReset<AccountForm>
+    ) => void;
     defaultAccountDetails?: DeepPartial<AccountForm>;
 }
 export const AccountView = ({
     onImageUploadSuccess,
     onImageUploadError,
     imageUrl,
-    user,
     onUpdateUserDetails,
     defaultAccountDetails,
 }: AccountViewProps) => {

--- a/src/lib/modules/accounts/components/settings/SettingsPage/views/AccountView/AccountView.tsx
+++ b/src/lib/modules/accounts/components/settings/SettingsPage/views/AccountView/AccountView.tsx
@@ -1,0 +1,82 @@
+import { Box, Stack } from '@mui/material';
+import { CloudinaryUploadResult } from '@/lib/modules/media/components/hooks/userCloudinaryWidget';
+import { TherifyUser } from '@/lib/shared/types';
+import {
+    FormRenderer,
+    Avatar,
+    AVATAR_SIZE,
+    Paragraph,
+} from '@/lib/shared/components/ui';
+import { ImageUploadButton } from './ui/ImageUploadButton';
+import { accountForm, AccountForm } from './form';
+
+interface AccountViewProps {
+    onImageUploadSuccess: (
+        error: Error | null,
+        result: CloudinaryUploadResult
+    ) => void;
+    onImageUploadError: (error: string | Error) => void;
+    imageUrl?: string;
+
+    user: TherifyUser.TherifyUser;
+    onUpdateUserDetails: (user: AccountForm) => void;
+}
+export const AccountView = ({
+    onImageUploadSuccess,
+    onImageUploadError,
+    imageUrl,
+    user,
+    onUpdateUserDetails,
+}: AccountViewProps) => {
+    return (
+        <Box>
+            <Stack
+                justifyContent="flex-start"
+                flexDirection="row"
+                alignItems="center"
+                mb={6}
+            >
+                <Avatar
+                    src={imageUrl}
+                    alt="Your profile image preview"
+                    size={AVATAR_SIZE.XHUGE}
+                />
+                <Box px={6}>
+                    <Paragraph bold noMargin>
+                        Profile Photo
+                    </Paragraph>
+                    <ImageUploadButton
+                        onUploadError={onImageUploadError}
+                        onUploadSuccess={onImageUploadSuccess}
+                        buttonText={imageUrl ? 'Change Photo' : 'Upload Photo'}
+                    />
+                </Box>
+            </Stack>
+            <FormRenderer
+                validationSchema={accountForm.schema}
+                config={accountForm.config}
+                submitButtonText="Save Changes"
+                defaultValues={getDefaultValuesFromUser(user)}
+                onSubmit={onUpdateUserDetails}
+                sx={{
+                    maxWidth: 600,
+                    '& > div': {
+                        padding: 0,
+                    },
+                }}
+            />
+        </Box>
+    );
+};
+
+// TODO: Get this info from member profile query, not therify user
+const getDefaultValuesFromUser = (
+    user: TherifyUser.TherifyUser
+): Partial<AccountForm> => ({
+    accountDetails: {
+        givenName: user.givenName,
+        surname: user.surname,
+        emailAddress: user.emailAddress,
+        phoneNumber: '',
+    },
+});

--- a/src/lib/modules/accounts/components/settings/SettingsPage/views/AccountView/AccountView.tsx
+++ b/src/lib/modules/accounts/components/settings/SettingsPage/views/AccountView/AccountView.tsx
@@ -1,4 +1,5 @@
 import { Box, Stack } from '@mui/material';
+import { DeepPartial } from 'react-hook-form';
 import { CloudinaryUploadResult } from '@/lib/modules/media/components/hooks/userCloudinaryWidget';
 import { TherifyUser } from '@/lib/shared/types';
 import {
@@ -10,7 +11,7 @@ import {
 import { ImageUploadButton } from './ui/ImageUploadButton';
 import { accountForm, AccountForm } from './form';
 
-interface AccountViewProps {
+export interface AccountViewProps {
     onImageUploadSuccess: (
         error: Error | null,
         result: CloudinaryUploadResult
@@ -20,6 +21,7 @@ interface AccountViewProps {
 
     user: TherifyUser.TherifyUser;
     onUpdateUserDetails: (user: AccountForm) => void;
+    defaultAccountDetails?: DeepPartial<AccountForm>;
 }
 export const AccountView = ({
     onImageUploadSuccess,
@@ -27,6 +29,7 @@ export const AccountView = ({
     imageUrl,
     user,
     onUpdateUserDetails,
+    defaultAccountDetails,
 }: AccountViewProps) => {
     return (
         <Box>
@@ -56,7 +59,7 @@ export const AccountView = ({
                 validationSchema={accountForm.schema}
                 config={accountForm.config}
                 submitButtonText="Save Changes"
-                defaultValues={getDefaultValuesFromUser(user)}
+                defaultValues={defaultAccountDetails}
                 onSubmit={onUpdateUserDetails}
                 sx={{
                     maxWidth: 600,
@@ -68,15 +71,3 @@ export const AccountView = ({
         </Box>
     );
 };
-
-// TODO: Get this info from member profile query, not therify user
-const getDefaultValuesFromUser = (
-    user: TherifyUser.TherifyUser
-): Partial<AccountForm> => ({
-    accountDetails: {
-        givenName: user.givenName,
-        surname: user.surname,
-        emailAddress: user.emailAddress,
-        phoneNumber: '',
-    },
-});

--- a/src/lib/modules/accounts/components/settings/SettingsPage/views/AccountView/form/config.ts
+++ b/src/lib/modules/accounts/components/settings/SettingsPage/views/AccountView/form/config.ts
@@ -1,0 +1,105 @@
+import {
+    FormConfig,
+    FormSection,
+} from '@/lib/shared/components/ui/FormElements/FormRenderer/types';
+import { Gender, UNITED_STATES, Ethnicity } from '@/lib/shared/types';
+import { Type as AccountSettingsForm } from './schema';
+
+const accountDetails: FormSection<AccountSettingsForm> = {
+    title: 'Account Details',
+    fields: [
+        {
+            id: 'givenName',
+            type: 'input',
+            label: 'First Name',
+            inputType: 'text',
+            statePath: 'accountDetails.givenName',
+        },
+        {
+            id: 'surname',
+            type: 'input',
+            label: 'Last Name',
+            inputType: 'text',
+            statePath: 'accountDetails.surname',
+        },
+        {
+            id: 'emailAddress',
+            type: 'input',
+            label: 'Email Address',
+            inputType: 'email',
+            statePath: 'accountDetails.emailAddress',
+        },
+        {
+            id: 'phoneNumber',
+            type: 'input',
+            label: 'Phone Number',
+            inputType: 'text',
+            statePath: 'accountDetails.phoneNumber',
+        },
+    ],
+};
+
+const personalDetails: FormSection<AccountSettingsForm> = {
+    title: 'Personal Details',
+    fields: [
+        {
+            id: 'state',
+            type: 'select',
+            label: 'State',
+            statePath: 'personalDetails.state',
+            options: [...UNITED_STATES.STATE.ENTRIES],
+        },
+        {
+            id: 'gender',
+            type: 'select',
+            label: 'Gender',
+            statePath: 'personalDetails.gender',
+            options: [...Gender.ENTRIES],
+        },
+        {
+            id: 'ethnicity',
+            type: 'select',
+            label: 'Ethnicity',
+            statePath: 'personalDetails.ethnicity',
+            options: [...Ethnicity.ENTRIES],
+        },
+    ],
+};
+
+const emergencyDetails: FormSection<AccountSettingsForm> = {
+    title: 'Emergency Details',
+    fields: [
+        {
+            id: 'address',
+            type: 'input',
+            label: 'Your Address',
+            inputType: 'text',
+            statePath: 'emergencyDetails.homeAddress',
+        },
+        {
+            id: 'emergencyPhoneNumber',
+            type: 'input',
+            label: 'Emergency Phone Number',
+            inputType: 'text',
+            statePath: 'emergencyDetails.contactPhoneNumber',
+        },
+        {
+            id: 'emergencyContactName',
+            type: 'input',
+            label: 'Emergency Contact Name',
+            inputType: 'text',
+            statePath: 'emergencyDetails.contactName',
+        },
+        {
+            id: 'emergencyContactcontactRelationship',
+            type: 'input',
+            label: 'Emergency Contact Relation',
+            inputType: 'text',
+            statePath: 'emergencyDetails.contactRelationship',
+        },
+    ],
+};
+
+export const config: FormConfig<AccountSettingsForm> = {
+    sections: [accountDetails, personalDetails, emergencyDetails],
+};

--- a/src/lib/modules/accounts/components/settings/SettingsPage/views/AccountView/form/config.ts
+++ b/src/lib/modules/accounts/components/settings/SettingsPage/views/AccountView/form/config.ts
@@ -72,16 +72,9 @@ const emergencyDetails: FormSection<AccountSettingsForm> = {
         {
             id: 'address',
             type: 'input',
-            label: 'Your Address',
+            label: 'Your Home Address',
             inputType: 'text',
             statePath: 'emergencyDetails.homeAddress',
-        },
-        {
-            id: 'emergencyPhoneNumber',
-            type: 'input',
-            label: 'Emergency Phone Number',
-            inputType: 'text',
-            statePath: 'emergencyDetails.contactPhoneNumber',
         },
         {
             id: 'emergencyContactName',
@@ -89,6 +82,13 @@ const emergencyDetails: FormSection<AccountSettingsForm> = {
             label: 'Emergency Contact Name',
             inputType: 'text',
             statePath: 'emergencyDetails.contactName',
+        },
+        {
+            id: 'emergencyPhoneNumber',
+            type: 'input',
+            label: 'Emergency Phone Number',
+            inputType: 'text',
+            statePath: 'emergencyDetails.contactPhoneNumber',
         },
         {
             id: 'emergencyContactcontactRelationship',

--- a/src/lib/modules/accounts/components/settings/SettingsPage/views/AccountView/form/index.ts
+++ b/src/lib/modules/accounts/components/settings/SettingsPage/views/AccountView/form/index.ts
@@ -1,0 +1,9 @@
+import { schema } from './schema';
+import { config } from './config';
+
+export const accountForm = {
+    schema,
+    config,
+};
+
+export type { Type as AccountForm } from './schema';

--- a/src/lib/modules/accounts/components/settings/SettingsPage/views/AccountView/form/schema.ts
+++ b/src/lib/modules/accounts/components/settings/SettingsPage/views/AccountView/form/schema.ts
@@ -1,0 +1,62 @@
+import { Gender, UNITED_STATES, Ethnicity } from '@/lib/shared/types';
+import z from 'zod';
+
+export const schema = z.object({
+    accountDetails: z.object({
+        givenName: z.string().nonempty({
+            message: 'First name is required',
+        }),
+        surname: z.string().nonempty({
+            message: 'Last name is required',
+        }),
+        emailAddress: z
+            .string()
+            .nonempty({
+                message: 'Email is required',
+            })
+            .email({
+                message: 'Email is invalid',
+            }),
+        phoneNumber: z.string().refine(
+            (value: string) => {
+                const phoneNumber = value.replace(/\D/g, '');
+                return phoneNumber.length === 10;
+            },
+            {
+                message: 'Please enter a 10 digit phone number',
+            }
+        ),
+    }),
+    personalDetails: z.object({
+        state: z.enum(UNITED_STATES.STATE.ENTRIES),
+        gender: z.enum(Gender.ENTRIES),
+        ethnicity: z.enum(Ethnicity.ENTRIES),
+    }),
+    emergencyDetails: z.object({
+        homeAddress: z.string().nonempty({
+            message: 'Your home address is required',
+        }),
+        contactName: z.string().nonempty({
+            message: 'Contact name is required',
+        }),
+        contactPhoneNumber: z
+            .string()
+            .nonempty({
+                message: 'Contact phone number is required',
+            })
+            .refine(
+                (value: string) => {
+                    const phoneNumber = value.replace(/\D/g, '');
+                    return phoneNumber.length === 10;
+                },
+                {
+                    message: 'Please enter a 10 digit phone number',
+                }
+            ),
+        contactRelationship: z.string().nonempty({
+            message: 'Contact relationship is required',
+        }),
+    }),
+});
+
+export type Type = z.infer<typeof schema>;

--- a/src/lib/modules/accounts/components/settings/SettingsPage/views/AccountView/index.ts
+++ b/src/lib/modules/accounts/components/settings/SettingsPage/views/AccountView/index.ts
@@ -1,0 +1,2 @@
+export * from './AccountView';
+export * from './form';

--- a/src/lib/modules/accounts/components/settings/SettingsPage/views/AccountView/ui/ImageUploadButton.tsx
+++ b/src/lib/modules/accounts/components/settings/SettingsPage/views/AccountView/ui/ImageUploadButton.tsx
@@ -1,0 +1,66 @@
+import {
+    CloudinaryUploadResult,
+    CreateUploadImageParams,
+    useCloudinaryWidget,
+} from '@/lib/modules/media/components/hooks/userCloudinaryWidget';
+import { styled } from '@mui/material/styles';
+import React from 'react';
+interface MediaUploadWidgetProps {
+    folder?: string;
+    buttonText?: string;
+    disabled?: boolean;
+    onUploadSuccess: (
+        error: Error | null,
+        result: CloudinaryUploadResult
+    ) => void;
+    onUploadError: (error: Error | string) => void;
+    cloudinaryParams?: CreateUploadImageParams;
+}
+
+export const ImageUploadButton = React.memo(
+    function MediaUploadWidget({
+        onUploadSuccess,
+        onUploadError,
+        disabled,
+        folder,
+        buttonText = 'Upload Image',
+        cloudinaryParams,
+    }: MediaUploadWidgetProps) {
+        const buttonRef = React.useRef<HTMLButtonElement>(null);
+        useCloudinaryWidget({
+            buttonRef,
+            folder,
+            params: cloudinaryParams,
+            onUploadResult(error, result) {
+                if (!error && result && result.event === 'success') {
+                    onUploadSuccess(null, result);
+                    return;
+                }
+                if (error) {
+                    onUploadError(error);
+                }
+            },
+        });
+        return (
+            <UploadButton ref={buttonRef} disabled={disabled}>
+                {buttonText}
+            </UploadButton>
+        );
+    },
+    (prevProps, nextProps) => {
+        return (
+            prevProps.disabled === nextProps.disabled &&
+            prevProps.buttonText === nextProps.buttonText
+        );
+    }
+);
+
+const UploadButton = styled('button')(({ theme }) => ({
+    textDecoration: 'underline',
+    background: 'transparent',
+    border: 'none',
+    color: theme.palette.primary.main,
+    cursor: 'pointer',
+    padding: 0,
+    margin: 0,
+}));

--- a/src/lib/modules/accounts/components/settings/SettingsPage/views/index.ts
+++ b/src/lib/modules/accounts/components/settings/SettingsPage/views/index.ts
@@ -1,0 +1,1 @@
+export * from './AccountView';

--- a/src/lib/shared/components/ui/FormElements/FormRenderer/FormRenderer.tsx
+++ b/src/lib/shared/components/ui/FormElements/FormRenderer/FormRenderer.tsx
@@ -59,7 +59,7 @@ export function FormRenderer<ValidationSchema extends z.ZodTypeAny>({
     return (
         <Form sx={sx} onSubmit={(e) => e.preventDefault()}>
             <FormContent isError={!!errorMessage}>
-                <Header>{config.title}</Header>
+                {config.title && <Header>{config.title}</Header>}
                 {config.subtitle && (
                     <Paragraph noMargin>{config.subtitle}</Paragraph>
                 )}

--- a/src/lib/shared/components/ui/FormElements/FormRenderer/FormRenderer.tsx
+++ b/src/lib/shared/components/ui/FormElements/FormRenderer/FormRenderer.tsx
@@ -4,7 +4,7 @@ import { ReportProblemRounded } from '@mui/icons-material';
 import Box from '@mui/material/Box';
 import { SxProps, Theme, styled } from '@mui/material/styles';
 import { motion } from 'framer-motion';
-import { DeepPartial, useForm } from 'react-hook-form';
+import { DeepPartial, useForm, UseFormReset } from 'react-hook-form';
 import { ALERT_TYPE, Alert } from '../../Alert';
 import { Button } from '../../Button';
 import { CenteredContainer } from '../../Containers';
@@ -42,7 +42,10 @@ export function FormRenderer<ValidationSchema extends z.ZodTypeAny>({
     clearErrorMessage?: () => void;
     validationMode?: 'onBlur' | 'onChange' | 'onSubmit' | 'onTouched' | 'all';
     onBack?: () => void;
-    onSubmit: (data: z.infer<ValidationSchema>) => void;
+    onSubmit: (
+        data: z.infer<ValidationSchema>,
+        resetForm: UseFormReset<z.TypeOf<ValidationSchema>>
+    ) => void;
     sx?: SxProps<Theme>;
 }) {
     const form = useForm<z.infer<ValidationSchema>>({
@@ -54,6 +57,7 @@ export function FormRenderer<ValidationSchema extends z.ZodTypeAny>({
     const {
         formState: { isValid },
         handleSubmit,
+        reset,
     } = form;
 
     return (
@@ -131,7 +135,7 @@ export function FormRenderer<ValidationSchema extends z.ZodTypeAny>({
                     data-testid={TEST_IDS.SUBMIT_BUTTON}
                     disabled={!isValid || isSubmitting}
                     isLoading={isSubmitting}
-                    onClick={handleSubmit((values) => onSubmit(values))}
+                    onClick={handleSubmit((values) => onSubmit(values, reset))}
                 >
                     {submitButtonText}
                 </Button>

--- a/src/lib/shared/components/ui/FormElements/FormRenderer/__tests__/DateField.spec.tsx
+++ b/src/lib/shared/components/ui/FormElements/FormRenderer/__tests__/DateField.spec.tsx
@@ -55,7 +55,8 @@ describe('Date field', () => {
         await user.type(input, userInput);
         expect(input).toHaveValue(userInput);
         await user.click(submitButton);
-        expect(mockSubmit).toHaveBeenCalledWith({
+        const dataArg = mockSubmit.mock.calls[0][0];
+        expect(dataArg).toEqual({
             date: new Date(userInput),
         });
     });

--- a/src/lib/shared/components/ui/FormElements/FormRenderer/__tests__/FormRenderer.spec.tsx
+++ b/src/lib/shared/components/ui/FormElements/FormRenderer/__tests__/FormRenderer.spec.tsx
@@ -234,5 +234,35 @@ describe('FormRenderer', () => {
 
             expect(button).toBeDisabled();
         });
+
+        it('resets the form', async () => {
+            const { getByTestId, getByPlaceholderText } = renderWithTheme(
+                <FormRenderer
+                    validationSchema={z.object({
+                        firstName: z.string(),
+                    })}
+                    config={getMockInputConfig({
+                        id: 'test',
+                        type: 'input',
+                        label: 'First Name',
+                        placeholder: 'First Name',
+                        statePath: 'firstName',
+                        inputType: 'text',
+                    })}
+                    validationMode={'onChange'}
+                    onSubmit={(_, reset) => {
+                        console.log('resetting', _);
+                        reset();
+                    }}
+                />
+            );
+            const name = 'John';
+            const input = getByPlaceholderText('First Name');
+            const submitButton = getByTestId(TEST_IDS.SUBMIT_BUTTON);
+            await user.type(input, name);
+            await userEvent.click(submitButton);
+            await sleep(0);
+            expect(input).toHaveValue('');
+        });
     });
 });

--- a/src/lib/shared/components/ui/FormElements/FormRenderer/__tests__/InputField.spec.tsx
+++ b/src/lib/shared/components/ui/FormElements/FormRenderer/__tests__/InputField.spec.tsx
@@ -62,7 +62,8 @@ describe('Input field', () => {
         await user.type(input, 'John');
         expect(input).toHaveValue('John');
         await user.click(submitButton);
-        expect(mockSubmit).toHaveBeenCalledWith({ firstName: 'John' });
+        const dataArg = mockSubmit.mock.calls[0][0];
+        expect(dataArg).toEqual({ firstName: 'John' });
     });
 
     it('captures number input', async () => {
@@ -90,7 +91,8 @@ describe('Input field', () => {
         await user.type(input, '1');
         expect(input).toHaveValue(1);
         await user.click(submitButton);
-        expect(mockSubmit).toHaveBeenCalledWith({ age: 1 });
+        const dataArg = mockSubmit.mock.calls[0][0];
+        expect(dataArg).toEqual({ age: 1 });
     });
 
     it('captures email input', async () => {
@@ -120,7 +122,8 @@ describe('Input field', () => {
         await user.type(input, emailAddress);
         expect(input).toHaveValue(emailAddress);
         await user.click(submitButton);
-        expect(mockSubmit).toHaveBeenCalledWith({
+        const dataArg = mockSubmit.mock.calls[0][0];
+        expect(dataArg).toEqual({
             email: emailAddress,
         });
     });
@@ -151,7 +154,8 @@ describe('Input field', () => {
         await user.type(input, phone);
         expect(input).toHaveValue(phone);
         await user.click(submitButton);
-        expect(mockSubmit).toHaveBeenCalledWith({
+        const dataArg = mockSubmit.mock.calls[0][0];
+        expect(dataArg).toEqual({
             phone,
         });
     });
@@ -183,7 +187,8 @@ describe('Input field', () => {
         await user.type(input, phone);
         expect(input).toHaveValue(expectedPhone);
         await user.click(submitButton);
-        expect(mockSubmit).toHaveBeenCalledWith({
+        const dataArg = mockSubmit.mock.calls[0][0];
+        expect(dataArg).toEqual({
             phone: expectedPhone,
         });
     });

--- a/src/lib/shared/components/ui/FormElements/FormRenderer/__tests__/PasswordField.spec.tsx
+++ b/src/lib/shared/components/ui/FormElements/FormRenderer/__tests__/PasswordField.spec.tsx
@@ -52,7 +52,8 @@ describe('Password field', () => {
         await user.type(input, password);
         expect(input).toHaveValue(password);
         await user.click(submitButton);
-        expect(mockSubmit).toHaveBeenCalledWith({ password });
+        const dataArg = mockSubmit.mock.calls[0][0];
+        expect(dataArg).toEqual({ password });
     });
 
     it('validates password input', async () => {

--- a/src/lib/shared/components/ui/FormElements/FormRenderer/__tests__/RadioSelectField.spec.tsx
+++ b/src/lib/shared/components/ui/FormElements/FormRenderer/__tests__/RadioSelectField.spec.tsx
@@ -19,9 +19,8 @@ describe('Select field', () => {
         options: ['Yes', 'No'],
     };
     const mockRadioSelectConfig = getMockInputConfig(radioSelectConfig);
-    const radioSelectDetails = mockRadioSelectConfig.sections[0].fields[0] as RadioSelectInput<
-        z.infer<typeof mockSchema>
-    >;
+    const radioSelectDetails = mockRadioSelectConfig.sections[0]
+        .fields[0] as RadioSelectInput<z.infer<typeof mockSchema>>;
 
     it('renders radio select', () => {
         const { getByText } = renderWithTheme(
@@ -49,7 +48,8 @@ describe('Select field', () => {
         const optionEl = getByText('Yes');
         await userEvent.click(optionEl);
         await user.click(submitButton);
-        expect(mockSubmit).toHaveBeenCalledWith({ yesOrNo: 'Yes' });
+        const dataArg = mockSubmit.mock.calls[0][0];
+        expect(dataArg).toEqual({ yesOrNo: 'Yes' });
     });
 
     it('requires selection to submit', async () => {
@@ -77,29 +77,30 @@ describe('Select field', () => {
                 isSubmitting
             />
         );
-        radioSelectDetails.options.forEach(option => {
+        radioSelectDetails.options.forEach((option) => {
             expect(getByText(option as string)).toHaveClass('Mui-disabled');
-        })
+        });
     });
 
     it('selects default value when given at the field level', async () => {
-            const mockSubmit = jest.fn();
-            const mockDefaultValueConfig = getMockInputConfig({
-                    ...radioSelectDetails,
-                    defaultValue: 'Yes',
-                });
-            const { getByText } = renderWithTheme(
-                <FormRenderer
-                    validationSchema={mockSchema}
-                    config={mockDefaultValueConfig}
-                    validationMode={'onChange'}
-                    onSubmit={mockSubmit}
-                />
-            );
-            // allow the default value to re-render before assertion occurs
-            await sleep(0);
-            const submitButton = getByText('Submit');
-            await user.click(submitButton);
-            expect(mockSubmit).toHaveBeenCalledWith({ yesOrNo: 'Yes' });
+        const mockSubmit = jest.fn();
+        const mockDefaultValueConfig = getMockInputConfig({
+            ...radioSelectDetails,
+            defaultValue: 'Yes',
         });
+        const { getByText } = renderWithTheme(
+            <FormRenderer
+                validationSchema={mockSchema}
+                config={mockDefaultValueConfig}
+                validationMode={'onChange'}
+                onSubmit={mockSubmit}
+            />
+        );
+        // allow the default value to re-render before assertion occurs
+        await sleep(0);
+        const submitButton = getByText('Submit');
+        await user.click(submitButton);
+        const dataArg = mockSubmit.mock.calls[0][0];
+        expect(dataArg).toEqual({ yesOrNo: 'Yes' });
+    });
 });

--- a/src/lib/shared/components/ui/FormElements/FormRenderer/__tests__/Select.spec.tsx
+++ b/src/lib/shared/components/ui/FormElements/FormRenderer/__tests__/Select.spec.tsx
@@ -55,7 +55,8 @@ describe('Select field', () => {
         );
         await userEvent.click(optionEl);
         await user.click(submitButton);
-        expect(mockSubmit).toHaveBeenCalledWith({ yesOrNo: 'Yes' });
+        const dataArg = mockSubmit.mock.calls[0][0];
+        expect(dataArg).toEqual({ yesOrNo: 'Yes' });
     });
 
     it('requires selection to submit', async () => {

--- a/src/lib/shared/components/ui/FormElements/FormRenderer/__tests__/TelephoneField.spec.tsx
+++ b/src/lib/shared/components/ui/FormElements/FormRenderer/__tests__/TelephoneField.spec.tsx
@@ -54,7 +54,8 @@ describe('Telephone field', () => {
         const submitButton = getByText('Submit');
         await user.type(input, number);
         await user.click(submitButton);
-        expect(mockSubmit).toHaveBeenCalledWith({ phone: number });
+        const dataArg = mockSubmit.mock.calls[0][0];
+        expect(dataArg).toEqual({ phone: number });
     });
 
     it('masks telephone input', async () => {
@@ -108,7 +109,8 @@ describe('Telephone field', () => {
         await user.type(input, phone);
         expect(input).toHaveValue(formattedPhone);
         await user.click(submitButton);
-        expect(mockSubmit).toHaveBeenCalledWith({
+        const dataArg = mockSubmit.mock.calls[0][0];
+        expect(dataArg).toEqual({
             phone: expectedPhone,
         });
     });

--- a/src/lib/shared/components/ui/FormElements/FormRenderer/__tests__/TextareaField.spec.tsx
+++ b/src/lib/shared/components/ui/FormElements/FormRenderer/__tests__/TextareaField.spec.tsx
@@ -54,7 +54,8 @@ describe('Textarea field', () => {
         await user.type(input, description);
         expect(input).toHaveValue(description);
         await user.click(submitButton);
-        expect(mockSubmit).toHaveBeenCalledWith({ description });
+        const dataArg = mockSubmit.mock.calls[0][0];
+        expect(dataArg).toEqual({ description });
     });
 
     it('validates textarea', async () => {

--- a/src/lib/shared/components/ui/FormElements/FormRenderer/__tests__/ToggleField.spec.tsx
+++ b/src/lib/shared/components/ui/FormElements/FormRenderer/__tests__/ToggleField.spec.tsx
@@ -90,7 +90,8 @@ describe('Toggle Field', () => {
         const submitButton = getByText('Submit');
         await user.click(toggle);
         await user.click(submitButton);
-        expect(mockSubmit).toHaveBeenCalledWith({ iAgree: true });
+        const dataArg = mockSubmit.mock.calls[0][0];
+        expect(dataArg).toEqual({ iAgree: true });
     });
 
     it('validates toggle', async () => {

--- a/src/lib/shared/components/ui/FormElements/FormRenderer/types.ts
+++ b/src/lib/shared/components/ui/FormElements/FormRenderer/types.ts
@@ -3,7 +3,7 @@ import { PhoneNumberFormat } from '../form-validation/phone';
 import { SelectOption } from '../Select';
 
 export type FormConfig<T extends FieldValues> = {
-    title: string;
+    title?: string;
     subtitle?: string;
     sections: FormSection<T>[];
 };

--- a/src/pages/members/account/settings/[view].tsx
+++ b/src/pages/members/account/settings/[view].tsx
@@ -1,5 +1,6 @@
-import { useEffect } from 'react';
+import { useContext, useEffect } from 'react';
 import { useRouter } from 'next/router';
+import { Alerts } from '@/lib/modules/alerts/context';
 import { MemberNavigationPage } from '@/lib/shared/components/features/pages';
 import { URL_PATHS } from '@/lib/sitemap';
 import { RBAC } from '@/lib/shared/utils';
@@ -18,9 +19,10 @@ export const getServerSideProps = RBAC.requireMemberAuth(
     })
 );
 
-export default function ClientDetailsPage({
+export default function MemberSettingsPage({
     user,
 }: MemberTherifyUserPageProps) {
+    const { createAlert } = useContext(Alerts.Context);
     const { flags } = useFeatureFlags(user);
     const router = useRouter();
     const view = Array.isArray(router.query.view)
@@ -46,6 +48,39 @@ export default function ClientDetailsPage({
                         `${URL_PATHS.MEMBERS.ACCOUNT.SETTINGS.ROOT}/${tabId}`
                     )
                 }
+                onImageUploadError={(error) =>
+                    createAlert({
+                        title: error instanceof Error ? error.message : error,
+                        type: 'success',
+                    })
+                }
+                onImageUploadSuccess={(error) => {
+                    if (error) {
+                        createAlert({
+                            title: error.message,
+                            type: 'error',
+                        });
+                        return;
+                    }
+                    createAlert({
+                        title: 'Account details updated',
+                        type: 'success',
+                    });
+                }}
+                onUpdateUserDetails={(details, reset) => {
+                    // TODO: Update with TRPC mutation
+                    console.log({ details });
+                    reset(
+                        {
+                            ...details,
+                        },
+                        {
+                            keepIsValid: false,
+                            keepDirty: false,
+                            keepTouched: false,
+                        }
+                    );
+                }}
             />
         </MemberNavigationPage>
     );


### PR DESCRIPTION
# Description
#### Settings page
- Adds Account view to v3 member settings page + unit tests

#### Form Renderer
- Makes Form Title optional
- Passes `reset` function to `FormRenderer`'s `onSubmit` handler to allow form's `dirty` and `touched` states to reset after submitting prefilled results on the Settings page.
  - Adds unit test for form reset

# Closes issue(s)
[V3 Setting: Account View](https://www.notion.so/V3-Settings-Account-View-55443d42f41745568a622be79051d246?pvs=4)

# How to test / repro
1. Spin up the app locally
2. Login as a member (with v3 feature flag turned on)
3. Visit `http://localhost:3000/members/account/settings/account`

# Screenshots
![image](https://github.com/Therify/directory/assets/25045075/b210549b-194b-4c8d-95bc-527e2b45710f)

# Changes include

-   [ ] Bugfix (non-breaking change that solves an issue)
-   [x] New feature (non-breaking change that adds functionality)
-   [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Checklist

-   [x] I have tested this code
-   [ ] I have updated the Readme

# Other comments
